### PR TITLE
Add *args, **kwargs to read data method in reader interface

### DIFF
--- a/dataset_reader/ann_h5_multi_reader.py
+++ b/dataset_reader/ann_h5_multi_reader.py
@@ -52,7 +52,7 @@ class AnnH5MultiReader(BaseReader):
                 )
 
     def read_data(
-        self, start_idx: int = 0, end_idx: int = None, chunk_size: int = 10_000
+        self, start_idx: int = 0, end_idx: int = None, chunk_size: int = 10_000, *args, **kwargs
     ) -> Iterator[Record]:
         """
         Reads the 'train' data vectors from multiple HDF5 files based on the specified range.

--- a/dataset_reader/ann_h5_reader.py
+++ b/dataset_reader/ann_h5_reader.py
@@ -27,7 +27,7 @@ class AnnH5Reader(BaseReader):
                 expected_scores=expected_scores.tolist(),
             )
 
-    def read_data(self) -> Iterator[Record]:
+    def read_data(self, *args, **kwargs) -> Iterator[Record]:
         data = h5py.File(self.path)
 
         for idx, vector in enumerate(data["train"]):

--- a/dataset_reader/base_reader.py
+++ b/dataset_reader/base_reader.py
@@ -18,7 +18,7 @@ class Query:
 
 
 class BaseReader:
-    def read_data(self) -> Iterator[Record]:
+    def read_data(self, *args, **kwargs) -> Iterator[Record]:
         raise NotImplementedError()
 
     def read_queries(self) -> Iterator[Query]:

--- a/dataset_reader/json_reader.py
+++ b/dataset_reader/json_reader.py
@@ -60,7 +60,7 @@ class JSONReader(BaseReader):
 
             yield Query(vector=vector, meta_conditions=None, expected_result=neighbours)
 
-    def read_data(self) -> Iterator[Record]:
+    def read_data(self, *args, **kwargs) -> Iterator[Record]:
         for idx, (vector, payload) in enumerate(
             zip(self.read_vectors(), self.read_payloads())
         ):


### PR DESCRIPTION
Since we are passing two arguments` upload_start_idx` and `upload_end_idx` to read_data method of a reader: https://github.com/redis-performance/vector-db-benchmark/blob/update.redisearch/engine/base_client/client.py#L116,
We need to accept additional arguments in readers other than multi_ann reader.
If not we will get when using different reader:
`TypeError: AnnH5Reader.read_data() takes 1 positional argument but 3 were given`
