### PR TITLE
fix(parity): include index-build wait in total_time; count failed queries

### DIFF
--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -746,11 +746,18 @@ impl Engine for ElasticsearchEngine {
             vectors.len() as f64 / upload_time
         );
 
-        // Force merge post-upload
+        // Force merge post-upload. Include the merge/index-settle time in
+        // total_time for cross-engine comparability (mirrors mongodb; matches
+        // v0's post_upload() timing).
+        let index_start = Instant::now();
         self.force_merge()?;
+        let index_time = index_start.elapsed().as_secs_f64();
 
-        let total_time = read_time + upload_time;
-        println!("Total time: {:.3}s", total_time);
+        let total_time = read_time + upload_time + index_time;
+        println!(
+            "Index time: {:.3}s, Total time (read+upload+index): {:.3}s",
+            index_time, total_time
+        );
 
         Ok(UploadStats {
             upload_time,
@@ -892,7 +899,7 @@ impl Engine for ElasticsearchEngine {
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel,
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
         )
     }
 

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -729,18 +729,27 @@ impl Engine for MilvusEngine {
             vectors.len() as f64 / upload_time
         );
 
-        // Create index after upload
+        // Create index after upload, then load the collection into memory. Both
+        // are part of the ingest cost and are included in total_time for
+        // cross-engine comparability (mirrors mongodb; matches v0's post_upload()
+        // timing).
         let client = self.create_client()?;
         println!(
             "Creating {} index (M={}, efConstruction={}, metric={})...",
             self.index_type, self.index_m, self.index_ef_construction, self.metric_type
         );
+        let index_start = Instant::now();
         self.create_index(&client)?;
 
         // Load collection into memory
         self.load_collection(&client)?;
+        let index_time = index_start.elapsed().as_secs_f64();
 
-        let total_time = read_time + upload_time;
+        let total_time = read_time + upload_time + index_time;
+        println!(
+            "Index time: {:.3}s, Total time (read+upload+index): {:.3}s",
+            index_time, total_time
+        );
 
         Ok(UploadStats {
             upload_time,
@@ -891,7 +900,7 @@ impl Engine for MilvusEngine {
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel,
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
         )
     }
 

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -75,7 +75,14 @@ pub struct SearchResults {
     pub precisions: Vec<f64>,
     pub latencies: Vec<f64>,
     pub top: usize,
+    /// Number of *successful* queries folded into the latency/quality stats.
     pub num_queries: usize,
+    /// Number of queries requested for this run (num_to_run).
+    pub requested_queries: usize,
+    /// requested_queries - num_queries: queries that errored/timed out and were
+    /// excluded from the latency percentiles. Nonzero means the reported numbers
+    /// are over a partial set (e.g. a saturated client shedding timeouts).
+    pub failed_queries: usize,
     pub parallel: usize,
     // Mixed benchmark update metrics (None when search-only)
     pub update_count: Option<usize>,
@@ -94,7 +101,10 @@ pub struct SearchResults {
 ///
 /// `times`/`precisions`/`recalls`/`mrrs`/`ndcgs` are the per-successful-query
 /// samples (see the engines' search loops), `total_time` the wall clock,
-/// `top` the k used, and `parallel` the client concurrency.
+/// `top` the k used, `parallel` the client concurrency, and `requested_queries`
+/// the number of queries dispatched (num_to_run) so failures can be counted as
+/// `requested_queries - times.len()`. RPS stays successes/wall-clock; a nonzero
+/// `failed_queries` flags that the stats cover only the successful subset.
 #[allow(clippy::too_many_arguments)]
 pub fn compute_search_stats(
     times: &[f64],
@@ -105,6 +115,7 @@ pub fn compute_search_stats(
     total_time: f64,
     top: usize,
     parallel: usize,
+    requested_queries: usize,
 ) -> Result<SearchResults, String> {
     if times.is_empty() {
         return Err("No searches completed".to_string());
@@ -150,6 +161,8 @@ pub fn compute_search_stats(
         latencies: times.to_vec(),
         top,
         num_queries: times.len(),
+        requested_queries,
+        failed_queries: requested_queries.saturating_sub(times.len()),
         parallel,
         ..Default::default()
     })
@@ -261,15 +274,17 @@ mod stats_tests {
 
     #[test]
     fn empty_times_errors() {
-        assert!(compute_search_stats(&[], &[], &[], &[], &[], 1.0, 10, 1).is_err());
+        assert!(compute_search_stats(&[], &[], &[], &[], &[], 1.0, 10, 1, 0).is_err());
     }
 
     #[test]
     fn computes_means_rps_and_clamped_percentiles() {
         let times = vec![0.1, 0.2, 0.3, 0.4];
         let ones = vec![1.0, 1.0, 1.0, 1.0];
-        let r = compute_search_stats(&times, &ones, &ones, &ones, &ones, 2.0, 10, 4).unwrap();
+        let r = compute_search_stats(&times, &ones, &ones, &ones, &ones, 2.0, 10, 4, 5).unwrap();
         assert_eq!(r.num_queries, 4);
+        assert_eq!(r.requested_queries, 5);
+        assert_eq!(r.failed_queries, 1); // 5 requested, 4 succeeded
         assert!((r.rps - 2.0).abs() < 1e-9); // 4 / 2.0s
         assert!((r.mean_recall - 1.0).abs() < 1e-9);
         assert!((r.mean_time - 0.25).abs() < 1e-9);
@@ -283,7 +298,7 @@ mod stats_tests {
 
     #[test]
     fn single_query_percentiles_dont_panic() {
-        let r = compute_search_stats(&[0.5], &[1.0], &[1.0], &[1.0], &[1.0], 1.0, 5, 1).unwrap();
+        let r = compute_search_stats(&[0.5], &[1.0], &[1.0], &[1.0], &[1.0], 1.0, 5, 1, 1).unwrap();
         assert!((r.p99_time - 0.5).abs() < 1e-9);
     }
 }

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -1172,7 +1172,7 @@ impl Engine for MongoDBEngine {
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel,
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
         )
     }
 
@@ -1436,6 +1436,8 @@ impl Engine for MongoDBEngine {
             latencies: times.to_vec(),
             top: explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10)),
             num_queries: times.len(),
+            requested_queries: num_to_run,
+            failed_queries: num_to_run.saturating_sub(times.len()),
             parallel,
             update_count,
             update_rps,

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -837,11 +837,19 @@ impl Engine for OpenSearchEngine {
         );
 
         // Explicit refresh (refresh_interval is disabled during upload) so the
-        // documents are searchable, then merge segments.
+        // documents are searchable, then merge segments. Include this
+        // refresh+merge time in total_time for cross-engine comparability
+        // (mirrors mongodb; matches v0's post_upload() timing).
+        let index_start = Instant::now();
         self.refresh()?;
         self.force_merge()?;
+        let index_time = index_start.elapsed().as_secs_f64();
 
-        let total_time = read_time + upload_time;
+        let total_time = read_time + upload_time + index_time;
+        println!(
+            "Index time: {:.3}s, Total time (read+upload+index): {:.3}s",
+            index_time, total_time
+        );
 
         Ok(UploadStats {
             upload_time,
@@ -984,7 +992,7 @@ impl Engine for OpenSearchEngine {
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel,
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
         )
     }
 

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -535,7 +535,7 @@ impl Engine for PgVectorEngine {
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel,
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
         )
     }
 

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -378,11 +378,14 @@ impl QdrantEngine {
         }
         pb.finish_with_message("Upload complete");
         let upload_time = upload_start.elapsed().as_secs_f64();
+        // Include the index-build wait in total_time (see upload()).
+        let index_start = Instant::now();
         self.wait_collection_green()?;
+        let index_time = index_start.elapsed().as_secs_f64();
 
         Ok(UploadStats {
             upload_time,
-            total_time: read_time + upload_time,
+            total_time: read_time + upload_time + index_time,
             upload_count: vectors.len(),
             parallel: 1,
             batch_size: self.batch_size,
@@ -797,10 +800,18 @@ impl Engine for QdrantEngine {
             vectors.len() as f64 / upload_time
         );
 
-        // Wait for indexing to complete
+        // Wait for indexing to complete. Include this wait in total_time for
+        // cross-engine comparability (mirrors mongodb; matches v0's post_upload()
+        // timing) — the HNSW build is the dominant part of Qdrant ingest cost.
+        let index_start = Instant::now();
         self.wait_collection_green()?;
+        let index_time = index_start.elapsed().as_secs_f64();
 
-        let total_time = read_time + upload_time;
+        let total_time = read_time + upload_time + index_time;
+        println!(
+            "Index time: {:.3}s, Total time (read+upload+index): {:.3}s",
+            index_time, total_time
+        );
 
         Ok(UploadStats {
             upload_time,
@@ -1075,7 +1086,7 @@ impl Engine for QdrantEngine {
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel,
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
         )
     }
 

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -1330,12 +1330,21 @@ impl Engine for RedisEngine {
             vectors.len() as f64 / upload_time
         );
 
-        // Wait for RediSearch indexing to complete
+        // Wait for RediSearch indexing to complete. The index-build wait is part
+        // of the ingest cost and must be included in total_time for cross-engine
+        // comparability (mirrors mongodb; matches v0 which times through
+        // post_upload()). Excluding it made every engine but mongodb look
+        // artificially fast to index.
         let expected = vectors.len();
+        let index_start = Instant::now();
         self.wait_for_indexing(expected)?;
+        let index_time = index_start.elapsed().as_secs_f64();
 
-        let total_time = read_time + upload_time;
-        println!("Total time: {:.3}s", total_time);
+        let total_time = read_time + upload_time + index_time;
+        println!(
+            "Index time: {:.3}s, Total time (read+upload+index): {:.3}s",
+            index_time, total_time
+        );
 
         // Verify no HSET failures occurred during upload
         let mut conn = self.get_connection()?;
@@ -1519,7 +1528,7 @@ impl Engine for RedisEngine {
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrs, &nds, total_time, top, parallel,
+            &times, &precs, &recs, &mrs, &nds, total_time, top, parallel, num_to_run,
         )
     }
 
@@ -1796,6 +1805,8 @@ impl Engine for RedisEngine {
             latencies: times.to_vec(),
             top: explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10)),
             num_queries: times.len(),
+            requested_queries: num_to_run,
+            failed_queries: num_to_run.saturating_sub(times.len()),
             parallel,
             update_count,
             update_rps,

--- a/src/bin/vector_db_benchmark/engine/turbopuffer.rs
+++ b/src/bin/vector_db_benchmark/engine/turbopuffer.rs
@@ -649,7 +649,11 @@ impl Engine for TurbopufferEngine {
             ndcgs,
             latencies,
             top,
-            num_queries: num_to_run,
+            // num_queries = successes folded into the stats (matches
+            // compute_search_stats); requested/failed track the full workload.
+            num_queries: succeeded,
+            requested_queries: num_to_run,
+            failed_queries: failed,
             parallel,
             ..Default::default()
         })

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -1343,11 +1343,18 @@ impl Engine for ValkeyEngine {
             vectors.len() as f64 / upload_time
         );
 
+        // Include the index-build wait in total_time for cross-engine
+        // comparability (mirrors mongodb; matches v0's post_upload() timing).
         let expected = vectors.len();
+        let index_start = Instant::now();
         self.wait_for_indexing(expected)?;
+        let index_time = index_start.elapsed().as_secs_f64();
 
-        let total_time = read_time + upload_time;
-        println!("Total time: {:.3}s", total_time);
+        let total_time = read_time + upload_time + index_time;
+        println!(
+            "Index time: {:.3}s, Total time (read+upload+index): {:.3}s",
+            index_time, total_time
+        );
 
         // Verify no HSET failures occurred during upload
         let mut conn = self.get_connection()?;
@@ -1530,7 +1537,7 @@ impl Engine for ValkeyEngine {
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel,
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
         )
     }
 
@@ -1804,6 +1811,8 @@ impl Engine for ValkeyEngine {
             latencies: times.to_vec(),
             top: explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10)),
             num_queries: times.len(),
+            requested_queries: num_to_run,
+            failed_queries: num_to_run.saturating_sub(times.len()),
             parallel,
             update_count,
             update_rps,

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -636,7 +636,7 @@ impl Engine for VectorSetsEngine {
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel,
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
         )
     }
 
@@ -911,6 +911,8 @@ impl Engine for VectorSetsEngine {
             latencies: times.to_vec(),
             top: explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10)),
             num_queries: times.len(),
+            requested_queries: num_to_run,
+            failed_queries: num_to_run.saturating_sub(times.len()),
             parallel,
             update_count,
             update_rps,

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -1081,7 +1081,7 @@ impl Engine for WeaviateEngine {
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel,
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
         )
     }
 

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -462,6 +462,19 @@ fn run_single_experiment(
                                 results.rps, results.mean_recall, results.mean_precision, results.mean_mrr, results.mean_ndcg
                             );
                         }
+                        // Surface dropped queries loudly: latency percentiles and
+                        // recall above cover only the successful subset, so a
+                        // nonzero count means the numbers are not over the full
+                        // requested workload.
+                        if results.failed_queries > 0 {
+                            eprintln!(
+                                "\t⚠ WARNING: {}/{} queries FAILED (only {} succeeded); \
+                                 latency/recall/QPS above reflect the successful subset only",
+                                results.failed_queries,
+                                results.requested_queries,
+                                results.num_queries,
+                            );
+                        }
                         save_search_results(
                             engine.name(),
                             &dataset.config.name,
@@ -618,6 +631,14 @@ fn save_search_results(
         "results": {
             "total_time": results.total_time,
             "mean_time": results.mean_time,
+            // Query accounting: rps and the latency percentiles are computed over
+            // succeeded_queries only, while total_time (the rps denominator) spans
+            // the whole run. A nonzero failed_queries means the reported latency
+            // distribution covers a partial set — typically the regime where a
+            // saturated client or an overloaded server sheds timeouts.
+            "requested_queries": results.requested_queries,
+            "succeeded_queries": results.num_queries,
+            "failed_queries": results.failed_queries,
             "mean_precisions": results.mean_precision,
             "mean_recall": results.mean_recall,
             "mean_mrr": results.mean_mrr,


### PR DESCRIPTION
## Summary

Two critical parity/trustworthiness fixes surfaced by a 15-agent adversarial review of the benchmark methodology against the `v0/` Python oracle (qdrant/vector-db-benchmark).

### 1. Index-build wait now counted in upload `total_time` (all applicable engines)
6 of 8 engines computed `total_time = read_time + upload_time` **before** the async index-readiness wait (RediSearch `percent_indexed`, Qdrant GREEN, ES/OS force-merge+refresh, Milvus `create_index`+`load`), so the headline **indexing-time column excluded the dominant ingest cost**. Only mongodb included it — making every other engine look artificially fast and breaking cross-engine comparison.

Each engine now times the wait separately and adds it (mirrors `mongodb_engine`, matches v0 which times through `post_upload()`):
- `redis`, `valkey`, `qdrant` (KNN + sparse), `elasticsearch`, `opensearch`, `milvus`
- `pgvector` is unaffected — it builds its HNSW index in `configure()` before upload, so the cost is already inside `upload_time`.
- `vectorsets`/`turbopuffer` have no local index-build wait.

### 2. Failed / requested / succeeded query accounting
RPS and latency percentiles are computed over **successful queries only**, while `total_time` (the RPS denominator) spans the whole run — and failures were merely `eprintln`'d. A run that sheds timeouts (e.g. a saturated client) wrote to disk as clean, tail-flattered numbers with no trace of the drops.
- `SearchResults` gains `requested_queries` + `failed_queries`; `compute_search_stats` takes `requested_queries` and derives `failed = requested - successes`.
- `save_search_results` emits `requested_queries` / `succeeded_queries` / `failed_queries`; the runner prints a loud **WARNING** when any query failed.
- `turbopuffer` (inline stats) corrected: `num_queries` now = successes (was mislabeled as `num_to_run`) and reports requested/failed consistently.

## Follow-ups (tracked, not in this PR)
- `weaviate` has **no** post-upload readiness wait at all (may search a partially-indexed store) — a behavioral gap beyond timing.
- Next backlog items: client CPU/saturation coverage, per-thread hot-path buffers, REPETITIONS=3, numpy-linear percentiles.

## Verification
- `make check` (fmt + clippy) — clean
- `make test` (49) + `stats_tests` (3) + `make integration-test` (15) — all pass
- End-to-end on redis/random-100: `Index time` now in `total_time`; new query counts present in the result JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)