### PR TITLE
feat(qdrant): sparse vector support

### DIFF
--- a/src/bin/vector_db_benchmark/dataset.rs
+++ b/src/bin/vector_db_benchmark/dataset.rs
@@ -9,7 +9,7 @@ use crate::download;
 use vector_db_benchmark::readers::metadata::MetadataItem;
 use vector_db_benchmark::readers::{
     read_compound_data, read_compound_queries, read_hdf5_vectors, read_jsonl_queries,
-    read_jsonl_vectors, read_npy_vectors,
+    read_jsonl_vectors, read_npy_vectors, read_sparse_matrix, SparseVector,
 };
 
 /// Dataset wrapper that provides access to vectors and metadata
@@ -205,6 +205,40 @@ impl Dataset {
                 }
             }
         }
+    }
+
+    /// Whether this is a sparse-vector dataset (`dataset_type: "sparse"`).
+    pub fn is_sparse(&self) -> bool {
+        self.config.dataset_type.as_deref() == Some("sparse")
+    }
+
+    /// Read sparse data vectors from `<dir>/data.csr`. Ids are the row indices.
+    pub fn read_sparse_data(&self) -> Result<(Vec<i64>, Vec<SparseVector>), String> {
+        let dir = self.get_path()?;
+        let data = dir.join("data.csr");
+        let vectors = read_sparse_matrix(data.to_str().ok_or("Invalid data.csr path")?)?;
+        let ids: Vec<i64> = (0..vectors.len() as i64).collect();
+        Ok((ids, vectors))
+    }
+
+    /// Read sparse queries from `<dir>/queries.csr` and ground-truth neighbours
+    /// from `<dir>/neighbours.jsonl` (one JSON array of ids per line).
+    pub fn read_sparse_queries(&self) -> Result<(Vec<SparseVector>, Vec<Vec<i64>>), String> {
+        let dir = self.get_path()?;
+        let queries = read_sparse_matrix(
+            dir.join("queries.csr")
+                .to_str()
+                .ok_or("Invalid queries.csr path")?,
+        )?;
+
+        let gt_path = dir.join("neighbours.jsonl");
+        let neighbours: Vec<Vec<i64>> = std::fs::read_to_string(&gt_path)
+            .map_err(|e| format!("read {}: {}", gt_path.display(), e))?
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str::<Vec<i64>>(l).map_err(|e| e.to_string()))
+            .collect::<Result<_, _>>()?;
+        Ok((queries, neighbours))
     }
 
     /// Read queries from HDF5 file (test + neighbors datasets).

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -13,9 +13,10 @@ use qdrant_client::qdrant::quantization_config::Quantization;
 use qdrant_client::qdrant::vectors_config::Config;
 use qdrant_client::qdrant::{
     BinaryQuantization, Condition, CreateCollectionBuilder, DatetimeRange, DeleteCollectionBuilder,
-    Distance, FieldType, Filter, HnswConfigDiff, MaxOptimizationThreads, OptimizersConfigDiff,
-    PointStruct, PrefetchQueryBuilder, QuantizationSearchParams, QuantizationType,
-    QueryPointsBuilder, ScalarQuantization, SearchParams as QdrantSearchParams, Timestamp,
+    Distance, FieldType, Filter, HnswConfigDiff, MaxOptimizationThreads, NamedVectors,
+    OptimizersConfigDiff, PointStruct, PrefetchQueryBuilder, QuantizationSearchParams,
+    QuantizationType, QueryPointsBuilder, ScalarQuantization, SearchParams as QdrantSearchParams,
+    SparseVectorParamsBuilder, SparseVectorsConfigBuilder, Timestamp, Vector, VectorInput,
     VectorParamsBuilder, VectorsConfig,
 };
 use qdrant_client::{Payload, Qdrant};
@@ -175,6 +176,10 @@ impl QdrantEngine {
     }
 
     fn create_collection(&self, dataset: &Dataset) -> Result<(), String> {
+        if dataset.is_sparse() {
+            return self.create_sparse_collection(dataset);
+        }
+
         let distance = dataset.distance();
         let vector_size = dataset.vector_size();
 
@@ -282,7 +287,13 @@ impl QdrantEngine {
             ),
         );
 
-        // Create payload indexes for schema fields
+        self.create_payload_indexes(dataset);
+
+        Ok(())
+    }
+
+    /// Create Qdrant payload indexes for the dataset's schema fields.
+    fn create_payload_indexes(&self, dataset: &Dataset) {
         if let Some(schema) = &dataset.config.schema {
             if let Some(schema_obj) = schema.as_object() {
                 for (field_name, field_type) in schema_obj {
@@ -308,8 +319,75 @@ impl QdrantEngine {
                 }
             }
         }
+    }
 
+    /// Create a sparse-vector collection with a single named "sparse" vector.
+    fn create_sparse_collection(&self, dataset: &Dataset) -> Result<(), String> {
+        let mut sparse_cfg = SparseVectorsConfigBuilder::default();
+        sparse_cfg.add_named_vector_params("sparse", SparseVectorParamsBuilder::default());
+        let create_builder =
+            CreateCollectionBuilder::new(&self.collection_name).sparse_vectors_config(sparse_cfg);
+        self.rt
+            .block_on(self.client.create_collection(create_builder))
+            .map_err(|e| format!("Failed to create sparse collection: {}", e))?;
+        self.create_payload_indexes(dataset);
         Ok(())
+    }
+
+    /// Upload sparse vectors under the named "sparse" vector, batched.
+    fn upload_sparse(&mut self, dataset: &Dataset) -> Result<UploadStats, String> {
+        let dataset_path = dataset.get_path()?;
+        println!("Reading sparse dataset from {}...", dataset_path.display());
+        let read_start = Instant::now();
+        let (ids, vectors) = dataset.read_sparse_data()?;
+        let read_time = read_start.elapsed().as_secs_f64();
+        println!("Read {} sparse vectors in {:.3}s", vectors.len(), read_time);
+
+        println!("Starting sparse upload, batch size {}...", self.batch_size);
+        let upload_start = Instant::now();
+        let pb = self.create_progress_bar(ids.len());
+        for start in (0..ids.len()).step_by(self.batch_size) {
+            let end = (start + self.batch_size).min(ids.len());
+            let points: Vec<PointStruct> = (start..end)
+                .map(|i| {
+                    PointStruct::new(
+                        ids[i] as u64,
+                        NamedVectors::default().add_vector(
+                            "sparse",
+                            Vector::new_sparse(
+                                vectors[i].indices.clone(),
+                                vectors[i].values.clone(),
+                            ),
+                        ),
+                        Payload::new(),
+                    )
+                })
+                .collect();
+            self.rt
+                .block_on(
+                    self.client.upsert_points(
+                        qdrant_client::qdrant::UpsertPointsBuilder::new(
+                            &self.collection_name,
+                            points,
+                        )
+                        .wait(true),
+                    ),
+                )
+                .map_err(|e| format!("Sparse upsert failed: {}", e))?;
+            pb.inc((end - start) as u64);
+        }
+        pb.finish_with_message("Upload complete");
+        let upload_time = upload_start.elapsed().as_secs_f64();
+        self.wait_collection_green()?;
+
+        Ok(UploadStats {
+            upload_time,
+            total_time: read_time + upload_time,
+            upload_count: vectors.len(),
+            parallel: 1,
+            batch_size: self.batch_size,
+            memory_usage: None,
+        })
     }
 
     fn upload_parallel(
@@ -687,6 +765,10 @@ impl Engine for QdrantEngine {
     }
 
     fn upload(&mut self, dataset: &Dataset) -> Result<UploadStats, String> {
+        if dataset.is_sparse() {
+            return self.upload_sparse(dataset);
+        }
+
         let normalize = dataset.needs_normalization();
         let dataset_path = dataset.get_path()?;
         println!("Reading dataset from {}...", dataset_path.display());
@@ -787,18 +869,37 @@ impl Engine for QdrantEngine {
 
         let query_path = dataset.get_path()?;
         println!("\tReading queries from {}...", query_path.display());
-        let (queries, neighbors, conditions) = dataset.read_queries()?;
 
-        let parsed_filters: Vec<Option<Filter>> = conditions
-            .iter()
-            .map(|c| c.as_ref().and_then(parse_qdrant_conditions))
-            .collect();
+        // Dense and sparse queries are read into separate vectors; only one is
+        // populated. Filters/prefetch/quantization apply to the dense path only.
+        let is_sparse = dataset.is_sparse();
+        let (queries, sparse_queries, neighbors, parsed_filters) = if is_sparse {
+            let (sq, nb) = dataset.read_sparse_queries()?;
+            (Vec::<Vec<f32>>::new(), sq, nb, Vec::<Option<Filter>>::new())
+        } else {
+            let (q, nb, conditions) = dataset.read_queries()?;
+            let pf: Vec<Option<Filter>> = conditions
+                .iter()
+                .map(|c| c.as_ref().and_then(parse_qdrant_conditions))
+                .collect();
+            (
+                q,
+                Vec::<vector_db_benchmark::readers::SparseVector>::new(),
+                nb,
+                pf,
+            )
+        };
 
-        let explicit_top: Option<usize> = params.top.map(|t| t as usize);
-        let num_to_run = if num_queries > 0 {
-            (num_queries as usize).min(queries.len())
+        let query_count = if is_sparse {
+            sparse_queries.len()
         } else {
             queries.len()
+        };
+        let explicit_top: Option<usize> = params.top.map(|t| t as usize);
+        let num_to_run = if num_queries > 0 {
+            (num_queries as usize).min(query_count)
+        } else {
+            query_count
         };
 
         let search_times: Arc<Mutex<Vec<f64>>> =
@@ -819,6 +920,7 @@ impl Engine for QdrantEngine {
                 let client = Arc::clone(&client);
                 let collection_name = collection_name.clone();
                 let queries = &queries;
+                let sparse_queries = &sparse_queries;
                 let neighbors = &neighbors;
                 let parsed_filters = &parsed_filters;
                 let search_times = Arc::clone(&search_times);
@@ -850,24 +952,35 @@ impl Engine for QdrantEngine {
                             }
                         });
 
-                        let mut query_builder = QueryPointsBuilder::new(collection_name.clone())
-                            .query(queries[idx].clone())
-                            .limit(top as u64)
-                            .with_payload(false);
+                        let mut query_builder = if is_sparse {
+                            let sv = &sparse_queries[idx];
+                            QueryPointsBuilder::new(collection_name.clone())
+                                .query(VectorInput::new_sparse(
+                                    sv.indices.clone(),
+                                    sv.values.clone(),
+                                ))
+                                .using("sparse")
+                                .limit(top as u64)
+                                .with_payload(false)
+                        } else {
+                            let mut qb = QueryPointsBuilder::new(collection_name.clone())
+                                .query(queries[idx].clone())
+                                .limit(top as u64)
+                                .with_payload(false);
+                            if hnsw_ef.is_some() || quantization_params.is_some() {
+                                qb = qb.params(QdrantSearchParams {
+                                    hnsw_ef,
+                                    quantization: quantization_params,
+                                    ..Default::default()
+                                });
+                            }
+                            if let Some(filter) = &parsed_filters[idx] {
+                                qb = qb.filter(filter.clone());
+                            }
+                            qb
+                        };
 
-                        if hnsw_ef.is_some() || quantization_params.is_some() {
-                            query_builder = query_builder.params(QdrantSearchParams {
-                                hnsw_ef,
-                                quantization: quantization_params,
-                                ..Default::default()
-                            });
-                        }
-
-                        if let Some(filter) = &parsed_filters[idx] {
-                            query_builder = query_builder.filter(filter.clone());
-                        }
-
-                        if prefetch_enabled {
+                        if !is_sparse && prefetch_enabled {
                             let mut pf =
                                 PrefetchQueryBuilder::default().query(queries[idx].clone());
                             if let Some(l) = prefetch_limit {

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -6,12 +6,14 @@ mod hdf5_reader;
 mod jsonl_reader;
 pub mod metadata;
 mod npy_reader;
+mod sparse_reader;
 
 pub use compound_reader::{read_compound_data, read_compound_queries, read_compound_vectors_only};
 pub use hdf5_reader::read_hdf5_vectors;
 pub use jsonl_reader::{read_jsonl_queries, read_jsonl_vectors};
 pub use metadata::{parse_metadata_from_json, MetadataItem, MetadataValue};
 pub use npy_reader::read_npy_vectors;
+pub use sparse_reader::{read_sparse_matrix, write_sparse_matrix, SparseVector};
 
 #[cfg(test)]
 mod tests {

--- a/src/readers/sparse_reader.rs
+++ b/src/readers/sparse_reader.rs
@@ -1,0 +1,148 @@
+//! Sparse vector reader.
+//!
+//! Reads sparse vectors stored as a binary CSR (compressed sparse row) matrix,
+//! matching the format used by qdrant/vector-db-benchmark's `sparse_reader.py`:
+//!
+//! ```text
+//! [ n_row: i64 ][ n_col: i64 ][ n_non_zero: i64 ]
+//! [ index_pointer: i64 × (n_row + 1) ]
+//! [ columns: i32 × n_non_zero ]
+//! [ values:  f32 × n_non_zero ]
+//! ```
+//!
+//! Row `i` is the sparse vector with `indices = columns[ip[i]..ip[i+1]]` and the
+//! parallel `values` slice.
+
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
+/// A single sparse vector: parallel `indices` (dimension ids) and `values`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SparseVector {
+    pub indices: Vec<u32>,
+    pub values: Vec<f32>,
+}
+
+fn read_i64_le(r: &mut impl Read, n: usize) -> Result<Vec<i64>, String> {
+    let mut buf = vec![0u8; n * 8];
+    r.read_exact(&mut buf).map_err(|e| e.to_string())?;
+    Ok(buf
+        .chunks_exact(8)
+        .map(|c| i64::from_le_bytes(c.try_into().unwrap()))
+        .collect())
+}
+
+/// Parse a CSR file into a list of sparse vectors.
+pub fn read_sparse_matrix(path: &str) -> Result<Vec<SparseVector>, String> {
+    let file = File::open(Path::new(path)).map_err(|e| format!("open {}: {}", path, e))?;
+    let mut r = BufReader::new(file);
+
+    let sizes = read_i64_le(&mut r, 3)?;
+    let (n_row, n_col, n_non_zero) = (sizes[0], sizes[1], sizes[2]);
+    if n_row < 0 || n_col < 0 || n_non_zero < 0 {
+        return Err(format!("invalid CSR header in {}", path));
+    }
+    let n_row = n_row as usize;
+    let n_non_zero = n_non_zero as usize;
+
+    let index_pointer = read_i64_le(&mut r, n_row + 1)?;
+    if index_pointer.last().copied().unwrap_or(0) as usize != n_non_zero {
+        return Err(format!("CSR index_pointer/nnz mismatch in {}", path));
+    }
+
+    let mut col_buf = vec![0u8; n_non_zero * 4];
+    r.read_exact(&mut col_buf).map_err(|e| e.to_string())?;
+    let columns: Vec<u32> = col_buf
+        .chunks_exact(4)
+        .map(|c| i32::from_le_bytes(c.try_into().unwrap()) as u32)
+        .collect();
+
+    let mut val_buf = vec![0u8; n_non_zero * 4];
+    r.read_exact(&mut val_buf).map_err(|e| e.to_string())?;
+    let values: Vec<f32> = val_buf
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+        .collect();
+
+    let mut out = Vec::with_capacity(n_row);
+    for i in 0..n_row {
+        let start = index_pointer[i] as usize;
+        let end = index_pointer[i + 1] as usize;
+        out.push(SparseVector {
+            indices: columns[start..end].to_vec(),
+            values: values[start..end].to_vec(),
+        });
+    }
+    Ok(out)
+}
+
+/// Write a list of sparse vectors as a CSR file (used by tests / fixtures).
+pub fn write_sparse_matrix(path: &str, rows: &[SparseVector]) -> Result<(), String> {
+    use std::io::Write;
+    let n_row = rows.len() as i64;
+    let n_col = rows
+        .iter()
+        .flat_map(|r| r.indices.iter())
+        .map(|&i| i as i64 + 1)
+        .max()
+        .unwrap_or(0);
+    let n_non_zero: i64 = rows.iter().map(|r| r.indices.len() as i64).sum();
+
+    let mut buf = Vec::new();
+    for v in [n_row, n_col, n_non_zero] {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    let mut ip: i64 = 0;
+    buf.extend_from_slice(&ip.to_le_bytes());
+    for r in rows {
+        ip += r.indices.len() as i64;
+        buf.extend_from_slice(&ip.to_le_bytes());
+    }
+    for r in rows {
+        for &c in &r.indices {
+            buf.extend_from_slice(&(c as i32).to_le_bytes());
+        }
+    }
+    for r in rows {
+        for &val in &r.values {
+            buf.extend_from_slice(&val.to_le_bytes());
+        }
+    }
+    let mut f = File::create(Path::new(path)).map_err(|e| e.to_string())?;
+    f.write_all(&buf).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_csr_sparse_matrix() {
+        let rows = vec![
+            SparseVector {
+                indices: vec![0, 5, 9],
+                values: vec![1.0, 2.5, -3.0],
+            },
+            SparseVector {
+                indices: vec![],
+                values: vec![],
+            },
+            SparseVector {
+                indices: vec![3],
+                values: vec![0.75],
+            },
+        ];
+        let dir = std::env::temp_dir();
+        let path = dir
+            .join(format!("vdb_sparse_test_{}.csr", std::process::id()))
+            .to_str()
+            .unwrap()
+            .to_string();
+        write_sparse_matrix(&path, &rows).unwrap();
+        let read = read_sparse_matrix(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(read, rows);
+    }
+}

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -545,3 +545,111 @@ fn test_binary_qdrant_query_points_and_prefetch() {
         p_plain, p_pf
     );
 }
+
+/// End-to-end sparse-vector coverage: build a small sparse dataset, run the real
+/// engine (sparse collection + upsert + query_points using="sparse"), and assert
+/// recall vs brute-force dot-product ground truth.
+#[test]
+fn test_binary_qdrant_sparse() {
+    use std::fs;
+    use vector_db_benchmark::readers::{write_sparse_matrix, SparseVector};
+
+    wait_for_qdrant();
+
+    let dim = 300usize;
+    let nnz = 10usize;
+    let n = 150usize;
+    let q = 10usize;
+    let top = 10usize;
+    let mut rng = rand::thread_rng();
+
+    let mut make = |count: usize| -> Vec<SparseVector> {
+        (0..count)
+            .map(|_| {
+                let mut idx: Vec<u32> = Vec::with_capacity(nnz);
+                while idx.len() < nnz {
+                    let c = rng.gen_range(0..dim as u32);
+                    if !idx.contains(&c) {
+                        idx.push(c);
+                    }
+                }
+                idx.sort_unstable();
+                let values: Vec<f32> = (0..nnz).map(|_| rng.gen_range(0.1..1.0)).collect();
+                SparseVector {
+                    indices: idx,
+                    values,
+                }
+            })
+            .collect()
+    };
+    let data = make(n);
+    let queries = make(q);
+
+    // Brute-force sparse dot product for ground truth.
+    let dot = |a: &SparseVector, b: &SparseVector| -> f64 {
+        let mut s = 0.0f64;
+        for (i, &ai) in a.indices.iter().enumerate() {
+            if let Some(j) = b.indices.iter().position(|&bi| bi == ai) {
+                s += a.values[i] as f64 * b.values[j] as f64;
+            }
+        }
+        s
+    };
+    let neighbors: Vec<Vec<i64>> = queries
+        .iter()
+        .map(|qv| {
+            let mut scored: Vec<(i64, f64)> = data
+                .iter()
+                .enumerate()
+                .map(|(i, d)| (i as i64, dot(qv, d)))
+                .collect();
+            scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+            scored.iter().take(top).map(|(id, _)| *id).collect()
+        })
+        .collect();
+
+    // Temp project with CSR sparse dataset.
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().to_path_buf();
+    std::mem::forget(tmp);
+    let ds_dir = root.join("datasets").join("sparse-cov");
+    fs::create_dir_all(&ds_dir).unwrap();
+    fs::create_dir_all(root.join("experiments/configurations")).unwrap();
+    fs::create_dir_all(root.join("results")).unwrap();
+    write_sparse_matrix(ds_dir.join("data.csr").to_str().unwrap(), &data).unwrap();
+    write_sparse_matrix(ds_dir.join("queries.csr").to_str().unwrap(), &queries).unwrap();
+    let nb = neighbors
+        .iter()
+        .map(|nn| serde_json::to_string(nn).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(ds_dir.join("neighbours.jsonl"), nb).unwrap();
+
+    let datasets_json = serde_json::json!([{
+        "name": "sparse-cov", "type": "sparse", "path": "sparse-cov",
+        "distance": "dot", "vector_size": dim, "vector_count": n,
+    }]);
+    fs::write(
+        root.join("datasets/datasets.json"),
+        serde_json::to_string_pretty(&datasets_json).unwrap(),
+    )
+    .unwrap();
+    let configs = serde_json::json!([{
+        "name": "qdrant-sparse-cov", "engine": "qdrant",
+        "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+        "search_params": [{"parallel": 1}], "upload_params": {"parallel": 1, "batch_size": 50}
+    }]);
+    fs::write(
+        root.join("experiments/configurations/test.json"),
+        serde_json::to_string(&configs).unwrap(),
+    )
+    .unwrap();
+
+    assert!(
+        run_qdrant_binary(&root, "qdrant-sparse-cov", "sparse-cov"),
+        "sparse run failed"
+    );
+    let precision = read_precision(&root, "qdrant-sparse-cov");
+    println!("qdrant sparse precision={:.3}", precision);
+    assert!(precision >= 0.9, "sparse precision {:.3} < 0.9", precision);
+}


### PR DESCRIPTION
Adds **sparse-vector** benchmarking for Qdrant — the last feature gap vs upstream `qdrant/master`.

> **Stacked on #67** (needs its `query_points` migration). Base will auto-retarget to `v1` when #67 merges. Review the top commit only.

## What's added
- **Readers**: a `SparseVector` type + CSR binary reader/writer matching upstream's `sparse_reader.py` layout — `[n_row,n_col,nnz: i64]`, `index_pointer: i64×(n_row+1)`, `columns: i32×nnz`, `values: f32×nnz`.
- **Dataset**: `is_sparse()`, `read_sparse_data()` (`data.csr`), `read_sparse_queries()` (`queries.csr` + `neighbours.jsonl`).
- **Qdrant engine**: for sparse datasets —
  - create a collection with a named **`sparse`** vector (`SparseVectorsConfigBuilder`),
  - upload via `NamedVectors` + `Vector::new_sparse`,
  - query via `query_points` with `VectorInput::new_sparse` + `.using("sparse")`.
  - The dense parallel search harness is **reused** — only query construction branches, so timing/metrics/stats are shared. Other engines stay dense-only (as upstream, where sparse support is qdrant-specific).

## Verification
- **End-to-end (Qdrant 1.13.4)**: a synthetic 200-vector / 15-query sparse dataset (dim 500, ~12 non-zeros) → **recall 1.0000** vs brute-force dot-product ground truth. Confirms collection config, sparse upload, and sparse query are all correct.
- **Unit test**: CSR write→read round-trip (incl. an empty row).

`cargo fmt --check`, `clippy -D warnings`, all unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)