### PR TITLE
fix(qdrant): config passthrough — hnsw m/ef_construct, optimizers, quantization, search-time rescore/oversampling

### DIFF
--- a/src/bin/vector_db_benchmark/config.rs
+++ b/src/bin/vector_db_benchmark/config.rs
@@ -27,7 +27,11 @@ pub struct DatasetConfig {
 pub struct HnswConfig {
     #[serde(rename = "M", alias = "m")]
     pub m: Option<i64>,
-    #[serde(rename = "EF_CONSTRUCTION", alias = "ef_construct", alias = "ef_construction")]
+    #[serde(
+        rename = "EF_CONSTRUCTION",
+        alias = "ef_construct",
+        alias = "ef_construction"
+    )]
     pub ef_construction: Option<i64>,
 }
 

--- a/src/bin/vector_db_benchmark/config.rs
+++ b/src/bin/vector_db_benchmark/config.rs
@@ -25,9 +25,9 @@ pub struct DatasetConfig {
 /// HNSW configuration
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct HnswConfig {
-    #[serde(rename = "M")]
+    #[serde(rename = "M", alias = "m")]
     pub m: Option<i64>,
-    #[serde(rename = "EF_CONSTRUCTION")]
+    #[serde(rename = "EF_CONSTRUCTION", alias = "ef_construct", alias = "ef_construction")]
     pub ef_construction: Option<i64>,
 }
 

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -40,6 +40,8 @@ pub struct QdrantEngine {
     search_params: Vec<SearchParams>,
     /// Raw collection_params JSON to pass through to Qdrant
     collection_params_extra: serde_json::Value,
+    hnsw_m: Option<u64>,
+    hnsw_ef_construct: Option<u64>,
     /// Tokio runtime for async operations
     rt: tokio::runtime::Runtime,
     /// Shared Qdrant client (wrapped in Arc for thread-safe sharing)
@@ -97,6 +99,13 @@ impl QdrantEngine {
             .map(|e| serde_json::to_value(e).unwrap_or_default())
             .unwrap_or(serde_json::json!({}));
 
+        let typed_hnsw = engine_config
+            .collection_params
+            .as_ref()
+            .and_then(|cp| cp.hnsw_config.as_ref());
+        let hnsw_m = typed_hnsw.and_then(|h| h.m).map(|v| v as u64);
+        let hnsw_ef_construct = typed_hnsw.and_then(|h| h.ef_construction).map(|v| v as u64);
+
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| format!("Failed to create tokio runtime: {}", e))?;
 
@@ -121,6 +130,8 @@ impl QdrantEngine {
             api_key,
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             collection_params_extra,
+            hnsw_m,
+            hnsw_ef_construct,
             rt,
             client: Arc::new(client),
         })
@@ -159,17 +170,11 @@ impl QdrantEngine {
             other => return Err(format!("Unsupported distance metric for Qdrant: {}", other)),
         };
 
-        // Extract HNSW params from extra config
-        let hnsw_m = self
-            .collection_params_extra
-            .get("hnsw_config")
-            .and_then(|h| h.get("m"))
-            .and_then(|v| v.as_u64());
-        let hnsw_ef = self
-            .collection_params_extra
-            .get("hnsw_config")
-            .and_then(|h| h.get("ef_construct"))
-            .and_then(|v| v.as_u64());
+        // HNSW params come from the TYPED collection_params.hnsw_config field
+        // (serde captures "m"/"ef_construct" there via aliases; the flattened
+        // `extra` map never contains hnsw_config since it is a declared field).
+        let hnsw_m = self.hnsw_m;
+        let hnsw_ef = self.hnsw_ef_construct;
 
         let vector_params = VectorParamsBuilder::new(vector_size as u64, qdrant_distance);
 

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -9,8 +9,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
-use qdrant_client::qdrant::vectors_config::Config;
 use qdrant_client::qdrant::quantization_config::Quantization;
+use qdrant_client::qdrant::vectors_config::Config;
 use qdrant_client::qdrant::{
     BinaryQuantization, Condition, CreateCollectionBuilder, DeleteCollectionBuilder, Distance,
     FieldType, Filter, HnswConfigDiff, MaxOptimizationThreads, OptimizersConfigDiff, PointStruct,
@@ -762,7 +762,8 @@ impl Engine for QdrantEngine {
                                     }
                                 })
                                 .collect();
-                            let m = crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
+                            let m =
+                                crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
                             precisions.lock().unwrap().push(m.precision);
                             recalls.lock().unwrap().push(m.recall);
                             mrrs.lock().unwrap().push(m.mrr);

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -10,9 +10,11 @@ use std::time::Instant;
 
 use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 use qdrant_client::qdrant::vectors_config::Config;
+use qdrant_client::qdrant::quantization_config::Quantization;
 use qdrant_client::qdrant::{
-    Condition, CreateCollectionBuilder, DeleteCollectionBuilder, Distance, FieldType, Filter,
-    HnswConfigDiff, MaxOptimizationThreads, OptimizersConfigDiff, PointStruct, SearchPointsBuilder,
+    BinaryQuantization, Condition, CreateCollectionBuilder, DeleteCollectionBuilder, Distance,
+    FieldType, Filter, HnswConfigDiff, MaxOptimizationThreads, OptimizersConfigDiff, PointStruct,
+    QuantizationSearchParams, QuantizationType, ScalarQuantization, SearchPointsBuilder,
     VectorParamsBuilder, VectorsConfig,
 };
 use qdrant_client::{Payload, Qdrant};
@@ -186,6 +188,50 @@ impl QdrantEngine {
                 hnsw_config.ef_construct = Some(ef as u64);
             }
             create_builder = create_builder.hnsw_config(hnsw_config);
+        }
+
+        // Pass through optimizers_config (e.g. the rps-tuned default_segment_number /
+        // max_segment_size / memmap_threshold) — mirrors the python engine, which
+        // forwards collection_params verbatim.
+        if let Some(opt) = self.collection_params_extra.get("optimizers_config") {
+            let mut diff = OptimizersConfigDiff::default();
+            if let Some(v) = opt.get("default_segment_number").and_then(|v| v.as_u64()) {
+                diff.default_segment_number = Some(v);
+            }
+            if let Some(v) = opt.get("max_segment_size").and_then(|v| v.as_u64()) {
+                diff.max_segment_size = Some(v);
+            }
+            if let Some(v) = opt.get("memmap_threshold").and_then(|v| v.as_u64()) {
+                diff.memmap_threshold = Some(v);
+            }
+            create_builder = create_builder.optimizers_config(diff);
+        }
+
+        // Pass through quantization_config (sq/bq tuned setups).
+        if let Some(q) = self.collection_params_extra.get("quantization_config") {
+            let quantization = if let Some(s) = q.get("scalar") {
+                let qtype = match s.get("type").and_then(|v| v.as_str()) {
+                    Some("int8") | None => QuantizationType::Int8,
+                    Some(other) => {
+                        return Err(format!("Unsupported scalar quantization type: {}", other))
+                    }
+                };
+                Some(Quantization::Scalar(ScalarQuantization {
+                    r#type: qtype.into(),
+                    quantile: s.get("quantile").and_then(|v| v.as_f64()).map(|v| v as f32),
+                    always_ram: s.get("always_ram").and_then(|v| v.as_bool()),
+                }))
+            } else if let Some(b) = q.get("binary") {
+                Some(Quantization::Binary(BinaryQuantization {
+                    always_ram: b.get("always_ram").and_then(|v| v.as_bool()),
+                    ..Default::default()
+                }))
+            } else {
+                None
+            };
+            if let Some(quantization) = quantization {
+                create_builder = create_builder.quantization_config(quantization);
+            }
         }
 
         self.rt
@@ -591,6 +637,19 @@ impl Engine for QdrantEngine {
             })
         });
 
+        // Search-time quantization params (rescore/oversampling) from the config's
+        // search_params.quantization object — mirrors python rest.SearchParams(**params).
+        let quantization_params: Option<QuantizationSearchParams> = params
+            .search_params
+            .as_ref()
+            .and_then(|sp| sp.extra.as_ref())
+            .and_then(|e| e.get("quantization"))
+            .map(|q| QuantizationSearchParams {
+                rescore: q.get("rescore").and_then(|v| v.as_bool()),
+                oversampling: q.get("oversampling").and_then(|v| v.as_f64()),
+                ..Default::default()
+            });
+
         let query_path = dataset.get_path()?;
         println!("\tReading queries from {}...", query_path.display());
         let (queries, neighbors, conditions) = dataset.read_queries()?;
@@ -663,9 +722,10 @@ impl Engine for QdrantEngine {
                         )
                         .with_payload(false);
 
-                        if let Some(ef) = hnsw_ef {
+                        if hnsw_ef.is_some() || quantization_params.is_some() {
                             let search_params = qdrant_client::qdrant::SearchParams {
-                                hnsw_ef: Some(ef),
+                                hnsw_ef,
+                                quantization: quantization_params.clone(),
                                 ..Default::default()
                             };
                             search_builder = search_builder.params(search_params);


### PR DESCRIPTION
## Bugs fixed (all silent config drops in the qdrant engine)

1. **hnsw_config m/ef_construct never reached the server.** `CollectionParams.hnsw_config` is typed with redis-style keys (`M`/`EF_CONSTRUCTION`); qdrant configs use `m`/`ef_construct` → deserialized to `None`, and the declared field shadowed `extra`, so the engine's extra-based lookup always missed. **Every qdrant collection was built with server defaults m=16/ef_construct=100 regardless of experiment name** — confirmed in collection_info of 60 cloud benchmark runs and statistically (recall flat across the M×EF grid while redis spreads as expected).
2. **`optimizers_config` dropped** — the rps-tuned `default_segment_number: 2` / `max_segment_size` / `memmap_threshold` never applied.
3. **`quantization_config` dropped** — `qdrant-sq-rps-*` / `qdrant-bq-rps-*` built plain float32 HNSW (no quantization at all).
4. **Search-time `quantization {rescore, oversampling}` dropped** — the sq/bq oversampling ladder was a no-op.

## Fix

- `config.rs`: serde aliases `m` / `ef_construct` / `ef_construction` on `HnswConfig` (redis-style `M`/`EF_CONSTRUCTION` unchanged).
- `engine/qdrant.rs`: read hnsw from the typed field; pass through `optimizers_config` and `quantization_config` (scalar int8 + binary) at collection creation; set `SearchParams.quantization` from the config ladder.

## Verification

Against qdrant v1.13.4 (docker): `qdrant-sq-rps-m-32-ef-256` now produces collection config `m=32, ef_construct=256, quantization scalar int8 quantile=0.99 always_ram, default_segment_number=2, max_segment_size=1e6`. Unit tests 15/15. (`tests/integration_qdrant.rs` compile breakage is pre-existing on v1.)

Impact: all prior qdrant results from this engine measured the default index; M×EF sweeps and sq/bq/rps families must be re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)