### PR TITLE
feat(cli): make --timeout a functional overall wall-clock budget

### DIFF
--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -60,7 +60,8 @@ pub struct Args {
     )]
     pub exit_on_error: bool,
 
-    /// Timeout in seconds
+    /// Overall wall-clock budget in seconds: stop launching new experiments once
+    /// total elapsed exceeds this (any in-flight experiment finishes). 0 disables.
     #[arg(long, default_value = "86400.0")]
     pub timeout: f64,
 

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -4,6 +4,7 @@
 
 use std::fs;
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use chrono::Local;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -112,7 +113,18 @@ pub fn run(args: &Args) -> Result<(), String> {
 
     let skip_vector_engines = ["redis", "valkey", "mongodb"];
 
-    for (_engine_name, engine_config) in &engines {
+    // Soft wall-clock budget: once total elapsed reaches --timeout, stop launching
+    // further experiments and finish cleanly. This bounds the overall run without
+    // interrupting an in-flight experiment (the Rust runner is blocking, so a hard
+    // per-experiment abort as in the Python tool is not safe here).
+    let run_start = Instant::now();
+    let budget = if args.timeout.is_finite() && args.timeout > 0.0 {
+        Some(Duration::from_secs_f64(args.timeout))
+    } else {
+        None
+    };
+
+    'experiments: for (_engine_name, engine_config) in &engines {
         // Apply --skip-vector-index: override name and set flag on config
         let mut engine_config = (*engine_config).clone();
         if args.skip_vector_index {
@@ -129,6 +141,24 @@ pub fn run(args: &Args) -> Result<(), String> {
         }
 
         for (dataset_name, dataset_config) in &datasets {
+            // Stop before starting a new experiment if the time budget is exhausted.
+            if let Some(budget) = budget {
+                let elapsed = run_start.elapsed();
+                if elapsed >= budget {
+                    let remaining = total_experiments as u64 - pb.position();
+                    pb.suspend(|| {
+                        eprintln!(
+                            "Reached --timeout budget ({:.0}s, elapsed {:.0}s); \
+                             stopping with {} experiment(s) not started.",
+                            budget.as_secs_f64(),
+                            elapsed.as_secs_f64(),
+                            remaining
+                        );
+                    });
+                    break 'experiments;
+                }
+            }
+
             let experiment_num = pb.position() + 1;
             pb.suspend(|| {
                 println!("\n{}", "=".repeat(60));


### PR DESCRIPTION
The `--timeout` flag was **parsed but never consumed** — it did nothing (surfaced during the open-PR triage; it's the still-relevant part of Python PR #1).

## Semantics choice
Python used `--timeout` as a *per-experiment hard abort* (via `stopit`), which can't be done safely in v1's blocking/rayon runner (no safe way to interrupt an in-flight blocking upload/search). Implemented the safe analog agreed with the maintainer: a **soft overall wall-clock budget**.

- Before launching each experiment, if total elapsed since the run started ≥ `--timeout`, stop launching new experiments and finish cleanly.
- Any in-flight experiment runs to completion (not interrupted).
- `0` disables the budget. Default stays 86400s (24h). Help text updated.

## Verified end-to-end (Qdrant)
3 experiments, `--timeout 0.001`:
```
Running experiment (1/3): qdrant-m-64-ef-64 - random-100
Reached --timeout budget (0s, elapsed 13s); stopping with 2 experiment(s) not started.
```
Experiment 1 completes; the runner then stops the rest.

`cargo fmt --check`, `clippy -D warnings`, unit tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)