### PR TITLE
WIP: add qdrant-m-{16,32,64}-ef-64 grid cells

### DIFF
--- a/experiments/configurations/qdrant-single-node.json
+++ b/experiments/configurations/qdrant-single-node.json
@@ -63,6 +63,21 @@
     "upload_params": { "parallel": 16, "batch_size": 1024 }
   },
   {
+    "name": "qdrant-m-16-ef-64",
+    "engine": "qdrant",
+    "connection_params": { "timeout": 300 },
+    "collection_params": {
+      "timeout": 300,
+      "optimizers_config": { "memmap_threshold": 25000000 },
+      "hnsw_config": { "m": 16, "ef_construct": 64 }
+    },
+    "search_params": [
+      { "parallel": 1, "search_params": { "hnsw_ef": 64 } }, { "parallel": 1, "search_params": { "hnsw_ef": 128 } }, { "parallel": 1, "search_params": { "hnsw_ef": 256 } }, { "parallel": 1, "search_params": { "hnsw_ef": 512 } },
+      { "parallel": 100, "search_params": { "hnsw_ef": 64 } }, { "parallel": 100, "search_params": { "hnsw_ef": 128 } }, { "parallel": 100, "search_params": { "hnsw_ef": 256 } }, { "parallel": 100, "search_params": { "hnsw_ef": 512 } }
+    ],
+    "upload_params": { "parallel": 16 }
+  },
+  {
     "name": "qdrant-m-16-ef-128",
     "engine": "qdrant",
     "connection_params": { "timeout": 300 },
@@ -108,6 +123,21 @@
     "upload_params": { "parallel": 16 }
   },
   {
+    "name": "qdrant-m-32-ef-64",
+    "engine": "qdrant",
+    "connection_params": { "timeout": 300 },
+    "collection_params": {
+      "timeout": 300,
+      "optimizers_config": { "memmap_threshold": 25000000 },
+      "hnsw_config": { "m": 32, "ef_construct": 64 }
+    },
+    "search_params": [
+      { "parallel": 1, "search_params": { "hnsw_ef": 64 } }, { "parallel": 1, "search_params": { "hnsw_ef": 128 } }, { "parallel": 1, "search_params": { "hnsw_ef": 256 } }, { "parallel": 1, "search_params": { "hnsw_ef": 512 } },
+      { "parallel": 100, "search_params": { "hnsw_ef": 64 } }, { "parallel": 100, "search_params": { "hnsw_ef": 128 } }, { "parallel": 100, "search_params": { "hnsw_ef": 256 } }, { "parallel": 100, "search_params": { "hnsw_ef": 512 } }
+    ],
+    "upload_params": { "parallel": 16 }
+  },
+  {
     "name": "qdrant-m-32-ef-128",
     "engine": "qdrant",
     "connection_params": { "timeout": 300 },
@@ -145,6 +175,21 @@
       "timeout": 300,
       "optimizers_config": { "memmap_threshold": 25000000 },
       "hnsw_config": { "m": 32, "ef_construct": 512 }
+    },
+    "search_params": [
+      { "parallel": 1, "search_params": { "hnsw_ef": 64 } }, { "parallel": 1, "search_params": { "hnsw_ef": 128 } }, { "parallel": 1, "search_params": { "hnsw_ef": 256 } }, { "parallel": 1, "search_params": { "hnsw_ef": 512 } },
+      { "parallel": 100, "search_params": { "hnsw_ef": 64 } }, { "parallel": 100, "search_params": { "hnsw_ef": 128 } }, { "parallel": 100, "search_params": { "hnsw_ef": 256 } }, { "parallel": 100, "search_params": { "hnsw_ef": 512 } }
+    ],
+    "upload_params": { "parallel": 16 }
+  },
+  {
+    "name": "qdrant-m-64-ef-64",
+    "engine": "qdrant",
+    "connection_params": { "timeout": 300 },
+    "collection_params": {
+      "timeout": 300,
+      "optimizers_config": { "memmap_threshold": 25000000 },
+      "hnsw_config": { "m": 64, "ef_construct": 64 }
     },
     "search_params": [
       { "parallel": 1, "search_params": { "hnsw_ef": 64 } }, { "parallel": 1, "search_params": { "hnsw_ef": 128 } }, { "parallel": 1, "search_params": { "hnsw_ef": 256 } }, { "parallel": 1, "search_params": { "hnsw_ef": 512 } },


### PR DESCRIPTION
## What

Adds the three missing `ef_construct=64` qdrant configs (`qdrant-m-{16,32,64}-ef-64`) to `experiments/configurations/qdrant-single-node.json`, completing the M ∈ {16,32,64} × EF_construct ∈ {64,128,256,512} grid to match the redis side (`redis-single-node.json` already has all 12 cells).

## Why

Part of the RCP vs Qdrant Cloud vector benchmark (re-run of the [2024 vector blog](https://redis.io/blog/benchmarking-results-for-vector-databases/) methodology with current versions, driven from `cloud-benchmarks-private`). The matched-precision comparison sweeps the full grid on both engines; until this merges, the workflow injects these cells via `--engines-file` (`scripts/vector-configs/qdrant-cloud-ef64-supplement.json` in that repo).

Marked WIP while the first full fan-out (4 blog datasets × 2 engines) is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)