### PR TITLE
perf(engines): fix cross-engine timing fairness in the parallel harness

### DIFF
--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -260,7 +260,10 @@ impl ElasticsearchEngine {
                 let pb = &pb;
 
                 s.spawn(move || {
-                    let rt = match tokio::runtime::Runtime::new() {
+                    let rt = match tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                    {
                         Ok(rt) => rt,
                         Err(e) => {
                             *error.lock().unwrap() = Some(e.to_string());
@@ -799,7 +802,10 @@ impl Engine for ElasticsearchEngine {
                 let pb = &pb;
 
                 s.spawn(move || {
-                    let rt = match tokio::runtime::Runtime::new() {
+                    let rt = match tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                    {
                         Ok(rt) => rt,
                         Err(_) => return,
                     };

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -263,7 +263,10 @@ impl OpenSearchEngine {
                 let pb = &pb;
 
                 s.spawn(move || {
-                    let rt = match tokio::runtime::Runtime::new() {
+                    let rt = match tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                    {
                         Ok(rt) => rt,
                         Err(e) => {
                             *error.lock().unwrap() = Some(e.to_string());
@@ -897,7 +900,10 @@ impl Engine for OpenSearchEngine {
                 let pb = &pb;
 
                 s.spawn(move || {
-                    let rt = match tokio::runtime::Runtime::new() {
+                    let rt = match tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                    {
                         Ok(rt) => rt,
                         Err(_) => return,
                     };

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -420,7 +420,7 @@ impl QdrantEngine {
                 let pb = &pb;
 
                 s.spawn(move || {
-                    let rt = match tokio::runtime::Runtime::new() {
+                    let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
                         Ok(rt) => rt,
                         Err(e) => {
                             *error.lock().unwrap() = Some(e.to_string());
@@ -912,12 +912,17 @@ impl Engine for QdrantEngine {
 
         let pb = self.create_progress_bar(num_to_run);
         let start_time = Instant::now();
-        let client = Arc::clone(&self.client);
+        // Each worker builds its own client/connection (like ES/OpenSearch) rather
+        // than sharing one gRPC connection, which would serialize parallel queries.
+        let grpc_url = self.grpc_url.clone();
+        let api_key = self.api_key.clone();
+        let timeout = self.timeout;
         let collection_name = self.collection_name.clone();
 
         std::thread::scope(|s| {
             for _ in 0..parallel {
-                let client = Arc::clone(&client);
+                let grpc_url = grpc_url.clone();
+                let api_key = api_key.clone();
                 let collection_name = collection_name.clone();
                 let queries = &queries;
                 let sparse_queries = &sparse_queries;
@@ -932,9 +937,28 @@ impl Engine for QdrantEngine {
                 let pb = &pb;
 
                 s.spawn(move || {
-                    let rt = match tokio::runtime::Runtime::new() {
+                    let rt = match tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                    {
                         Ok(rt) => rt,
                         Err(_) => return,
+                    };
+
+                    // Per-worker client so each thread has an independent connection.
+                    let client = match rt.block_on(async {
+                        let mut b = Qdrant::from_url(&grpc_url)
+                            .timeout(std::time::Duration::from_secs(timeout));
+                        if let Some(k) = &api_key {
+                            b = b.api_key(k.clone());
+                        }
+                        b.build()
+                    }) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            eprintln!("Qdrant worker client build failed: {}", e);
+                            return;
+                        }
                     };
 
                     loop {

--- a/src/bin/vector_db_benchmark/engine/turbopuffer.rs
+++ b/src/bin/vector_db_benchmark/engine/turbopuffer.rs
@@ -401,7 +401,10 @@ impl Engine for TurbopufferEngine {
                     let pb = pb.clone();
 
                     s.spawn(move |_| {
-                        let rt = tokio::runtime::Runtime::new().unwrap();
+                        let rt = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .unwrap();
                         if let Err(e) = Self::upload_batch(
                             &client, &namespace, batch_ids, batch_vecs, batch_meta, &rt,
                         ) {
@@ -545,7 +548,10 @@ impl Engine for TurbopufferEngine {
                     let pb = &pb;
 
                     s.spawn(move |_| {
-                        let rt = tokio::runtime::Runtime::new().unwrap();
+                        let rt = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .unwrap();
                         let start = Instant::now();
                         let results = single_query(
                             &client,


### PR DESCRIPTION
Two client-side distortions from the v1 review that biased QPS/latency **between** engines.

## 1. Per-worker runtimes were multi-threaded → CPU oversubscription
A `parallel=N` search built `N` **multi-threaded** tokio runtimes (one per worker), each spawning ~`ncpu` threads → `N×ncpu` client threads for the async engines (ES, OpenSearch, Qdrant, Turbopuffer). That oversubscription depressed *those* engines' measured QPS. Each worker only does serial `block_on`, so the per-worker runtimes are now `Builder::new_current_thread()`.

⚠️ The **struct-level** runtime that drives the shared client for uploads stays multi-threaded on purpose — a current-thread runtime there would starve the connection task and hang upload.

## 2. Qdrant shared one gRPC connection across all parallel workers
Qdrant search cloned a single `Arc<Qdrant>` (one HTTP/2 connection) into every worker, serializing "parallel N" queries — a structural handicap the other engines (N independent connections) don't have. Each Qdrant search worker now **builds its own client**, mirroring ES/OpenSearch.

## Verification
CI's per-engine integration jobs (Qdrant, Elasticsearch, OpenSearch) validate that recall/behavior are unchanged. Not run locally per the resourcing constraint.

Follow-up (not here): Turbopuffer still spawns a rayon task **per query** (per-query runtime) — a larger rewrite to the N-worker model, and it's cloud-only/untestable locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)