### PR TITLE
chore(docker): bump test images to latest stable

### DIFF
--- a/tests/docker-compose.ci-test.yml
+++ b/tests/docker-compose.ci-test.yml
@@ -10,7 +10,7 @@
 
 services:
   redis:
-    image: redis:8.6.0
+    image: redis:8.8.0
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 1s

--- a/tests/docker-compose.docker-test.yml
+++ b/tests/docker-compose.docker-test.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:8.6.0
+    image: redis:8.8.0
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 1s

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:8.6.0
+    image: redis:8.8.0
     ports:
       - "6399:6379"
     healthcheck:
@@ -10,7 +10,7 @@ services:
       retries: 10
 
   pgvector:
-    image: pgvector/pgvector:pg16
+    image: pgvector/pgvector:pg18
     environment:
       POSTGRES_PASSWORD: "passwd"
     ports:
@@ -22,7 +22,7 @@ services:
       retries: 15
 
   qdrant:
-    image: qdrant/qdrant:v1.13.4
+    image: qdrant/qdrant:v1.18.2
     ports:
       - "6334:6333"
       - "6335:6334"
@@ -35,7 +35,7 @@ services:
       retries: 15
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.4.3
     environment:
       ELASTIC_PASSWORD: "passwd"
       discovery.type: "single-node"
@@ -53,7 +53,7 @@ services:
           memory: 2Gb
 
   weaviate:
-    image: semitechnologies/weaviate:1.28.9
+    image: semitechnologies/weaviate:1.38.2
     environment:
       QUERY_DEFAULTS_LIMIT: "100"
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"
@@ -71,7 +71,7 @@ services:
       retries: 15
 
   milvus-etcd:
-    image: quay.io/coreos/etcd:v3.5.18
+    image: quay.io/coreos/etcd:v3.6.13
     environment:
       ETCD_AUTO_COMPACTION_MODE: "revision"
       ETCD_AUTO_COMPACTION_RETENTION: "1000"
@@ -85,7 +85,7 @@ services:
       retries: 10
 
   milvus-minio:
-    image: minio/minio:RELEASE.2024-09-13T20-26-02Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
       MINIO_ACCESS_KEY: "minioadmin"
       MINIO_SECRET_KEY: "minioadmin"
@@ -97,7 +97,7 @@ services:
       retries: 10
 
   milvus:
-    image: milvusdb/milvus:v2.5.6
+    image: milvusdb/milvus:v2.6.19
     environment:
       ETCD_ENDPOINTS: "milvus-etcd:2379"
       MINIO_ADDRESS: "milvus-minio:9000"
@@ -120,7 +120,7 @@ services:
           memory: 4Gb
 
   opensearch:
-    image: opensearchproject/opensearch:2.19.2
+    image: opensearchproject/opensearch:3.7.0
     environment:
       discovery.type: "single-node"
       # DISABLE_SECURITY_PLUGIN skips the security demo installer entirely; the
@@ -141,7 +141,7 @@ services:
           memory: 2Gb
 
   mongodb-search:
-    image: mongodb/mongodb-atlas-local:8.0.4
+    image: mongodb/mongodb-atlas-local:8.0.17
     ports:
       - "27018:27017"
     healthcheck:


### PR DESCRIPTION
Updates all pinned integration-test container images to latest stable.

| Image | From | To |
|---|---|---|
| redis | 8.6.0 | **8.8.0** |
| qdrant | v1.13.4 | **v1.18.2** |
| weaviate | 1.28.9 | **1.38.2** |
| pgvector | pg16 | **pg18** |
| elasticsearch | 8.10.2 | **9.4.3** |
| opensearch | 2.19.2 | **3.7.0** |
| milvus | v2.5.6 | **v2.6.19** |
| milvus etcd | v3.5.18 | **v3.6.13** |
| milvus minio | 2024-09-13 | **2025-09-07** |
| mongodb-atlas-local | 8.0.4 | **8.0.17** |
| valkey | latest | latest (unchanged) |

Also bumps redis in `docker-compose.ci-test.yml` / `docker-compose.docker-test.yml`.

**Several are major-version jumps** (ES 8→9, OpenSearch 2→3, milvus 2.5→2.6, pgvector pg16→pg18). OpenSearch 3.7.0 verified locally — all 6 integration tests pass and the security-disable startup still works. The rest are validated by CI's per-engine integration jobs; I'll fall back any engine that a major bump breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)