### PR TITLE
Restore performance optimizations

### DIFF
--- a/engine/base_client/client.py
+++ b/engine/base_client/client.py
@@ -40,8 +40,9 @@ class BaseClient:
     ):
         now = datetime.now()
         timestamp = now.strftime("%Y-%m-%d-%H-%M-%S")
+        pid = os.getpid()  # Get the current process ID
         experiments_file = (
-            f"{self.name}-{dataset_name}-search-{search_id}-{timestamp}.json"
+            f"{self.name}-{dataset_name}-search-{search_id}-{pid}-{timestamp}.json"
         )
         result_path = RESULTS_DIR / experiments_file
         with open(result_path, "w") as out:
@@ -99,7 +100,8 @@ class BaseClient:
         reader = dataset.get_reader(execution_params.get("normalize", False))
 
         if skip_if_exists:
-            glob_pattern = f"{self.name}-{dataset.config.name}-search-*-*.json"
+            pid = os.getpid()  # Get the current process ID
+            glob_pattern = f"{self.name}-{dataset.config.name}-search-*-{pid}-*.json"
             existing_results = list(RESULTS_DIR.glob(glob_pattern))
             if len(existing_results) == len(self.searchers):
                 print(
@@ -137,8 +139,9 @@ class BaseClient:
             print("Experiment stage: Search")
             for search_id, searcher in enumerate(self.searchers):
                 if skip_if_exists:
+                    pid = os.getpid()  # Get the current process ID
                     glob_pattern = (
-                        f"{self.name}-{dataset.config.name}-search-{search_id}-*.json"
+                        f"{self.name}-{dataset.config.name}-search-{search_id}-{pid}-*.json"
                     )
                     existing_results = list(RESULTS_DIR.glob(glob_pattern))
                     print("Pattern", glob_pattern, "Results:", existing_results)

--- a/engine/base_client/search.py
+++ b/engine/base_client/search.py
@@ -140,10 +140,20 @@ class BaseSearcher:
             # Start measuring time for the critical work
             start = time.perf_counter()
 
+            # Create a progress bar for the total number of queries
+            total_queries = len(used_queries)
+            pbar = tqdm.tqdm(total=total_queries, desc="Processing queries", unit="queries")
+
             # Collect results from all worker processes
             results = []
             for _ in processes:
-                results.extend(result_queue.get())
+                chunk_results = result_queue.get()
+                results.extend(chunk_results)
+                # Update the progress bar with the number of processed queries in this chunk
+                pbar.update(len(chunk_results))
+
+            # Close the progress bar
+            pbar.close()
 
             # Wait for all worker processes to finish
             for process in processes:
@@ -192,6 +202,7 @@ def chunked_iterable(iterable, size):
 
 def process_chunk(chunk, search_one):
     """Process a chunk of queries using the search_one function."""
+    # No progress bar in worker processes to avoid cluttering the output
     return [search_one(query) for query in chunk]
 
 

--- a/engine/base_client/search.py
+++ b/engine/base_client/search.py
@@ -2,6 +2,7 @@ import functools
 import time
 from multiprocessing import get_context
 from typing import Iterable, List, Optional, Tuple
+from itertools import islice
 
 import numpy as np
 import tqdm
@@ -112,22 +113,31 @@ class BaseSearcher:
         else:
             ctx = get_context(self.get_mp_start_method())
 
-            with ctx.Pool(
-                processes=parallel,
-                initializer=self.__class__.init_client,
-                initargs=(
+            def process_initializer():
+                """Initialize each process before starting the search."""
+                self.__class__.init_client(
                     self.host,
                     distance,
                     self.connection_params,
                     self.search_params,
-                ),
+                )
+                self.setup_search()
+
+            # Dynamically chunk the generator
+            query_chunks = list(chunked_iterable(used_queries, max(1, len(used_queries) // parallel)))
+
+            with ctx.Pool(
+                processes=parallel,
+                initializer=process_initializer,
             ) as pool:
                 if parallel > 10:
                     time.sleep(15)  # Wait for all processes to start
                 start = time.perf_counter()
-                precisions, latencies = list(
-                    zip(*pool.imap_unordered(search_one, iterable=tqdm.tqdm(used_queries)))
+                results = pool.starmap(
+                    process_chunk,
+                    [(chunk, search_one) for chunk in query_chunks],
                 )
+                precisions, latencies = zip(*[result for chunk in results for result in chunk])
 
         total_time = time.perf_counter() - start
 
@@ -157,3 +167,15 @@ class BaseSearcher:
     @classmethod
     def delete_client(cls):
         pass
+
+
+def chunked_iterable(iterable, size):
+    """Yield successive chunks of a given size from an iterable."""
+    it = iter(iterable)
+    while chunk := list(islice(it, size)):
+        yield chunk
+
+
+def process_chunk(chunk, search_one):
+    """Process a chunk of queries using the search_one function."""
+    return [search_one(query) for query in chunk]

--- a/test_multiprocessing.py
+++ b/test_multiprocessing.py
@@ -20,15 +20,15 @@ class TestSearcher(BaseSearcher):
     def setup_search(self):
         pass
 
-# Create test queries
-queries = [Query(vector=[0.1]*10, meta_conditions=None, expected_result=None) for _ in range(1000)]
+# Create a small set of test queries
+queries = [Query(vector=[0.1]*10, meta_conditions=None, expected_result=None) for _ in range(10)]
 
 # Create a searcher with parallel=10
 searcher = TestSearcher('localhost', {}, {'parallel': 10})
 
-# Run the search_all method
+# Run the search_all method with a large num_queries parameter
 start = time.perf_counter()
-results = searcher.search_all('cosine', queries)
+results = searcher.search_all('cosine', queries, num_queries=1000)
 total_time = time.perf_counter() - start
 
 print(f'Number of queries: {len(results["latencies"])}')

--- a/test_multiprocessing.py
+++ b/test_multiprocessing.py
@@ -1,0 +1,36 @@
+from engine.base_client.search import BaseSearcher
+from dataset_reader.base_reader import Query
+import time
+
+class TestSearcher(BaseSearcher):
+    @classmethod
+    def init_client(cls, host, distance, connection_params, search_params):
+        pass
+
+    @classmethod
+    def search_one(cls, vector, meta_conditions, top):
+        return []
+
+    @classmethod
+    def _search_one(cls, query, top=None):
+        # Add a small delay to simulate real work
+        time.sleep(0.001)
+        return 1.0, 0.1
+
+    def setup_search(self):
+        pass
+
+# Create test queries
+queries = [Query(vector=[0.1]*10, meta_conditions=None, expected_result=None) for _ in range(1000)]
+
+# Create a searcher with parallel=10
+searcher = TestSearcher('localhost', {}, {'parallel': 10})
+
+# Run the search_all method
+start = time.perf_counter()
+results = searcher.search_all('cosine', queries)
+total_time = time.perf_counter() - start
+
+print(f'Number of queries: {len(results["latencies"])}')
+print(f'Total time: {total_time:.6f} seconds')
+print(f'Throughput: {results["rps"]:.2f} queries/sec')


### PR DESCRIPTION
Using the gist-960-euclidean dataset, and a single docker redis container with 16 threads max configured as follow:

```
docker run --network=host -d redis:8.0.0
redis-cli config set save ''
redis-cli config set search-min-operation-workers 16
redis-cli  config set search-workers 16
```

and running:
```
python3 run.py --engines redis-m-16-ef-64  --datasets gist-960-euclidean  --host 10.3.0.65 --skip-upload --parallels 100 --queries 200000 --no-skip-if-exists --ef-runtime 64
```

we can see that we can fully saturate Redis by restoring the performance optimizations from PR #16 (85a6bc7) and increase the median QPS from 10K ops/sec to 15K ops/sec. 

## Summary

| Metric                | `restore-performance-optimizations` | `update-redisearch` | Δ       |
|-----------------------|--------------------------------------|----------------------|---------|
| Median QPS            | 15,517.66                           | 10,030.81            | +54.7%  |
| Median CPU (Peak)     | 1610.48%                            | 1170.07%             | +37.6%  |
