### PR TITLE
fix(ci): make v1 CI green — healthchecks, settable bool flags, fmt+clippy

### DIFF
--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -38,12 +38,26 @@ pub struct Args {
     #[arg(long, default_value = "false")]
     pub skip_search: bool,
 
-    /// Skip if results already exist
-    #[arg(long, default_value = "true")]
+    /// Skip if results already exist (accepts an optional value, e.g.
+    /// `--skip-if-exists false`; bare `--skip-if-exists` means true)
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = true,
+        default_missing_value = "true",
+        action = clap::ArgAction::Set
+    )]
     pub skip_if_exists: bool,
 
-    /// Exit on first error
-    #[arg(long, default_value = "true")]
+    /// Exit on first error (accepts an optional value, e.g.
+    /// `--exit-on-error false`; bare `--exit-on-error` means true)
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = true,
+        default_missing_value = "true",
+        action = clap::ArgAction::Set
+    )]
     pub exit_on_error: bool,
 
     /// Timeout in seconds
@@ -83,4 +97,42 @@ pub struct Args {
     /// Collapses all M/EF variants of the same engine into a single "<engine>-no-vector" experiment.
     #[arg(long, default_value = "false")]
     pub skip_vector_index: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(extra: &[&str]) -> Args {
+        let mut argv = vec!["vector-db-benchmark", "--engines", "x", "--datasets", "y"];
+        argv.extend_from_slice(extra);
+        Args::try_parse_from(argv).expect("args should parse")
+    }
+
+    // Regression: the default-true bool flags must accept an explicit value
+    // (`--skip-if-exists false`, as the mongodb integration test invokes it),
+    // an `=` value, a bare flag, and default to true when omitted. Previously
+    // they were SetTrue flags that rejected any value and could never be false.
+    #[test]
+    fn skip_if_exists_accepts_all_forms() {
+        assert!(parse(&[]).skip_if_exists, "omitted → true");
+        assert!(parse(&["--skip-if-exists"]).skip_if_exists, "bare → true");
+        assert!(
+            !parse(&["--skip-if-exists", "false"]).skip_if_exists,
+            "space value → false"
+        );
+        assert!(
+            !parse(&["--skip-if-exists=false"]).skip_if_exists,
+            "= value → false"
+        );
+        assert!(parse(&["--skip-if-exists", "true"]).skip_if_exists);
+    }
+
+    #[test]
+    fn exit_on_error_accepts_all_forms() {
+        assert!(parse(&[]).exit_on_error, "omitted → true");
+        assert!(parse(&["--exit-on-error"]).exit_on_error, "bare → true");
+        assert!(!parse(&["--exit-on-error", "false"]).exit_on_error);
+        assert!(!parse(&["--exit-on-error=false"]).exit_on_error);
+    }
 }

--- a/src/bin/vector_db_benchmark/download.rs
+++ b/src/bin/vector_db_benchmark/download.rs
@@ -122,7 +122,7 @@ fn extract_or_move(tmp_path: &Path, target_path: &Path, link: &str) -> Result<()
         extract_tgz(tmp_path, target_path)
     } else if link_lower.ends_with(".bz2") {
         // Decompress bz2 — strip .bz2 from target if present
-        let final_target = if target_path.extension().map_or(false, |e| e == "bz2") {
+        let final_target = if target_path.extension().is_some_and(|e| e == "bz2") {
             target_path.with_extension("")
         } else {
             target_path.to_path_buf()

--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -840,11 +840,8 @@ impl Engine for ElasticsearchEngine {
                         if let Ok(result_ids) = results {
                             let ordered_ids: Vec<i64> =
                                 result_ids.iter().map(|(id, _)| *id).collect();
-                            let m = crate::metrics::compute_metrics(
-                                &ordered_ids,
-                                &neighbors[idx],
-                                top,
-                            );
+                            let m =
+                                crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
                             precisions.lock().unwrap().push(m.precision);
                             recalls.lock().unwrap().push(m.recall);
                             mrrs.lock().unwrap().push(m.mrr);

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -473,6 +473,7 @@ fn insert_batch(
 }
 
 /// Search Milvus via REST API.
+#[allow(clippy::too_many_arguments)]
 fn search_vectors(
     client: &reqwest::blocking::Client,
     base_url: &str,
@@ -571,7 +572,7 @@ fn parse_milvus_conditions(conditions: &serde_json::Value) -> Option<String> {
     if let Some(and_items) = obj.get("and").and_then(|v| v.as_array()) {
         let and_filters: Vec<String> = and_items
             .iter()
-            .filter_map(|entry| build_milvus_entry_filter(entry))
+            .filter_map(build_milvus_entry_filter)
             .collect();
         if !and_filters.is_empty() {
             clauses.push(format!("({})", and_filters.join(" && ")));
@@ -581,7 +582,7 @@ fn parse_milvus_conditions(conditions: &serde_json::Value) -> Option<String> {
     if let Some(or_items) = obj.get("or").and_then(|v| v.as_array()) {
         let or_filters: Vec<String> = or_items
             .iter()
-            .filter_map(|entry| build_milvus_entry_filter(entry))
+            .filter_map(build_milvus_entry_filter)
             .collect();
         if !or_filters.is_empty() {
             clauses.push(format!("({})", or_filters.join(" || ")));
@@ -857,8 +858,10 @@ impl Engine for MilvusEngine {
                         search_times.lock().unwrap().push(query_time);
 
                         if let Ok(result_ids) = results {
-                            let ordered_ids: Vec<i64> = result_ids.iter().map(|(id, _)| *id).collect();
-                            let m = crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
+                            let ordered_ids: Vec<i64> =
+                                result_ids.iter().map(|(id, _)| *id).collect();
+                            let m =
+                                crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
                             precisions.lock().unwrap().push(m.precision);
                             recalls.lock().unwrap().push(m.recall);
                             mrrs.lock().unwrap().push(m.mrr);

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -124,9 +124,7 @@ impl MongoDBEngine {
             .collect();
 
         if runnable_indices.is_empty() {
-            return Err(
-                "No queries with filter conditions for filter-only search".to_string(),
-            );
+            return Err("No queries with filter conditions for filter-only search".to_string());
         }
 
         // Round-robin: if num_queries > available queries, cycle through them
@@ -179,7 +177,11 @@ impl MongoDBEngine {
 
                         let top = explicit_top.unwrap_or_else(|| {
                             let n = neighbors[idx].len();
-                            if n > 0 { n } else { 10 }
+                            if n > 0 {
+                                n
+                            } else {
+                                10
+                            }
                         });
 
                         let filter = parsed_filters[idx].as_ref().unwrap();
@@ -292,16 +294,16 @@ impl MongoDBEngine {
         let deadline = Instant::now() + std::time::Duration::from_secs(120);
         loop {
             let cmd = doc! { "listSearchIndexes": &self.collection_name };
-            let index_exists = db.run_command(cmd).run().ok().map_or(false, |result| {
+            let index_exists = db.run_command(cmd).run().ok().is_some_and(|result| {
                 result
                     .get_document("cursor")
                     .ok()
                     .and_then(|c| c.get_array("firstBatch").ok())
-                    .map_or(false, |batch| {
+                    .is_some_and(|batch| {
                         batch.iter().any(|idx| {
                             idx.as_document()
                                 .and_then(|d| d.get_str("name").ok())
-                                .map_or(false, |n| n == self.index_name)
+                                .is_some_and(|n| n == self.index_name)
                         })
                     })
             });
@@ -1004,7 +1006,10 @@ impl Engine for MongoDBEngine {
         let total_time;
         if self.config.skip_vector_index {
             total_time = read_time + upload_time;
-            println!("Total time (read+upload): {:.3}s (no vector index)", total_time);
+            println!(
+                "Total time (read+upload): {:.3}s (no vector index)",
+                total_time
+            );
         } else {
             // Wait for the search index to finish indexing all uploaded documents
             // Use the first vector as a probe query to verify actual search readiness
@@ -1134,8 +1139,10 @@ impl Engine for MongoDBEngine {
                         search_times.lock().unwrap().push(query_time);
 
                         if let Ok(result_ids) = results {
-                            let ordered_ids: Vec<i64> = result_ids.iter().map(|(id, _)| *id).collect();
-                            let m = crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
+                            let ordered_ids: Vec<i64> =
+                                result_ids.iter().map(|(id, _)| *id).collect();
+                            let m =
+                                crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
                             precisions.lock().unwrap().push(m.precision);
                             recalls.lock().unwrap().push(m.recall);
                             mrrs.lock().unwrap().push(m.mrr);
@@ -1346,8 +1353,13 @@ impl Engine for MongoDBEngine {
                             search_times.lock().unwrap().push(query_time);
 
                             if let Ok(result_ids) = results {
-                                let ordered_ids: Vec<i64> = result_ids.iter().map(|(id, _)| *id).collect();
-                                let m = crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
+                                let ordered_ids: Vec<i64> =
+                                    result_ids.iter().map(|(id, _)| *id).collect();
+                                let m = crate::metrics::compute_metrics(
+                                    &ordered_ids,
+                                    &neighbors[idx],
+                                    top,
+                                );
                                 precisions.lock().unwrap().push(m.precision);
                                 recalls.lock().unwrap().push(m.recall);
                                 mrrs.lock().unwrap().push(m.mrr);

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -863,11 +863,8 @@ impl Engine for OpenSearchEngine {
                         if let Ok(result_ids) = results {
                             let ordered_ids: Vec<i64> =
                                 result_ids.iter().map(|(id, _)| *id).collect();
-                            let m = crate::metrics::compute_metrics(
-                                &ordered_ids,
-                                &neighbors[idx],
-                                top,
-                            );
+                            let m =
+                                crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
                             precisions.lock().unwrap().push(m.precision);
                             recalls.lock().unwrap().push(m.recall);
                             mrrs.lock().unwrap().push(m.mrr);

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -259,7 +259,7 @@ impl Engine for PgVectorEngine {
                                     .map(|v| v.to_string())
                                     .collect::<Vec<_>>()
                                     .join(",");
-                                write!(writer, "{}\t[{}]\n", ids[i], vec_str)
+                                writeln!(writer, "{}\t[{}]", ids[i], vec_str)
                                     .map_err(|e| format!("COPY write failed: {}", e))?;
                             }
 

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -86,7 +86,7 @@ impl QdrantEngine {
             .trim_start_matches("http://")
             .trim_start_matches("https://");
 
-        let grpc_url = if let Some(url) = std::env::var("QDRANT_URL").ok() {
+        let grpc_url = if let Ok(url) = std::env::var("QDRANT_URL") {
             url
         } else {
             format!("http://{}:{}", clean_host, grpc_port)
@@ -187,10 +187,10 @@ impl QdrantEngine {
         if hnsw_m.is_some() || hnsw_ef.is_some() {
             let mut hnsw_config = HnswConfigDiff::default();
             if let Some(m) = hnsw_m {
-                hnsw_config.m = Some(m as u64);
+                hnsw_config.m = Some(m);
             }
             if let Some(ef) = hnsw_ef {
-                hnsw_config.ef_construct = Some(ef as u64);
+                hnsw_config.ef_construct = Some(ef);
             }
             create_builder = create_builder.hnsw_config(hnsw_config);
         }
@@ -226,13 +226,13 @@ impl QdrantEngine {
                     quantile: s.get("quantile").and_then(|v| v.as_f64()).map(|v| v as f32),
                     always_ram: s.get("always_ram").and_then(|v| v.as_bool()),
                 }))
-            } else if let Some(b) = q.get("binary") {
-                Some(Quantization::Binary(BinaryQuantization {
-                    always_ram: b.get("always_ram").and_then(|v| v.as_bool()),
-                    ..Default::default()
-                }))
             } else {
-                None
+                q.get("binary").map(|b| {
+                    Quantization::Binary(BinaryQuantization {
+                        always_ram: b.get("always_ram").and_then(|v| v.as_bool()),
+                        ..Default::default()
+                    })
+                })
             };
             if let Some(quantization) = quantization {
                 create_builder = create_builder.quantization_config(quantization);
@@ -518,10 +518,10 @@ fn build_qdrant_filter(
             let value = criteria.get("value")?;
             if let Some(s) = value.as_str() {
                 Some(Condition::matches(field_name.to_string(), s.to_string()))
-            } else if let Some(n) = value.as_i64() {
-                Some(Condition::matches(field_name.to_string(), n))
             } else {
-                None
+                value
+                    .as_i64()
+                    .map(|n| Condition::matches(field_name.to_string(), n))
             }
         }
         "range" => {
@@ -730,7 +730,7 @@ impl Engine for QdrantEngine {
                         if hnsw_ef.is_some() || quantization_params.is_some() {
                             let search_params = qdrant_client::qdrant::SearchParams {
                                 hnsw_ef,
-                                quantization: quantization_params.clone(),
+                                quantization: quantization_params,
                                 ..Default::default()
                             };
                             search_builder = search_builder.params(search_params);

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -404,7 +404,7 @@ impl RedisEngine {
                 return Ok(());
             }
 
-            if start.elapsed().as_secs() > 0 && start.elapsed().as_secs() % 10 == 0 {
+            if start.elapsed().as_secs() > 0 && start.elapsed().as_secs().is_multiple_of(10) {
                 println!(
                     "  indexing... num_docs={}/{}, percent_indexed={:.2}, indexing={}",
                     num_docs, expected, percent_indexed, indexing
@@ -448,9 +448,7 @@ impl RedisEngine {
             .collect();
 
         if runnable_indices.is_empty() {
-            return Err(
-                "No queries with filter conditions for filter-only search".to_string()
-            );
+            return Err("No queries with filter conditions for filter-only search".to_string());
         }
 
         // Round-robin: if num_queries > available queries, cycle through them
@@ -499,7 +497,11 @@ impl RedisEngine {
 
                         let top = explicit_top.unwrap_or_else(|| {
                             let n = neighbors[idx].len();
-                            if n > 0 { n } else { 10 }
+                            if n > 0 {
+                                n
+                            } else {
+                                10
+                            }
                         });
 
                         let query_start = Instant::now();
@@ -567,7 +569,12 @@ impl RedisEngine {
 
         // Verify no FT.SEARCH failures occurred
         let mut check_conn = self.get_connection()?;
-        redis_utils::check_commandstats(&mut check_conn, &["FT.SEARCH"], "search", self.commandstats_baseline.as_ref())?;
+        redis_utils::check_commandstats(
+            &mut check_conn,
+            &["FT.SEARCH"],
+            "search",
+            self.commandstats_baseline.as_ref(),
+        )?;
 
         Ok(SearchResults {
             total_time,
@@ -1249,7 +1256,12 @@ impl Engine for RedisEngine {
 
         // Verify no HSET failures occurred during upload
         let mut conn = self.get_connection()?;
-        redis_utils::check_commandstats(&mut conn, &["hset"], "upload", self.commandstats_baseline.as_ref())?;
+        redis_utils::check_commandstats(
+            &mut conn,
+            &["hset"],
+            "upload",
+            self.commandstats_baseline.as_ref(),
+        )?;
 
         Ok(UploadStats {
             upload_time,
@@ -1376,7 +1388,8 @@ impl Engine for RedisEngine {
 
                         // Calculate retrieval quality metrics
                         if let Ok(result_ids) = results {
-                            let ordered_ids: Vec<i64> = result_ids.iter().map(|(id, _)| *id).collect();
+                            let ordered_ids: Vec<i64> =
+                                result_ids.iter().map(|(id, _)| *id).collect();
                             let m = compute_metrics(&ordered_ids, &neighbors[idx], top);
                             precisions.lock().unwrap().push(m.precision);
                             recalls.lock().unwrap().push(m.recall);
@@ -1440,7 +1453,12 @@ impl Engine for RedisEngine {
 
         // Verify no FT.SEARCH failures occurred
         let mut check_conn = self.get_connection()?;
-        redis_utils::check_commandstats(&mut check_conn, &["FT.SEARCH"], "search", self.commandstats_baseline.as_ref())?;
+        redis_utils::check_commandstats(
+            &mut check_conn,
+            &["FT.SEARCH"],
+            "search",
+            self.commandstats_baseline.as_ref(),
+        )?;
 
         Ok(SearchResults {
             total_time,
@@ -1598,7 +1616,8 @@ impl Engine for RedisEngine {
 
                             // Calculate retrieval quality metrics
                             if let Ok(result_ids) = results {
-                                let ordered_ids: Vec<i64> = result_ids.iter().map(|(id, _)| *id).collect();
+                                let ordered_ids: Vec<i64> =
+                                    result_ids.iter().map(|(id, _)| *id).collect();
                                 let m = compute_metrics(&ordered_ids, &neighbors[idx], top);
                                 precisions.lock().unwrap().push(m.precision);
                                 recalls.lock().unwrap().push(m.recall);
@@ -1710,7 +1729,12 @@ impl Engine for RedisEngine {
 
         // Verify no failures occurred
         let mut check_conn = self.get_connection()?;
-        redis_utils::check_commandstats(&mut check_conn, &["FT.SEARCH", "hset"], "mixed", self.commandstats_baseline.as_ref())?;
+        redis_utils::check_commandstats(
+            &mut check_conn,
+            &["FT.SEARCH", "hset"],
+            "mixed",
+            self.commandstats_baseline.as_ref(),
+        )?;
 
         Ok(SearchResults {
             total_time,

--- a/src/bin/vector_db_benchmark/engine/turbopuffer.rs
+++ b/src/bin/vector_db_benchmark/engine/turbopuffer.rs
@@ -19,6 +19,9 @@ use crate::dataset::Dataset;
 use crate::engine::{Engine, SearchResults, UploadStats};
 use vector_db_benchmark::readers::metadata::MetadataItem;
 
+/// One upload batch: ids, their vectors, and optional per-item metadata.
+type UploadBatch = (Vec<i64>, Vec<Vec<f32>>, Vec<Option<MetadataItem>>);
+
 const DEFAULT_NAMESPACE: &str = "benchmark";
 
 pub struct TurbopufferEngine {
@@ -372,7 +375,7 @@ impl Engine for TurbopufferEngine {
             let counter = Arc::new(AtomicUsize::new(0));
             let errors = Arc::new(Mutex::new(Vec::new()));
 
-            let batches: Vec<(Vec<i64>, Vec<Vec<f32>>, Vec<Option<MetadataItem>>)> = (0..total)
+            let batches: Vec<UploadBatch> = (0..total)
                 .step_by(batch_size)
                 .map(|start| {
                     let end = (start + batch_size).min(total);

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -432,7 +432,7 @@ impl ValkeyEngine {
                 return Ok(());
             }
 
-            if start.elapsed().as_secs() % 10 == 0 && start.elapsed().as_secs() > 0 {
+            if start.elapsed().as_secs().is_multiple_of(10) && start.elapsed().as_secs() > 0 {
                 println!(
                     "Waiting for indexing: {} docs, indexing={} ({:.0}s)",
                     num_docs,
@@ -474,9 +474,7 @@ impl ValkeyEngine {
             .collect();
 
         if runnable_indices.is_empty() {
-            return Err(
-                "No queries with filter conditions for filter-only search".to_string()
-            );
+            return Err("No queries with filter conditions for filter-only search".to_string());
         }
 
         // Round-robin: if num_queries > available queries, cycle through them
@@ -533,7 +531,11 @@ impl ValkeyEngine {
 
                         let top = explicit_top.unwrap_or_else(|| {
                             let n = neighbors[idx].len();
-                            if n > 0 { n } else { 10 }
+                            if n > 0 {
+                                n
+                            } else {
+                                10
+                            }
                         });
 
                         let query_start = Instant::now();
@@ -600,7 +602,12 @@ impl ValkeyEngine {
             .unwrap_or(0.0);
 
         let mut check_conn = self.get_connection()?;
-        redis_utils::check_commandstats(&mut check_conn, &["FT.SEARCH"], "search", self.commandstats_baseline.as_ref())?;
+        redis_utils::check_commandstats(
+            &mut check_conn,
+            &["FT.SEARCH"],
+            "search",
+            self.commandstats_baseline.as_ref(),
+        )?;
 
         Ok(SearchResults {
             total_time,
@@ -1263,7 +1270,12 @@ impl Engine for ValkeyEngine {
 
         // Verify no HSET failures occurred during upload
         let mut conn = self.get_connection()?;
-        redis_utils::check_commandstats(&mut conn, &["hset"], "upload", self.commandstats_baseline.as_ref())?;
+        redis_utils::check_commandstats(
+            &mut conn,
+            &["hset"],
+            "upload",
+            self.commandstats_baseline.as_ref(),
+        )?;
 
         Ok(UploadStats {
             upload_time,
@@ -1392,8 +1404,13 @@ impl Engine for ValkeyEngine {
 
                         match &results {
                             Ok(result_ids) => {
-                                let ordered_ids: Vec<i64> = result_ids.iter().map(|(id, _)| *id).collect();
-                                let m = crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
+                                let ordered_ids: Vec<i64> =
+                                    result_ids.iter().map(|(id, _)| *id).collect();
+                                let m = crate::metrics::compute_metrics(
+                                    &ordered_ids,
+                                    &neighbors[idx],
+                                    top,
+                                );
                                 precisions.lock().unwrap().push(m.precision);
                                 recalls.lock().unwrap().push(m.recall);
                                 mrrs.lock().unwrap().push(m.mrr);
@@ -1456,7 +1473,12 @@ impl Engine for ValkeyEngine {
 
         // Verify no FT.SEARCH failures occurred
         let mut check_conn = self.get_connection()?;
-        redis_utils::check_commandstats(&mut check_conn, &["FT.SEARCH"], "search", self.commandstats_baseline.as_ref())?;
+        redis_utils::check_commandstats(
+            &mut check_conn,
+            &["FT.SEARCH"],
+            "search",
+            self.commandstats_baseline.as_ref(),
+        )?;
 
         Ok(SearchResults {
             total_time,
@@ -1611,8 +1633,13 @@ impl Engine for ValkeyEngine {
 
                             match &results {
                                 Ok(result_ids) => {
-                                    let ordered_ids: Vec<i64> = result_ids.iter().map(|(id, _)| *id).collect();
-                                    let m = crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
+                                    let ordered_ids: Vec<i64> =
+                                        result_ids.iter().map(|(id, _)| *id).collect();
+                                    let m = crate::metrics::compute_metrics(
+                                        &ordered_ids,
+                                        &neighbors[idx],
+                                        top,
+                                    );
                                     precisions.lock().unwrap().push(m.precision);
                                     recalls.lock().unwrap().push(m.recall);
                                     mrrs.lock().unwrap().push(m.mrr);
@@ -1725,7 +1752,12 @@ impl Engine for ValkeyEngine {
 
         // Verify no failures occurred
         let mut check_conn = self.get_connection()?;
-        redis_utils::check_commandstats(&mut check_conn, &["FT.SEARCH", "hset"], "mixed", self.commandstats_baseline.as_ref())?;
+        redis_utils::check_commandstats(
+            &mut check_conn,
+            &["FT.SEARCH", "hset"],
+            "mixed",
+            self.commandstats_baseline.as_ref(),
+        )?;
 
         Ok(SearchResults {
             total_time,

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -472,7 +472,12 @@ impl Engine for VectorSetsEngine {
 
         // Verify no VADD failures occurred during upload
         let mut conn = self.get_connection()?;
-        redis_utils::check_commandstats(&mut conn, &["VADD"], "upload", self.commandstats_baseline.as_ref())?;
+        redis_utils::check_commandstats(
+            &mut conn,
+            &["VADD"],
+            "upload",
+            self.commandstats_baseline.as_ref(),
+        )?;
 
         Ok(UploadStats {
             upload_time,
@@ -585,8 +590,10 @@ impl Engine for VectorSetsEngine {
                         search_times.lock().unwrap().push(query_time);
 
                         if let Ok(result_ids) = results {
-                            let ordered_ids: Vec<i64> = result_ids.iter().map(|(id, _)| *id).collect();
-                            let m = crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
+                            let ordered_ids: Vec<i64> =
+                                result_ids.iter().map(|(id, _)| *id).collect();
+                            let m =
+                                crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
                             precisions.lock().unwrap().push(m.precision);
                             recalls.lock().unwrap().push(m.recall);
                             mrrs.lock().unwrap().push(m.mrr);
@@ -647,7 +654,12 @@ impl Engine for VectorSetsEngine {
 
         // Verify no VSIM failures occurred
         let mut check_conn = self.get_connection()?;
-        redis_utils::check_commandstats(&mut check_conn, &["VSIM"], "search", self.commandstats_baseline.as_ref())?;
+        redis_utils::check_commandstats(
+            &mut check_conn,
+            &["VSIM"],
+            "search",
+            self.commandstats_baseline.as_ref(),
+        )?;
 
         Ok(SearchResults {
             total_time,
@@ -802,8 +814,13 @@ impl Engine for VectorSetsEngine {
                             search_times.lock().unwrap().push(query_time);
 
                             if let Ok(result_ids) = results {
-                                let ordered_ids: Vec<i64> = result_ids.iter().map(|(id, _)| *id).collect();
-                                let m = crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
+                                let ordered_ids: Vec<i64> =
+                                    result_ids.iter().map(|(id, _)| *id).collect();
+                                let m = crate::metrics::compute_metrics(
+                                    &ordered_ids,
+                                    &neighbors[idx],
+                                    top,
+                                );
                                 precisions.lock().unwrap().push(m.precision);
                                 recalls.lock().unwrap().push(m.recall);
                                 mrrs.lock().unwrap().push(m.mrr);
@@ -914,7 +931,12 @@ impl Engine for VectorSetsEngine {
 
         // Verify no failures occurred
         let mut check_conn = self.get_connection()?;
-        redis_utils::check_commandstats(&mut check_conn, &["VSIM", "VADD"], "mixed", self.commandstats_baseline.as_ref())?;
+        redis_utils::check_commandstats(
+            &mut check_conn,
+            &["VSIM", "VADD"],
+            "mixed",
+            self.commandstats_baseline.as_ref(),
+        )?;
 
         Ok(SearchResults {
             total_time,
@@ -1049,10 +1071,8 @@ fn build_match_clause(field_name: &str, criteria: &serde_json::Value) -> Option<
         Some(format!(".{} == \"{}\"", field_name, escaped))
     } else if let Some(n) = value.as_i64() {
         Some(format!(".{} == {}", field_name, n))
-    } else if let Some(f) = value.as_f64() {
-        Some(format!(".{} == {}", field_name, f))
     } else {
-        None
+        value.as_f64().map(|f| format!(".{} == {}", field_name, f))
     }
 }
 

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -538,7 +538,7 @@ fn parse_weaviate_conditions(conditions: &serde_json::Value) -> Option<serde_jso
     if let Some(and_items) = obj.get("and").and_then(|v| v.as_array()) {
         let and_filters: Vec<serde_json::Value> = and_items
             .iter()
-            .filter_map(|entry| build_weaviate_entry_filter(entry))
+            .filter_map(build_weaviate_entry_filter)
             .collect();
         if !and_filters.is_empty() {
             if and_filters.len() == 1 {
@@ -555,7 +555,7 @@ fn parse_weaviate_conditions(conditions: &serde_json::Value) -> Option<serde_jso
     if let Some(or_items) = obj.get("or").and_then(|v| v.as_array()) {
         let or_filters: Vec<serde_json::Value> = or_items
             .iter()
-            .filter_map(|entry| build_weaviate_entry_filter(entry))
+            .filter_map(build_weaviate_entry_filter)
             .collect();
         if !or_filters.is_empty() {
             if or_filters.len() == 1 {
@@ -878,8 +878,10 @@ impl Engine for WeaviateEngine {
                         search_times.lock().unwrap().push(query_time);
 
                         if let Ok(result_ids) = results {
-                            let ordered_ids: Vec<i64> = result_ids.iter().map(|(id, _)| *id).collect();
-                            let m = crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
+                            let ordered_ids: Vec<i64> =
+                                result_ids.iter().map(|(id, _)| *id).collect();
+                            let m =
+                                crate::metrics::compute_metrics(&ordered_ids, &neighbors[idx], top);
                             precisions.lock().unwrap().push(m.precision);
                             recalls.lock().unwrap().push(m.recall);
                             mrrs.lock().unwrap().push(m.mrr);

--- a/src/bin/vector_db_benchmark/summary.rs
+++ b/src/bin/vector_db_benchmark/summary.rs
@@ -92,16 +92,11 @@ pub fn display_results_summary(engine_name: &str, dataset_name: &str, entries: &
     }
 
     // Filter-only mode: precision is not applicable (mean_precision == -1.0)
-    let filter_only = entries
-        .iter()
-        .all(|e| e.results.mean_precision < 0.0);
+    let filter_only = entries.iter().all(|e| e.results.mean_precision < 0.0);
 
     if filter_only {
         println!("{}", "-".repeat(40));
-        println!(
-            "{:<10} {:<12} {:<12}",
-            "QPS", "P50 (ms)", "P95 (ms)"
-        );
+        println!("{:<10} {:<12} {:<12}", "QPS", "P50 (ms)", "P95 (ms)");
         println!("{}", "-".repeat(40));
 
         for e in entries {
@@ -162,7 +157,16 @@ pub fn display_mixed_summary(entries: &[SearchEntry]) {
     println!("\n{}", "-".repeat(116));
     println!(
         "{:<14} {:<8} {:<8} {:<8} {:<8} {:<10} {:<12} {:<12} {:<10} {:<12}",
-        "Ratio", "Recall", "Prec", "MRR", "NDCG", "QPS", "P50 (ms)", "P95 (ms)", "Upd QPS", "Upd P50 (ms)"
+        "Ratio",
+        "Recall",
+        "Prec",
+        "MRR",
+        "NDCG",
+        "QPS",
+        "P50 (ms)",
+        "P95 (ms)",
+        "Upd QPS",
+        "Upd P50 (ms)"
     );
     println!("{}", "-".repeat(116));
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -62,11 +62,13 @@ pub fn compute_metrics(result_ids_ordered: &[i64], ground_truth: &[i64], k: usiz
             .sum();
 
         let ideal_hits = k.min(truth_set.len());
-        let idcg: f64 = (0..ideal_hits)
-            .map(|i| 1.0 / (i as f64 + 2.0).log2())
-            .sum();
+        let idcg: f64 = (0..ideal_hits).map(|i| 1.0 / (i as f64 + 2.0).log2()).sum();
 
-        if idcg > 0.0 { dcg / idcg } else { 0.0 }
+        if idcg > 0.0 {
+            dcg / idcg
+        } else {
+            0.0
+        }
     };
 
     QueryMetrics {

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -27,7 +27,9 @@ services:
       - "6334:6333"
       - "6335:6334"
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:6333/collections || exit 1"]
+      # The qdrant image ships neither curl nor wget; it does have bash, so use a
+      # /dev/tcp connect check against the REST port to confirm readiness.
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/6333"]
       interval: 2s
       timeout: 5s
       retries: 15
@@ -61,7 +63,9 @@ services:
     ports:
       - "8081:8080"
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/v1/.well-known/ready || exit 1"]
+      # The weaviate image has no curl; use its bundled wget in spider mode to
+      # probe the readiness endpoint.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/v1/.well-known/ready"]
       interval: 2s
       timeout: 5s
       retries: 15

--- a/tests/integration_opensearch.rs
+++ b/tests/integration_opensearch.rs
@@ -502,7 +502,11 @@ fn test_opensearch_filtered_precision() {
     distances.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
     let ground_truth: std::collections::HashSet<i64> =
         distances.iter().take(k).map(|(id, _)| *id).collect();
-    assert_eq!(ground_truth.len(), k, "test setup: need >= k docs in category");
+    assert_eq!(
+        ground_truth.len(),
+        k,
+        "test setup: need >= k docs in category"
+    );
 
     let filter = serde_json::json!({"bool": {"must": [{"match": {"category": target_category}}]}});
 
@@ -548,8 +552,7 @@ fn test_opensearch_filtered_precision() {
         "size": k,
     });
     let post_hits = run(&post_body);
-    let post_found: std::collections::HashSet<i64> =
-        post_hits.iter().map(|(id, _)| *id).collect();
+    let post_found: std::collections::HashSet<i64> = post_hits.iter().map(|(id, _)| *id).collect();
     let post_precision = post_found.intersection(&ground_truth).count() as f64 / k as f64;
 
     println!(

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -87,8 +87,9 @@ fn brute_force_neighbors_l2(query: &[f32], vectors: &[Vec<f32>], top: usize) -> 
 
 fn create_grpc_client() -> (tokio::runtime::Runtime, qdrant_client::Qdrant) {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let client = rt
-        .block_on(qdrant_client::Qdrant::from_url(&grpc_url()).build())
+    // `from_url(...).build()` is synchronous and returns a Result, not a future.
+    let client = qdrant_client::Qdrant::from_url(&grpc_url())
+        .build()
         .unwrap();
     (rt, client)
 }


### PR DESCRIPTION
Gets the `v1` CI fully green. All failures here were **pre-existing** on `v1` (unrelated to the OpenSearch fix in #59). Three independent root causes:

## 1. Qdrant & Weaviate integration jobs — container never healthy
Both healthchecks shell out to `curl`, which **neither image ships**, so `docker compose up --wait` timed out (exit 1) before tests ran.
- **Qdrant**: image has `bash` (no curl/wget/nc) → bash `/dev/tcp` connect check on the REST port.
- **Weaviate**: image has `wget` (no curl/bash) → `wget --spider` on the readiness endpoint.

Verified locally: both reach `healthy` via the exact CI `up -d <svc> --wait` command.

## 2. MongoDB job — `test_binary_mongodb_multi_dataset` failed with `unexpected argument 'false'`
`--skip-if-exists` / `--exit-on-error` were derived as `SetTrue` flags with `default_value = "true"`, so they **rejected an explicit value and could never be set to false**. The test invokes `--skip-if-exists false`.

Fix: `num_args = 0..=1` + `default_missing_value = "true"`, so the bare flag still means true (README form), an explicit value now parses, and the default stays true. Added `cli.rs` unit tests covering omitted / bare / space-value / `=`-value forms. The real MongoDB integration test passes end-to-end locally.

## 3. `Check (fmt + clippy)` — died at fmt, masking a clippy backlog
`cargo fmt --check` failed, so the job never reached clippy — which had **20 `-D warnings` errors** underneath.
- repo-wide `cargo fmt`
- machine-applicable clippy fixes via `cargo clippy --fix`
- `milvus::search_vectors`: `#[allow(clippy::too_many_arguments)]` (8 params by design)
- `turbopuffer`: `UploadBatch` type alias for `type_complexity`

## Verified locally
- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓ (exit 0)
- unit tests: 65 passed ✓
- Qdrant + Weaviate `--wait` → healthy ✓
- MongoDB `test_binary_mongodb_multi_dataset` ✓

The fmt+clippy sweep is isolated in its own commit for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)