### PR TITLE
fix(elasticsearch): trim search response (_source: false)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -625,9 +625,14 @@ fn knn_search(
             .insert("filter".to_string(), f.clone());
     }
 
+    // Response trimming: the benchmark only needs each hit's id (always returned
+    // as `_id` metadata) and score, so don't ship the document `_source`. This
+    // trims the response for a fairer QPS/latency measurement — matching the
+    // OpenSearch engine's trimming.
     let body = serde_json::json!({
         "knn": knn,
         "size": top,
+        "_source": false,
     });
 
     let resp = rt


### PR DESCRIPTION
Elasticsearch returned the full document `_source` on every hit while every other engine returns only ids — inflating ES latency / depressing ES QPS on **all** runs (a systematic unfairness flagged in the v1 review). Set `_source: false` so responses carry only `id` + `score`; `_id` is always returned as metadata so parsing is unchanged. Mirrors the OpenSearch trimming from #66.

CI's Elasticsearch integration job validates recall is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)