### PR TITLE
fix(opensearch): use efficient kNN filtering instead of post-filtering

### DIFF
--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -441,22 +441,34 @@ fn parse_os_conditions(conditions: &serde_json::Value) -> Option<serde_json::Val
     let and_filters = obj
         .get("and")
         .and_then(|v| v.as_array())
-        .map(|entries| build_subfilters(entries));
+        .map(|entries| build_subfilters(entries))
+        .filter(|f| !f.is_empty());
     let or_filters = obj
         .get("or")
         .and_then(|v| v.as_array())
-        .map(|entries| build_subfilters(entries));
+        .map(|entries| build_subfilters(entries))
+        .filter(|f| !f.is_empty());
 
     if and_filters.is_none() && or_filters.is_none() {
         return None;
     }
 
-    Some(serde_json::json!({
-        "bool": {
-            "must": and_filters.unwrap_or_default(),
-            "should": or_filters.unwrap_or_default(),
-        }
-    }))
+    let mut bool_query = serde_json::Map::new();
+    if let Some(must) = and_filters {
+        bool_query.insert("must".to_string(), serde_json::Value::Array(must));
+    }
+    if let Some(should) = or_filters {
+        bool_query.insert("should".to_string(), serde_json::Value::Array(should));
+        // Force OR filters to actually restrict results. `minimum_should_match`
+        // defaults to 0 as soon as a `must` clause is also present, which would
+        // silently drop the OR condition in a mixed AND+OR filter.
+        bool_query.insert(
+            "minimum_should_match".to_string(),
+            serde_json::Value::from(1),
+        );
+    }
+
+    Some(serde_json::json!({ "bool": bool_query }))
 }
 
 fn build_subfilters(entries: &[serde_json::Value]) -> Vec<serde_json::Value> {
@@ -605,14 +617,18 @@ fn upload_bulk_batch(
 
 /// OpenSearch KNN search (different format from Elasticsearch).
 /// Uses {"query": {"knn": {"vector": {"vector": [...], "k": top}}}} format.
-fn knn_search(
-    rt: &tokio::runtime::Runtime,
-    client: &OpenSearch,
-    index_name: &str,
+/// Build the OpenSearch kNN search body.
+///
+/// Efficient (pre-)filtering: the filter is pushed *inside* the kNN clause so the
+/// Lucene engine applies it during graph traversal. Wrapping the kNN query in an
+/// outer `bool.must` + `filter` instead performs post-filtering, which collapses
+/// recall on filtered datasets (see qdrant/vector-db-benchmark#167). Requires the
+/// `lucene` engine, which our index mapping uses (see `configure`).
+fn build_knn_body(
     query_vector: &[f32],
     top: usize,
     filter: Option<&serde_json::Value>,
-) -> Result<Vec<(i64, f64)>, String> {
+) -> serde_json::Value {
     let mut query = serde_json::json!({
         "knn": {
             "vector": {
@@ -623,18 +639,24 @@ fn knn_search(
     });
 
     if let Some(f) = filter {
-        query = serde_json::json!({
-            "bool": {
-                "must": [query],
-                "filter": f,
-            }
-        });
+        query["knn"]["vector"]["filter"] = f.clone();
     }
 
-    let body = serde_json::json!({
+    serde_json::json!({
         "query": query,
         "size": top,
-    });
+    })
+}
+
+fn knn_search(
+    rt: &tokio::runtime::Runtime,
+    client: &OpenSearch,
+    index_name: &str,
+    query_vector: &[f32],
+    top: usize,
+    filter: Option<&serde_json::Value>,
+) -> Result<Vec<(i64, f64)>, String> {
+    let body = build_knn_body(query_vector, top, filter);
 
     let resp = rt
         .block_on(
@@ -932,5 +954,67 @@ impl Engine for OpenSearchEngine {
 
     fn delete(&mut self) -> Result<(), String> {
         self.delete_index()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Regression for qdrant/vector-db-benchmark#167: the filter must land inside
+    // the kNN clause (efficient filtering), not in an outer bool wrapper
+    // (post-filtering), otherwise filtered-search recall collapses.
+    #[test]
+    fn knn_filter_is_pushed_inside_knn_clause() {
+        let filter = json!({"bool": {"must": [{"match": {"a": 1}}]}});
+        let body = build_knn_body(&[0.1, 0.2, 0.3], 10, Some(&filter));
+
+        // Filter lives at query.knn.vector.filter ...
+        assert_eq!(body["query"]["knn"]["vector"]["filter"], filter);
+        // ... and there is no post-filtering bool wrapper around the kNN query.
+        assert!(
+            body["query"].get("bool").is_none(),
+            "kNN query must not be wrapped in an outer bool (post-filtering)"
+        );
+        assert_eq!(body["query"]["knn"]["vector"]["k"], 10);
+        assert_eq!(body["size"], 10);
+    }
+
+    #[test]
+    fn knn_body_without_filter_has_no_filter_key() {
+        let body = build_knn_body(&[0.1, 0.2], 5, None);
+        assert!(body["query"]["knn"]["vector"].get("filter").is_none());
+    }
+
+    #[test]
+    fn or_conditions_require_minimum_should_match() {
+        let conditions = json!({"or": [{"a": {"match": {"value": 1}}}]});
+        let parsed = parse_os_conditions(&conditions).expect("should parse");
+        let bool_query = &parsed["bool"];
+
+        // OR filters must actually restrict results, not just contribute score.
+        assert_eq!(bool_query["minimum_should_match"], 1);
+        assert!(bool_query["should"].as_array().unwrap().len() == 1);
+        // No empty `must` array should be emitted for an OR-only filter.
+        assert!(bool_query.get("must").is_none());
+    }
+
+    #[test]
+    fn and_only_conditions_omit_should() {
+        let conditions = json!({"and": [{"a": {"match": {"value": 1}}}]});
+        let parsed = parse_os_conditions(&conditions).expect("should parse");
+        let bool_query = &parsed["bool"];
+
+        assert!(bool_query["must"].as_array().unwrap().len() == 1);
+        assert!(bool_query.get("should").is_none());
+        assert!(bool_query.get("minimum_should_match").is_none());
+    }
+
+    #[test]
+    fn empty_conditions_return_none() {
+        assert!(parse_os_conditions(&json!({})).is_none());
+        // Present-but-empty sub-arrays should not produce a filter either.
+        assert!(parse_os_conditions(&json!({"and": [], "or": []})).is_none());
     }
 }

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -119,8 +119,11 @@ services:
     image: opensearchproject/opensearch:2.19.2
     environment:
       discovery.type: "single-node"
-      plugins.security.disabled: "true"
-      OPENSEARCH_INITIAL_ADMIN_PASSWORD: "Admin_1234!"
+      # DISABLE_SECURITY_PLUGIN skips the security demo installer entirely; the
+      # older plugins.security.disabled flag does not, so the installer still ran
+      # and rejected the (weak) admin password, crashing the container on startup.
+      DISABLE_SECURITY_PLUGIN: "true"
+      DISABLE_INSTALL_DEMO_CONFIG: "true"
     ports:
       - "9202:9200"
     healthcheck:

--- a/tests/integration_opensearch.rs
+++ b/tests/integration_opensearch.rs
@@ -413,6 +413,185 @@ fn test_opensearch_precision_l2() {
     delete_test_index();
 }
 
+/// Regression test for qdrant/vector-db-benchmark#167: filtered kNN search must
+/// use *efficient* filtering (filter pushed inside the `knn` clause) rather than
+/// post-filtering (kNN wrapped in an outer `bool.must` + `filter`).
+///
+/// With a selective filter, post-filtering retrieves the `k` global nearest
+/// neighbours first and only *then* drops those outside the filter, so it returns
+/// far fewer than `k` matches and collapses precision. Efficient filtering
+/// retrieves the `k` nearest neighbours *within* the filter. This test asserts the
+/// efficient form scores high, and asserts the post-filtering form does measurably
+/// worse on the same data — so the fix cannot silently regress.
+#[test]
+fn test_opensearch_filtered_precision() {
+    wait_for_opensearch();
+    delete_test_index();
+
+    let client = os_client();
+    let dim = 8;
+    let n = 500;
+    let k = 10;
+    let num_categories = 5; // target category is ~20% of the corpus → selective
+    let target_category = 3;
+
+    // Create index with a knn_vector plus an integer `category` payload field.
+    let body = serde_json::json!({
+        "settings": {"index": {"knn": true}},
+        "mappings": {
+            "properties": {
+                "vector": {
+                    "type": "knn_vector",
+                    "dimension": dim,
+                    "method": {
+                        "name": "hnsw",
+                        "engine": "lucene",
+                        "space_type": "l2",
+                        "parameters": {"m": 32, "ef_construction": 200}
+                    }
+                },
+                "category": {"type": "integer"}
+            }
+        }
+    });
+    let resp = client
+        .put(&format!("{}/{}", os_base_url(), OS_INDEX))
+        .json(&body)
+        .send()
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    // Upload random vectors, round-robin category assignment.
+    let (ids, vectors) = generate_test_vectors(n, dim);
+    let categories: Vec<i64> = (0..n as i64).map(|i| i % num_categories).collect();
+    let mut ndjson = String::new();
+    for i in 0..n {
+        let uuid_hex = id_to_uuid_hex(ids[i]);
+        ndjson.push_str(&format!("{{\"index\":{{\"_id\":\"{}\"}}}}\n", uuid_hex));
+        let doc = serde_json::json!({"vector": vectors[i], "category": categories[i]});
+        ndjson.push_str(&serde_json::to_string(&doc).unwrap());
+        ndjson.push('\n');
+    }
+    let resp = client
+        .post(&format!("{}/{}/_bulk", os_base_url(), OS_INDEX))
+        .header("Content-Type", "application/x-ndjson")
+        .body(ndjson)
+        .send()
+        .unwrap();
+    assert!(resp.status().is_success());
+    let _ = client
+        .post(&format!("{}/{}/_refresh", os_base_url(), OS_INDEX))
+        .send();
+
+    // Ground truth: k nearest by L2 *among docs in the target category*.
+    let query = &vectors[0];
+    let mut distances: Vec<(i64, f64)> = ids
+        .iter()
+        .zip(vectors.iter())
+        .zip(categories.iter())
+        .filter(|((_, _), &cat)| cat == target_category)
+        .map(|((&id, v), _)| {
+            let dist: f64 = query
+                .iter()
+                .zip(v.iter())
+                .map(|(a, b)| ((*a as f64) - (*b as f64)).powi(2))
+                .sum();
+            (id, dist)
+        })
+        .collect();
+    distances.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+    let ground_truth: std::collections::HashSet<i64> =
+        distances.iter().take(k).map(|(id, _)| *id).collect();
+    assert_eq!(ground_truth.len(), k, "test setup: need >= k docs in category");
+
+    let filter = serde_json::json!({"bool": {"must": [{"match": {"category": target_category}}]}});
+
+    // Helper: run a search body and return the set of returned ids.
+    let run = |search_body: &serde_json::Value| -> Vec<(i64, i64)> {
+        let resp = client
+            .post(&format!("{}/{}/_search", os_base_url(), OS_INDEX))
+            .json(search_body)
+            .send()
+            .unwrap();
+        assert!(resp.status().is_success());
+        let body: serde_json::Value = resp.json().unwrap();
+        body["hits"]["hits"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|h| {
+                let hex = h["_id"].as_str()?;
+                let id = uuid::Uuid::parse_str(hex).ok()?.as_u128() as i64;
+                let cat = h["_source"]["category"].as_i64()?;
+                Some((id, cat))
+            })
+            .collect()
+    };
+
+    // Efficient filtering (the form our engine now produces): filter inside knn.
+    let efficient_body = serde_json::json!({
+        "query": {"knn": {"vector": {"vector": query, "k": k, "filter": filter}}},
+        "size": k,
+    });
+    let efficient_hits = run(&efficient_body);
+    let efficient_found: std::collections::HashSet<i64> =
+        efficient_hits.iter().map(|(id, _)| *id).collect();
+    let efficient_overlap = ground_truth.intersection(&efficient_found).count();
+    let efficient_precision = efficient_overlap as f64 / k as f64;
+
+    // Post-filtering (the old buggy form): kNN wrapped in an outer bool + filter.
+    let post_body = serde_json::json!({
+        "query": {"bool": {
+            "must": [{"knn": {"vector": {"vector": query, "k": k}}}],
+            "filter": filter,
+        }},
+        "size": k,
+    });
+    let post_hits = run(&post_body);
+    let post_found: std::collections::HashSet<i64> =
+        post_hits.iter().map(|(id, _)| *id).collect();
+    let post_precision = post_found.intersection(&ground_truth).count() as f64 / k as f64;
+
+    println!(
+        "OpenSearch filtered precision@{k}: efficient={:.2} ({} hits), post-filter={:.2} ({} hits)",
+        efficient_precision,
+        efficient_hits.len(),
+        post_precision,
+        post_hits.len(),
+    );
+
+    // Every returned doc must satisfy the filter.
+    for (id, cat) in &efficient_hits {
+        assert_eq!(
+            *cat, target_category,
+            "efficient filtering returned doc {id} outside target category"
+        );
+    }
+
+    // Efficient filtering returns a full page of high-precision results ...
+    assert_eq!(
+        efficient_hits.len(),
+        k,
+        "efficient filtering should return k in-filter neighbours"
+    );
+    assert!(
+        efficient_precision >= 0.8,
+        "efficient filtering precision {:.2} < 0.80",
+        efficient_precision
+    );
+
+    // ... and it must clearly beat the old post-filtering behaviour, which loses
+    // most of its candidates to the selective filter.
+    assert!(
+        efficient_precision > post_precision,
+        "efficient filtering ({:.2}) should beat post-filtering ({:.2})",
+        efficient_precision,
+        post_precision
+    );
+
+    delete_test_index();
+}
+
 #[test]
 fn test_opensearch_full_cycle() {
     wait_for_opensearch();


### PR DESCRIPTION
## Problem

Filtered OpenSearch search wrapped the kNN query in an outer `bool.must` + `filter`, which **post-filters**: OpenSearch retrieves the `k` global nearest neighbours first and only *then* drops those outside the filter. With a selective filter this returns far fewer than `k` matches and collapses recall.

This is the same defect qdrant fixed upstream in [qdrant/vector-db-benchmark#167](https://github.com/qdrant/vector-db-benchmark/pull/167) (their Python impl went from precision ~0.11 → ~0.61). Our Rust port carried the identical bug in `knn_search`. Any previously published **filtered** OpenSearch numbers are understated and not comparable to the other engines.

## Fix

- Push the filter **inside** the kNN clause (`knn.vector.filter`) so the Lucene engine (which our index mapping uses) applies it during graph traversal.
- Force `minimum_should_match=1` when OR filters are present — otherwise a mixed AND+OR filter silently ignores the OR half (`should` becomes optional once a `must` clause exists). Also stop emitting empty `must`/`should` arrays.

## Proof (live, Docker)

Reproduced end-to-end against OpenSearch 2.19.2 with a selective 20% filter:

```
OpenSearch filtered precision@10: efficient=1.00 (10 hits), post-filter=0.20 (2 hits)
```

The old post-filtering form returns only 2 of 10 hits at 0.20; the fix returns a full page at 1.00.

## Tests

- **Unit** (no server): `build_knn_body` places the filter inside the kNN clause with no post-filter wrapper; `parse_os_conditions` OR → `minimum_should_match`, AND-only omits `should`, empty conditions → `None`.
- **Integration** `test_opensearch_filtered_precision`: uploads 500 vectors across 5 categories, filters to a selective 20% category, asserts the efficient form is full-page + high-precision **and** beats post-filtering on identical data — so the fix can't silently regress.
- **Infra**: fixes `docker-compose.test.yml` OpenSearch startup, which was crash-looping (`plugins.security.disabled` is ignored by the entrypoint's demo installer, which then rejected the weak admin password). Switched to `DISABLE_SECURITY_PLUGIN` + `DISABLE_INSTALL_DEMO_CONFIG`; container now comes up Healthy.

## Context

Found while auditing our fork against `qdrant/master` (166 commits behind, mostly CI/deps/Python-plumbing that don't apply post-Rust-rewrite). The other upstream precision fixes checked — pgvector `and_subfilter` (#193), OpenSearch range null-bounds (#172) — were already correct in our Rust port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)