### PR TITLE
feat(valkey): match_any filter (keyword/int IN-list)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -830,11 +830,86 @@ fn build_filter(
     counter: &mut usize,
 ) -> Option<ParsedFilter> {
     match condition_type {
-        "match" => build_exact_match_filter(field_name, criteria, counter),
+        "match" => {
+            // match_any (IN-list) takes precedence over exact {value}.
+            if let Some(any) = criteria.get("any").and_then(|v| v.as_array()) {
+                Some(build_match_any_filter(field_name, any, counter))
+            } else {
+                build_exact_match_filter(field_name, criteria, counter)
+            }
+        }
         "range" => build_range_filter(field_name, criteria, counter),
         "geo" => build_geo_filter(field_name, criteria, counter),
         _ => None,
     }
+}
+
+/// Escape the TAG-structural characters when inlining a value into a `{…}`
+/// clause (Valkey Search does not accept `$param` refs inside TAG brackets, so
+/// values are inlined). Only the characters that would otherwise break the OR
+/// (`|`) or the braces are escaped; other characters are passed raw, matching
+/// the exact-match path.
+fn escape_tag_value(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('|', "\\|")
+        .replace('{', "\\{")
+        .replace('}', "\\}")
+}
+
+/// Build a `match_any` (IN-list) filter, the OR-of-values semantics that mirror
+/// qdrant's `Condition::matches(field, Vec)`.
+///
+/// - All-integer list -> NUMERIC OR `(@f:[$a $a] | @f:[$b $b])` (params).
+/// - Otherwise -> TAG OR `@f:{a | b}` over the non-empty string values, inlined
+///   (Valkey Search rejects `$param` inside TAG `{…}`). Empty-string tokens are
+///   dropped (invalid TAG syntax).
+/// - Empty / no representable values -> a never-match `(@f:{s} -@f:{s})`
+///   contradiction so an empty IN-set matches NOTHING rather than being dropped
+///   (which, as the sole clause, would run kNN over ALL docs). Assumes a TAG
+///   field, the realistic case for a keyword IN-list.
+///
+/// NOTE: Valkey Search TAG matching is case-INSENSITIVE, whereas qdrant keyword
+/// match is case-sensitive; all shipped keyword datasets use consistent casing.
+fn build_match_any_filter(
+    field_name: &str,
+    any: &[serde_json::Value],
+    counter: &mut usize,
+) -> ParsedFilter {
+    let mut params = HashMap::new();
+
+    if !any.is_empty() && any.iter().all(|v| v.is_i64()) {
+        let clauses: Vec<String> = any
+            .iter()
+            .filter_map(|v| v.as_i64())
+            .map(|i| {
+                let p = format!("{}_{}", field_name, counter);
+                *counter += 1;
+                params.insert(p.clone(), FilterParamValue::Int(i));
+                format!("@{}:[${} ${}]", field_name, p, p)
+            })
+            .collect();
+        return (format!("({})", clauses.join(" | ")), params);
+    }
+
+    let tokens: Vec<String> = any
+        .iter()
+        .filter_map(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(escape_tag_value)
+        .collect();
+
+    if tokens.is_empty() {
+        let never = "__match_any_never_match__";
+        return (
+            format!("(@{0}:{{{1}}} -@{0}:{{{1}}})", field_name, never),
+            params,
+        );
+    }
+
+    (
+        format!("@{}:{{{}}}", field_name, tokens.join(" | ")),
+        params,
+    )
 }
 
 fn build_exact_match_filter(
@@ -1765,5 +1840,52 @@ impl Engine for ValkeyEngine {
             "used_memory": [used_memory],
             "index_info": ft_info,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_conditions, FilterParamValue};
+
+    #[test]
+    fn match_any_string_list_emits_inlined_tag_or() {
+        let cond = serde_json::json!({"and":[{"color":{"match":{"any":["red","blue"]}}}]});
+        let (q, _params) = parse_conditions(&cond).unwrap();
+        // Values inlined (no $param inside TAG braces on Valkey Search).
+        assert!(q.contains("@color:{red | blue}"), "q={}", q);
+    }
+
+    #[test]
+    fn match_any_int_list_emits_numeric_or() {
+        let cond = serde_json::json!({"and":[{"size":{"match":{"any":[1,2]}}}]});
+        let (q, params) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@size:[$size_0 $size_0]"), "q={}", q);
+        assert!(q.contains("@size:[$size_1 $size_1]"), "q={}", q);
+        assert!(matches!(
+            params.get("size_0"),
+            Some(FilterParamValue::Int(1))
+        ));
+    }
+
+    #[test]
+    fn match_any_empty_list_matches_nothing() {
+        let cond = serde_json::json!({"and":[{"color":{"match":{"any":[]}}}]});
+        let (q, _) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("-@color:{"), "expected never-match, q={}", q);
+    }
+
+    #[test]
+    fn match_any_escapes_or_delimiter() {
+        // A value containing '|' must not break the OR structure.
+        let cond = serde_json::json!({"and":[{"color":{"match":{"any":["a|b"]}}}]});
+        let (q, _) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("a\\|b"), "q={}", q);
+    }
+
+    #[test]
+    fn match_exact_value_still_inlined_tag() {
+        let cond = serde_json::json!({"and":[{"color":{"match":{"value":"red"}}}]});
+        let (q, _) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@color:{red}"), "q={}", q);
     }
 }

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 use rand::Rng;
 use redis::Connection;
 
+mod common;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1107,4 +1109,45 @@ fn test_valkey_sub_batched_pipeline_upload_high_dim() {
         .arg("idx")
         .query(&mut conn)
         .unwrap();
+}
+
+/// End-to-end `match_any`: filter a keyword (TAG) field to an OR-set and assert
+/// the engine returns the filtered nearest neighbours (recall vs ground truth
+/// brute-forced over only the matching docs). Proves the inlined TAG-OR arm.
+#[test]
+fn test_binary_valkey_match_any() {
+    wait_for_valkey();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "valkey-ma", "engine": "valkey",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "match-any-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(
+        proj.matching_docs >= proj.top,
+        "fixture must have >= top matching docs (got {})",
+        proj.matching_docs
+    );
+
+    let port = test_port().to_string();
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "valkey-ma",
+            "match-any-test",
+            "127.0.0.1",
+            &[("VALKEY_PORT", port.as_str())],
+        ),
+        "valkey match_any run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, "valkey-ma");
+    println!("valkey match_any recall={:.3}", recall);
+    assert!(recall >= 0.9, "valkey match_any recall {:.3} < 0.9", recall);
 }


### PR DESCRIPTION
## What
Implements `match_any` for **Valkey** (Valkey Search) — per-engine rollout on top of harness #77.

- all-int list → NUMERIC OR `(@f:[$a $a] | @f:[$b $b])`
- else → TAG OR `@f:{a | b}` over non-empty string values, **inlined** (Valkey Search rejects `$param` inside TAG `{…}`); TAG-structural chars (`|{}\`) escaped
- empty / no values → never-match `(@f:{s} -@f:{s})` (matches nothing; clause never dropped)

Exact/range/geo unchanged. **Known limitation:** Valkey TAG matching is case-insensitive vs qdrant case-sensitive (mixed-case data only; no shipped dataset).

## Testing
- **Unit:** inlined TAG OR, NUMERIC OR, empty-list never-match, `|` escaping, exact-value regression.
- **Integration (CI):** `test_binary_valkey_match_any` runs the real binary against a live Valkey container via `common::write_match_any_project`; ground truth over only matching docs, asserting recall ≥ 0.9.
- Local: unit green, clippy `-D warnings` clean, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)