### PR TITLE
docs: add Docker Hub and CI badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # vector-db-benchmark
 
+[![Docker Pulls](https://img.shields.io/docker/pulls/redis/vector-db-benchmark)](https://hub.docker.com/r/redis/vector-db-benchmark)
+[![CI](https://github.com/redis-performance/vector-db-benchmark/actions/workflows/test-basic-functionality-redisearch.yml/badge.svg)](https://github.com/redis-performance/vector-db-benchmark/actions/workflows/test-basic-functionality-redisearch.yml)
+
 A comprehensive benchmarking tool for vector databases, including Redis (both RediSearch and Vector Sets), Weaviate, Milvus, Qdrant, OpenSearch, Postgres, and others...
 
 In a one-liner cli tool you can get this and much more:


### PR DESCRIPTION
## Summary

- Adds Docker Pulls badge for `redis/vector-db-benchmark` on Docker Hub
- Adds CI status badge for the `test-basic-functionality-redisearch.yml` workflow

## Badges added

[![Docker Pulls](https://img.shields.io/docker/pulls/redis/vector-db-benchmark)](https://hub.docker.com/r/redis/vector-db-benchmark)
[![CI](https://github.com/redis-performance/vector-db-benchmark/actions/workflows/test-basic-functionality-redisearch.yml/badge.svg)](https://github.com/redis-performance/vector-db-benchmark/actions/workflows/test-basic-functionality-redisearch.yml)

## Test plan
- [ ] Badges render correctly on the README
- [ ] Docker Pulls link points to the correct Docker Hub page
- [ ] CI badge link points to the correct Actions workflow page

🤖 Generated with [Claude Code](https://claude.com/claude-code)