### PR TITLE
feat(valkey): ElastiCache Valkey 9.1 engine — full M×EF grid + EF_RUNTIME fix

### DIFF
--- a/experiments/configurations/valkey-single-node.json
+++ b/experiments/configurations/valkey-single-node.json
@@ -4,68 +4,804 @@
     "engine": "valkey",
     "connection_params": {},
     "collection_params": {
-      "hnsw_config": {  }
+      "hnsw_config": {}
     },
     "search_params": [
-      { "parallel": 100, "search_params": { "ef": 64 } }, { "parallel": 100, "search_params": { "ef": 128 } }, { "parallel": 100, "search_params": { "ef": 256 } }, { "parallel": 100, "search_params": { "ef": 512 } }
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
     ],
-    "upload_params": { "parallel": 100 }
-
+    "upload_params": {
+      "parallel": 100
+    }
+  },
+  {
+    "name": "valkey-m-16-ef-64",
+    "engine": "valkey",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 16,
+        "EF_CONSTRUCTION": 64
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100
+    }
   },
   {
     "name": "valkey-m-16-ef-128",
     "engine": "valkey",
     "connection_params": {},
     "collection_params": {
-      "hnsw_config": { "M": 16, "EF_CONSTRUCTION": 128 }
+      "hnsw_config": {
+        "M": 16,
+        "EF_CONSTRUCTION": 128
+      }
     },
     "search_params": [
-      { "parallel": 1, "search_params": { "ef": 64 } }, { "parallel": 1, "search_params": { "ef": 128 } }, { "parallel": 1, "search_params": { "ef": 256 } }, { "parallel": 1, "search_params": { "ef": 512 } },
-      { "parallel": 100, "search_params": { "ef": 64 } }, { "parallel": 100, "search_params": { "ef": 128 } }, { "parallel": 100, "search_params": { "ef": 256 } }, { "parallel": 100, "search_params": { "ef": 512 } }
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
     ],
-    "upload_params": { "parallel": 100 }
-
+    "upload_params": {
+      "parallel": 100
+    }
   },
   {
     "name": "valkey-m-16-ef-256",
     "engine": "valkey",
     "connection_params": {},
     "collection_params": {
-      "hnsw_config": { "M": 16, "EF_CONSTRUCTION": 256 }
+      "hnsw_config": {
+        "M": 16,
+        "EF_CONSTRUCTION": 256
+      }
     },
     "search_params": [
-      { "parallel": 1, "search_params": { "ef": 64 } }, { "parallel": 1, "search_params": { "ef": 128 } }, { "parallel": 1, "search_params": { "ef": 256 } }, { "parallel": 1, "search_params": { "ef": 512 } },
-      { "parallel": 100, "search_params": { "ef": 64 } }, { "parallel": 100, "search_params": { "ef": 128 } }, { "parallel": 100, "search_params": { "ef": 256 } }, { "parallel": 100, "search_params": { "ef": 512 } }
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
     ],
-    "upload_params": { "parallel": 100 }
-
+    "upload_params": {
+      "parallel": 100
+    }
+  },
+  {
+    "name": "valkey-m-16-ef-512",
+    "engine": "valkey",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 16,
+        "EF_CONSTRUCTION": 512
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100
+    }
+  },
+  {
+    "name": "valkey-m-32-ef-64",
+    "engine": "valkey",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 32,
+        "EF_CONSTRUCTION": 64
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100
+    }
   },
   {
     "name": "valkey-m-32-ef-128",
     "engine": "valkey",
     "connection_params": {},
     "collection_params": {
-      "hnsw_config": { "M": 32, "EF_CONSTRUCTION": 128 }
+      "hnsw_config": {
+        "M": 32,
+        "EF_CONSTRUCTION": 128
+      }
     },
     "search_params": [
-      { "parallel": 1, "search_params": { "ef": 64 } }, { "parallel": 1, "search_params": { "ef": 128 } }, { "parallel": 1, "search_params": { "ef": 256 } }, { "parallel": 1, "search_params": { "ef": 512 } },
-      { "parallel": 100, "search_params": { "ef": 64 } }, { "parallel": 100, "search_params": { "ef": 128 } }, { "parallel": 100, "search_params": { "ef": 256 } }, { "parallel": 100, "search_params": { "ef": 512 } }
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
     ],
-    "upload_params": { "parallel": 100 }
-
+    "upload_params": {
+      "parallel": 100
+    }
+  },
+  {
+    "name": "valkey-m-32-ef-256",
+    "engine": "valkey",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 32,
+        "EF_CONSTRUCTION": 256
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100
+    }
+  },
+  {
+    "name": "valkey-m-32-ef-512",
+    "engine": "valkey",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 32,
+        "EF_CONSTRUCTION": 512
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100
+    }
+  },
+  {
+    "name": "valkey-m-64-ef-64",
+    "engine": "valkey",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 64,
+        "EF_CONSTRUCTION": 64
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100
+    }
+  },
+  {
+    "name": "valkey-m-64-ef-128",
+    "engine": "valkey",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 64,
+        "EF_CONSTRUCTION": 128
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100
+    }
   },
   {
     "name": "valkey-m-64-ef-256",
     "engine": "valkey",
     "connection_params": {},
     "collection_params": {
-      "hnsw_config": { "M": 64, "EF_CONSTRUCTION": 256 }
+      "hnsw_config": {
+        "M": 64,
+        "EF_CONSTRUCTION": 256
+      }
     },
     "search_params": [
-      { "parallel": 1, "search_params": { "ef": 64 } }, { "parallel": 1, "search_params": { "ef": 128 } }, { "parallel": 1, "search_params": { "ef": 256 } }, { "parallel": 1, "search_params": { "ef": 512 } },
-      { "parallel": 100, "search_params": { "ef": 64 } }, { "parallel": 100, "search_params": { "ef": 128 } }, { "parallel": 100, "search_params": { "ef": 256 } }, { "parallel": 100, "search_params": { "ef": 512 } }
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
     ],
-    "upload_params": { "parallel": 100 }
-
+    "upload_params": {
+      "parallel": 100
+    }
+  },
+  {
+    "name": "valkey-m-64-ef-512",
+    "engine": "valkey",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 64,
+        "EF_CONSTRUCTION": 512
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100
+    }
   }
 ]

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -1039,7 +1039,7 @@ fn ft_search_knn(
     conn: &mut Connection,
     query_vector: &[f32],
     top: usize,
-    _ef: i64,
+    ef: i64,
     _algorithm: &str,
     _hybrid_policy: &str,
     query_timeout: i64,
@@ -1047,14 +1047,19 @@ fn ft_search_knn(
 ) -> Result<Vec<(i64, f64)>, String> {
     let vec_bytes: Vec<u8> = query_vector.iter().flat_map(|f| f.to_le_bytes()).collect();
 
-    // Valkey Search KNN query syntax (no EF_RUNTIME, no HYBRID_POLICY):
-    // "*=>[KNN $K @vector $vec_param AS vector_score]"
+    // Valkey Search KNN query syntax. EF_RUNTIME is a supported per-query HNSW
+    // attribute (validated by valkey-search ft_search_parser.cc) — without it,
+    // every ef in the search sweep runs at the index default, collapsing the
+    // precision/recall curve to a single point. Passed as a $EF param below.
     let prefilter = filter
         .as_ref()
         .map(|(expr, _)| expr.as_str())
         .unwrap_or("*");
 
-    let query_str = format!("{}=>[KNN $K @vector $vec_param AS vector_score]", prefilter);
+    let query_str = format!(
+        "{}=>[KNN $K @vector $vec_param EF_RUNTIME $EF AS vector_score]",
+        prefilter
+    );
 
     // Valkey Search: DIALECT 2 only, no SORTBY on computed fields
     let mut cmd = redis::cmd("FT.SEARCH");
@@ -1071,13 +1076,14 @@ fn ft_search_knn(
         .arg("TIMEOUT")
         .arg(query_timeout);
 
-    // Params: vec_param + K + filter params
+    // Params: vec_param + K + EF + filter params
     let filter_param_count = filter.as_ref().map(|(_, p)| p.len() * 2).unwrap_or(0);
-    let total_param_count = 4 + filter_param_count; // vec_param(2) + K(2) + filter params
+    let total_param_count = 6 + filter_param_count; // vec_param(2) + K(2) + EF(2) + filter params
 
     cmd.arg("PARAMS").arg(total_param_count);
     cmd.arg("vec_param").arg(&vec_bytes[..]);
     cmd.arg("K").arg(top.to_string());
+    cmd.arg("EF").arg(ef.to_string());
 
     if let Some((_, params)) = filter {
         for (name, value) in params {


### PR DESCRIPTION
## What

Adds ElastiCache-for-Valkey 9.1 (valkey-search) as a first-class engine target for the pure-kNN vector benchmark, to sit alongside `redis` and `qdrant` in the RCP-vs-Qdrant comparison.

Two commits:

1. **`feat(valkey)`: complete HNSW config grid** — fills `valkey-single-node.json` out to the full 12-cell M×EF grid (`valkey-m-{16,32,64}-ef-{64,128,256,512}`) mirroring `redis-m-*`, so the valkey side sweeps the same precision/recall curve as redis/qdrant. Each config sweeps ef_runtime ∈ {64,128,256,512} at parallel 1 and 100.

2. **`fix(valkey)`: pass `EF_RUNTIME` in the KNN query** — the engine previously omitted `EF_RUNTIME` from the `FT.SEARCH` KNN query (a comment claimed valkey-search didn't support it). Effect: every ef in the search sweep ran at the index default, so **recall was identical to 10 decimals across ef 64/128/256/512** (measured on glove: flat 0.6787) and the precision/recall curve collapsed to a single low point.

   valkey-search **does** support `EF_RUNTIME` as a per-query HNSW attribute — confirmed in valkey-search `src/commands/ft_search_parser.cc`, which validates `parameters.ef` against `max-ef-runtime`. The fix passes the swept ef as `$EF` in `PARAMS`, mirroring the `redis` engine. DIALECT 2 unchanged.

## Scope

Only touches the `valkey` engine + its config file — no change to `redis`/`qdrant` paths.

- `src/bin/vector_db_benchmark/engine/valkey.rs` — EF_RUNTIME in KNN query + PARAMS
- `experiments/configurations/valkey-single-node.json` — full M×EF grid

## Validation

- Smoke on EC Valkey 9.1 (random-100): FT.CREATE / upload / FT.SEARCH / summary all work end-to-end. ✅
- **In flight:** glove single-config ef-sweep run to confirm recall now *varies* across ef (rising toward ~0.95) with rps falling as ef rises. Marking this PR ready for review once that lands.

`cargo check` clean.
