### PR TITLE
feat(qdrant): prefetch/rescore, query_points, richer filters & payload types

### DIFF
--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -12,9 +12,10 @@ use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 use qdrant_client::qdrant::quantization_config::Quantization;
 use qdrant_client::qdrant::vectors_config::Config;
 use qdrant_client::qdrant::{
-    BinaryQuantization, Condition, CreateCollectionBuilder, DeleteCollectionBuilder, Distance,
-    FieldType, Filter, HnswConfigDiff, MaxOptimizationThreads, OptimizersConfigDiff, PointStruct,
-    QuantizationSearchParams, QuantizationType, ScalarQuantization, SearchPointsBuilder,
+    BinaryQuantization, Condition, CreateCollectionBuilder, DatetimeRange, DeleteCollectionBuilder,
+    Distance, FieldType, Filter, HnswConfigDiff, MaxOptimizationThreads, OptimizersConfigDiff,
+    PointStruct, PrefetchQueryBuilder, QuantizationSearchParams, QuantizationType,
+    QueryPointsBuilder, ScalarQuantization, SearchParams as QdrantSearchParams, Timestamp,
     VectorParamsBuilder, VectorsConfig,
 };
 use qdrant_client::{Payload, Qdrant};
@@ -190,7 +191,16 @@ impl QdrantEngine {
         let hnsw_m = self.hnsw_m;
         let hnsw_ef = self.hnsw_ef_construct;
 
-        let vector_params = VectorParamsBuilder::new(vector_size as u64, qdrant_distance);
+        // Optionally store vectors on disk (mmap) — collection_params.vectors_config.on_disk.
+        let vectors_on_disk = self
+            .collection_params_extra
+            .get("vectors_config")
+            .and_then(|v| v.get("on_disk"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let vector_params =
+            VectorParamsBuilder::new(vector_size as u64, qdrant_distance).on_disk(vectors_on_disk);
 
         let mut create_builder = CreateCollectionBuilder::new(&self.collection_name)
             .vectors_config(VectorsConfig {
@@ -283,6 +293,9 @@ impl QdrantEngine {
                         "text" => FieldType::Text,
                         "float" => FieldType::Float,
                         "geo" => FieldType::Geo,
+                        "uuid" => FieldType::Uuid,
+                        "bool" => FieldType::Bool,
+                        "datetime" => FieldType::Datetime,
                         _ => continue,
                     };
                     let _ = self.rt.block_on(self.client.create_field_index(
@@ -548,6 +561,15 @@ fn build_qdrant_subfilters(entries: &[serde_json::Value]) -> Vec<Condition> {
     filters
 }
 
+/// Parse an ISO-8601 / RFC 3339 datetime string into a protobuf Timestamp.
+fn parse_rfc3339_timestamp(s: &str) -> Option<Timestamp> {
+    let dt = chrono::DateTime::parse_from_rfc3339(s).ok()?;
+    Some(Timestamp {
+        seconds: dt.timestamp(),
+        nanos: dt.timestamp_subsec_nanos() as i32,
+    })
+}
+
 fn build_qdrant_filter(
     field_name: &str,
     condition_type: &str,
@@ -555,9 +577,32 @@ fn build_qdrant_filter(
 ) -> Option<Condition> {
     match condition_type {
         "match" => {
-            let value = criteria.get("value")?;
+            let criteria_obj = criteria.as_object()?;
+            // match_any: value in a list (keywords or integers).
+            if let Some(any) = criteria_obj.get("any").and_then(|v| v.as_array()) {
+                if !any.is_empty() && any.iter().all(|v| v.is_i64()) {
+                    let vals: Vec<i64> = any.iter().filter_map(|v| v.as_i64()).collect();
+                    return Some(Condition::matches(field_name.to_string(), vals));
+                }
+                let vals: Vec<String> = any
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+                return Some(Condition::matches(field_name.to_string(), vals));
+            }
+            // match_text: full-text match.
+            if let Some(text) = criteria_obj.get("text").and_then(|v| v.as_str()) {
+                return Some(Condition::matches_text(
+                    field_name.to_string(),
+                    text.to_string(),
+                ));
+            }
+            // exact match on keyword / integer / bool.
+            let value = criteria_obj.get("value")?;
             if let Some(s) = value.as_str() {
                 Some(Condition::matches(field_name.to_string(), s.to_string()))
+            } else if let Some(b) = value.as_bool() {
+                Some(Condition::matches(field_name.to_string(), b))
             } else {
                 value
                     .as_i64()
@@ -566,6 +611,27 @@ fn build_qdrant_filter(
         }
         "range" => {
             let criteria_obj = criteria.as_object()?;
+            // A string bound means an ISO-8601 datetime range rather than numeric.
+            let is_datetime = ["lt", "gt", "lte", "gte"]
+                .iter()
+                .any(|k| criteria_obj.get(*k).map(|v| v.is_string()).unwrap_or(false));
+            if is_datetime {
+                let ts = |k: &str| {
+                    criteria_obj
+                        .get(k)
+                        .and_then(|v| v.as_str())
+                        .and_then(parse_rfc3339_timestamp)
+                };
+                return Some(Condition::datetime_range(
+                    field_name.to_string(),
+                    DatetimeRange {
+                        lt: ts("lt"),
+                        gt: ts("gt"),
+                        gte: ts("gte"),
+                        lte: ts("lte"),
+                    },
+                ));
+            }
             let mut range = qdrant_client::qdrant::Range::default();
             if let Some(lt) = criteria_obj.get("lt").and_then(|v| v.as_f64()) {
                 range.lt = Some(lt);
@@ -695,6 +761,30 @@ impl Engine for QdrantEngine {
                 ..Default::default()
             });
 
+        // Prefetch (two-stage retrieval / rescoring): search_params.prefetch =
+        // { "limit": N, "params": { "hnsw_ef": .., "quantization": {..} } }.
+        // Mirrors python `models.Prefetch(**prefetch, query=query_vector)`.
+        let prefetch = params
+            .search_params
+            .as_ref()
+            .and_then(|sp| sp.extra.as_ref())
+            .and_then(|e| e.get("prefetch"));
+        let prefetch_enabled = prefetch.is_some();
+        let prefetch_limit = prefetch
+            .and_then(|p| p.get("limit"))
+            .and_then(|v| v.as_u64());
+        let prefetch_params = prefetch.and_then(|p| p.get("params"));
+        let prefetch_hnsw_ef = prefetch_params
+            .and_then(|p| p.get("hnsw_ef"))
+            .and_then(|v| v.as_u64());
+        let prefetch_quant: Option<QuantizationSearchParams> = prefetch_params
+            .and_then(|p| p.get("quantization"))
+            .map(|q| QuantizationSearchParams {
+                rescore: q.get("rescore").and_then(|v| v.as_bool()),
+                oversampling: q.get("oversampling").and_then(|v| v.as_f64()),
+                ..Default::default()
+            });
+
         let query_path = dataset.get_path()?;
         println!("\tReading queries from {}...", query_path.display());
         let (queries, neighbors, conditions) = dataset.read_queries()?;
@@ -760,28 +850,41 @@ impl Engine for QdrantEngine {
                             }
                         });
 
-                        let mut search_builder = SearchPointsBuilder::new(
-                            &collection_name,
-                            queries[idx].clone(),
-                            top as u64,
-                        )
-                        .with_payload(false);
+                        let mut query_builder = QueryPointsBuilder::new(collection_name.clone())
+                            .query(queries[idx].clone())
+                            .limit(top as u64)
+                            .with_payload(false);
 
                         if hnsw_ef.is_some() || quantization_params.is_some() {
-                            let search_params = qdrant_client::qdrant::SearchParams {
+                            query_builder = query_builder.params(QdrantSearchParams {
                                 hnsw_ef,
                                 quantization: quantization_params,
                                 ..Default::default()
-                            };
-                            search_builder = search_builder.params(search_params);
+                            });
                         }
 
                         if let Some(filter) = &parsed_filters[idx] {
-                            search_builder = search_builder.filter(filter.clone());
+                            query_builder = query_builder.filter(filter.clone());
+                        }
+
+                        if prefetch_enabled {
+                            let mut pf =
+                                PrefetchQueryBuilder::default().query(queries[idx].clone());
+                            if let Some(l) = prefetch_limit {
+                                pf = pf.limit(l);
+                            }
+                            if prefetch_hnsw_ef.is_some() || prefetch_quant.is_some() {
+                                pf = pf.params(QdrantSearchParams {
+                                    hnsw_ef: prefetch_hnsw_ef,
+                                    quantization: prefetch_quant,
+                                    ..Default::default()
+                                });
+                            }
+                            query_builder = query_builder.prefetch(vec![pf.build()]);
                         }
 
                         let query_start = Instant::now();
-                        let result = rt.block_on(client.search_points(search_builder));
+                        let result = rt.block_on(client.query(query_builder));
                         let query_time = query_start.elapsed().as_secs_f64();
 
                         search_times.lock().unwrap().push(query_time);
@@ -984,7 +1087,59 @@ fn parse_qdrant_metrics(text: &str) -> serde_json::Map<String, serde_json::Value
 
 #[cfg(test)]
 mod tests {
-    use super::parse_qdrant_metrics;
+    use super::{build_qdrant_filter, parse_qdrant_metrics, parse_rfc3339_timestamp};
+    use qdrant_client::qdrant::{condition::ConditionOneOf, FieldCondition};
+    use serde_json::json;
+
+    fn field_condition(c: &qdrant_client::qdrant::Condition) -> FieldCondition {
+        match c.condition_one_of.clone().unwrap() {
+            ConditionOneOf::Field(fc) => fc,
+            other => panic!("expected FieldCondition, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_rfc3339_timestamp() {
+        let ts = parse_rfc3339_timestamp("1970-01-01T00:00:01Z").unwrap();
+        assert_eq!(ts.seconds, 1);
+        assert!(parse_rfc3339_timestamp("not-a-date").is_none());
+    }
+
+    #[test]
+    fn builds_match_any_integers() {
+        let c = build_qdrant_filter("cat", "match", &json!({"any": [1, 2, 3]})).unwrap();
+        let fc = field_condition(&c);
+        assert_eq!(fc.key, "cat");
+        assert!(fc.r#match.is_some(), "match_any should set a Match");
+    }
+
+    #[test]
+    fn builds_match_text() {
+        let c = build_qdrant_filter("body", "match", &json!({"text": "hello"})).unwrap();
+        let fc = field_condition(&c);
+        assert_eq!(fc.key, "body");
+        assert!(fc.r#match.is_some());
+    }
+
+    #[test]
+    fn builds_bool_exact_match() {
+        let c = build_qdrant_filter("flag", "match", &json!({"value": true})).unwrap();
+        assert!(field_condition(&c).r#match.is_some());
+    }
+
+    #[test]
+    fn range_with_string_bound_becomes_datetime_range() {
+        let dt =
+            build_qdrant_filter("ts", "range", &json!({"gte": "2023-01-01T00:00:00Z"})).unwrap();
+        let fc = field_condition(&dt);
+        assert!(fc.datetime_range.is_some(), "string bound → datetime_range");
+        assert!(fc.range.is_none());
+
+        let num = build_qdrant_filter("n", "range", &json!({"gte": 5, "lt": 10})).unwrap();
+        let fc = field_condition(&num);
+        assert!(fc.range.is_some(), "numeric bounds → numeric range");
+        assert!(fc.datetime_range.is_none());
+    }
 
     #[test]
     fn parses_qdrant_memory_and_collection_gauges() {

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -55,7 +55,7 @@ fn wait_for_qdrant() {
 fn delete_collection() {
     let client = rest_client();
     let _ = client
-        .delete(&format!("{}/collections/{}", rest_url(), COLLECTION))
+        .delete(format!("{}/collections/{}", rest_url(), COLLECTION))
         .send();
 }
 

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -364,3 +364,184 @@ fn test_qdrant_payload_filter() {
 
     delete_collection();
 }
+
+// ---------------------------------------------------------------------------
+// Binary-level coverage: run the real engine end-to-end via the CLI.
+// Covers the query_points migration and prefetch (search_params.prefetch).
+// ---------------------------------------------------------------------------
+
+fn binary_path() -> std::path::PathBuf {
+    let mut path = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    path.push("vector-db-benchmark");
+    if path.exists() {
+        return path;
+    }
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/release/vector-db-benchmark")
+}
+
+/// Write a temp project (datasets + configs + results) and return its root.
+fn write_dense_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    vectors: &[Vec<f32>],
+    queries: &[Vec<f32>],
+    neighbors: &[Vec<i64>],
+    dim: usize,
+) -> std::path::PathBuf {
+    use std::fs;
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().to_path_buf();
+    std::mem::forget(tmp);
+
+    let dataset_dir = root.join("datasets").join(dataset_name);
+    fs::create_dir_all(&dataset_dir).unwrap();
+    fs::create_dir_all(root.join("experiments/configurations")).unwrap();
+    fs::create_dir_all(root.join("results")).unwrap();
+
+    let jsonl = |rows: &[Vec<f32>]| -> String {
+        rows.iter()
+            .map(|v| {
+                serde_json::to_string(&v.iter().map(|x| *x as f64).collect::<Vec<_>>()).unwrap()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    fs::write(dataset_dir.join("vectors.jsonl"), jsonl(vectors)).unwrap();
+    fs::write(dataset_dir.join("queries.jsonl"), jsonl(queries)).unwrap();
+    let nb = neighbors
+        .iter()
+        .map(|n| serde_json::to_string(n).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(dataset_dir.join("neighbours.jsonl"), nb).unwrap();
+
+    let datasets_json = serde_json::json!([{
+        "name": dataset_name, "type": "jsonl", "path": format!("{}/", dataset_name),
+        "distance": "l2", "vector_size": dim, "vector_count": vectors.len(),
+    }]);
+    fs::write(
+        root.join("datasets/datasets.json"),
+        serde_json::to_string_pretty(&datasets_json).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        root.join("experiments/configurations/test.json"),
+        engine_configs_json,
+    )
+    .unwrap();
+    root
+}
+
+fn run_qdrant_binary(root: &std::path::Path, engine: &str, dataset: &str) -> bool {
+    let out = std::process::Command::new(binary_path())
+        .args([
+            "--engines",
+            engine,
+            "--datasets",
+            dataset,
+            "--host",
+            "localhost",
+            "--skip-if-exists",
+            "false",
+        ])
+        .env("QDRANT_GRPC_PORT", QDRANT_GRPC_PORT.to_string())
+        .env("QDRANT_REST_PORT", QDRANT_REST_PORT.to_string())
+        .current_dir(root)
+        .output()
+        .expect("run vector-db-benchmark");
+    if !out.status.success() {
+        eprintln!(
+            "stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    out.status.success()
+}
+
+fn read_precision(root: &std::path::Path, engine: &str) -> f64 {
+    use std::fs;
+    let pattern = format!("{}-*-search-*.json", engine);
+    let dir = root.join("results");
+    let path = fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            glob::Pattern::new(&pattern)
+                .unwrap()
+                .matches(&p.file_name().unwrap().to_string_lossy())
+        })
+        .unwrap_or_else(|| panic!("no search result for {}", engine));
+    let v: serde_json::Value = serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
+    v["results"]["mean_precisions"].as_f64().unwrap()
+}
+
+/// End-to-end via the real engine: a plain search (covers the query_points
+/// migration) and a prefetch/two-stage search both return high-recall results.
+#[test]
+fn test_binary_qdrant_query_points_and_prefetch() {
+    wait_for_qdrant();
+
+    let dim = 8;
+    let (_ids, vectors) = generate_test_vectors(200, dim);
+    let queries: Vec<Vec<f32>> = vectors[..10].to_vec();
+    let top = 10;
+    let neighbors: Vec<Vec<i64>> = queries
+        .iter()
+        .map(|q| brute_force_neighbors_l2(q, &vectors, top))
+        .collect();
+
+    let configs = serde_json::json!([
+        {
+            "name": "qdrant-qp", "engine": "qdrant",
+            "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+            "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 128}}],
+            "upload_params": {"parallel": 1, "batch_size": 100}
+        },
+        {
+            "name": "qdrant-pf", "engine": "qdrant",
+            "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+            "search_params": [{"parallel": 1, "search_params": {
+                "hnsw_ef": 128, "prefetch": {"limit": 50, "params": {"hnsw_ef": 256}}
+            }}],
+            "upload_params": {"parallel": 1, "batch_size": 100}
+        }
+    ]);
+    let root = write_dense_project(
+        "qp-test",
+        &serde_json::to_string(&configs).unwrap(),
+        &vectors,
+        &queries,
+        &neighbors,
+        dim,
+    );
+
+    assert!(
+        run_qdrant_binary(&root, "qdrant-qp", "qp-test"),
+        "plain run failed"
+    );
+    let p_plain = read_precision(&root, "qdrant-qp");
+    assert!(
+        p_plain >= 0.9,
+        "query_points precision {:.3} < 0.9",
+        p_plain
+    );
+
+    assert!(
+        run_qdrant_binary(&root, "qdrant-pf", "qp-test"),
+        "prefetch run failed"
+    );
+    let p_pf = read_precision(&root, "qdrant-pf");
+    assert!(p_pf >= 0.9, "prefetch precision {:.3} < 0.9", p_pf);
+    println!(
+        "qdrant query_points precision={:.3}, prefetch precision={:.3}",
+        p_plain, p_pf
+    );
+}


### PR DESCRIPTION
Closes several qdrant-engine feature gaps vs the upstream `qdrant/master` Python tool (from the parity audit).

## Search — `query_points` + prefetch
- Migrate the search path from `search_points` → **`query_points`**.
- **Two-stage retrieval / rescore**: `search_params.prefetch = { "limit": N, "params": { "hnsw_ef": .., "quantization": {..} } }` → `models::Prefetch`, mirroring the Python engine. (Result parsing unchanged — `QueryResponse.result` is also `Vec<ScoredPoint>`.)

## Filters
- **`match_any`** (keywords/integers), **`match_text`** (full-text), and **bool** exact match.
- A `range` with an **ISO-8601 string bound** now builds a `DatetimeRange` (previously such bounds were silently dropped); numeric bounds keep the numeric `Range`.

## Configure
- Payload schema types **`uuid` / `bool` / `datetime`** (added to int/keyword/text/float/geo).
- Optional **on-disk (mmap) vectors** via `collection_params.vectors_config.on_disk`.

## Not ported
Per-field payload-index params (`is_tenant` / `on_disk`) — niche multi-tenant tuning; easy follow-up if a dataset needs it.

## Verification
- **Unit tests**: match_any / match_text / bool construction, numeric-vs-datetime range routing, RFC 3339 timestamp parsing.
- **End-to-end (Qdrant 1.13.4)**: plain search and a prefetch (`limit 50`, `params.hnsw_ef 256`) both keep **recall 1.0** on random-100 — confirms the `query_points` migration and prefetch path.

`cargo fmt --check`, `clippy -D warnings`, and all unit tests pass. Rebased on current `v1` (stacks cleanly on the #63 Qdrant-metrics work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)