### PR TITLE
feat(parity): repeat each search config, report warm best-of (v0 REPETITIONS)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ndarray = "0.16"
 ndarray-npy = "0.9"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 glob = "0.3"
 chrono = "0.4"
 reqwest = { version = "0.12", features = ["blocking", "json"] }

--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -77,6 +77,13 @@ pub struct Args {
     #[arg(long, default_value = "-1")]
     pub queries: i64,
 
+    /// Repeat each measured search config this many times and report the
+    /// best-RPS run (warm best-of, matching v0's REPETITIONS). The first run is
+    /// often cold (OS page cache / index warm-up); best-of discards it. Set 1 to
+    /// disable. Also honored via the REPETITIONS environment variable.
+    #[arg(long, env = "REPETITIONS", default_value = "3")]
+    pub repetitions: usize,
+
     /// Filter search experiments by ef runtime values (comma-separated)
     #[arg(long, value_delimiter = ',')]
     pub ef_runtime: Vec<i64>,

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -445,38 +445,70 @@ fn run_single_experiment(
                     );
                 }
 
-                // Sample client CPU around the search so we can flag runs where
-                // the benchmark client — not the database — was the bottleneck.
-                let cpu_before = crate::proc_cpu::sample();
-                let search_result = match phase {
-                    Some(ratio) => {
-                        engine.search_mixed(dataset, effective_params, args.queries, ratio)
-                    }
-                    None => engine.search(dataset, effective_params, args.queries),
-                };
-                let cpu_after = crate::proc_cpu::sample();
+                // Run the measured search `repetitions` times and keep the
+                // best-RPS run. Restores v0's REPETITIONS behavior: the first run
+                // is often cold (OS page cache / index warm-up), and best-of
+                // discards it, so published QPS is a warm figure comparable to
+                // the Python tool. --repetitions 1 disables it.
+                let repetitions = args.repetitions.max(1);
+                let mut best: Option<crate::engine::SearchResults> = None;
+                let mut last_err: Option<String> = None;
 
-                match search_result {
-                    Ok(mut results) => {
-                        // Attach CPU / oversubscription / saturation coverage.
-                        let sat = crate::proc_cpu::compute(
-                            cpu_before,
-                            cpu_after,
-                            results.parallel,
-                            crate::proc_cpu::available_cores(),
-                        );
-                        results.available_cores = sat.available_cores;
-                        results.oversubscribed = sat.oversubscribed;
-                        results.client_cpu_cores_used = sat.client_cpu_cores_used;
-                        results.system_cpu_pct = sat.system_cpu_pct;
-                        results.client_saturated = sat.client_saturated;
-                        results.saturation_reason = sat.saturation_reason;
+                for rep in 0..repetitions {
+                    // Sample client CPU around the search so we can flag runs where
+                    // the benchmark client — not the database — was the bottleneck.
+                    let cpu_before = crate::proc_cpu::sample();
+                    let search_result = match phase {
+                        Some(ratio) => {
+                            engine.search_mixed(dataset, effective_params, args.queries, ratio)
+                        }
+                        None => engine.search(dataset, effective_params, args.queries),
+                    };
+                    let cpu_after = crate::proc_cpu::sample();
+
+                    match search_result {
+                        Ok(mut results) => {
+                            // Attach CPU / oversubscription / saturation coverage.
+                            let sat = crate::proc_cpu::compute(
+                                cpu_before,
+                                cpu_after,
+                                results.parallel,
+                                crate::proc_cpu::available_cores(),
+                            );
+                            results.available_cores = sat.available_cores;
+                            results.oversubscribed = sat.oversubscribed;
+                            results.client_cpu_cores_used = sat.client_cpu_cores_used;
+                            results.system_cpu_pct = sat.system_cpu_pct;
+                            results.client_saturated = sat.client_saturated;
+                            results.saturation_reason = sat.saturation_reason;
+                            if repetitions > 1 {
+                                println!(
+                                    "\t  rep {}/{}: QPS {:.1}",
+                                    rep + 1,
+                                    repetitions,
+                                    results.rps
+                                );
+                            }
+                            if best.as_ref().map(|b| results.rps > b.rps).unwrap_or(true) {
+                                best = Some(results);
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("\tSearch failed (rep {}/{}): {}", rep + 1, repetitions, e);
+                            last_err = Some(e);
+                        }
+                    }
+                }
+
+                match best {
+                    Some(results) => {
                         if skip_vector_index {
                             println!("\t→ QPS: {:.1} (filter-only, no precision)", results.rps);
                         } else {
                             println!(
-                                "\t→ QPS: {:.1}, Recall: {:.4}, Precision: {:.4}, MRR: {:.4}, NDCG: {:.4}",
-                                results.rps, results.mean_recall, results.mean_precision, results.mean_mrr, results.mean_ndcg
+                                "\t→ QPS: {:.1}, Recall: {:.4}, Precision: {:.4}, MRR: {:.4}, NDCG: {:.4}{}",
+                                results.rps, results.mean_recall, results.mean_precision, results.mean_mrr, results.mean_ndcg,
+                                if repetitions > 1 { " (best of reps)" } else { "" }
                             );
                         }
                         // Surface dropped queries loudly: latency percentiles and
@@ -521,8 +553,12 @@ fn run_single_experiment(
                             results,
                         });
                     }
-                    Err(e) => {
-                        eprintln!("\tSearch failed: {}", e);
+                    None => {
+                        eprintln!(
+                            "\tSearch failed (all {} repetition(s)){}",
+                            repetitions,
+                            last_err.map(|e| format!(": {}", e)).unwrap_or_default()
+                        );
                     }
                 }
             }

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -1707,7 +1707,9 @@ fn test_binary_redis_mixed_benchmark() {
         .query(&mut conn)
         .unwrap();
 
-    // Run with --update-search-ratio 1:5 (10 queries → 2 update cycles)
+    // Run with --update-search-ratio 1:5 (10 queries → 2 update cycles).
+    // --repetitions 1: this test asserts the exact per-run FT.SEARCH/HSET call
+    // counts, so it must measure a single pass (the default is 3 warm reps).
     let output = Command::new(&bin)
         .args([
             "--engines",
@@ -1718,6 +1720,8 @@ fn test_binary_redis_mixed_benchmark() {
             "localhost",
             "--update-search-ratio",
             "1:5",
+            "--repetitions",
+            "1",
         ])
         .env("REDIS_PORT", TEST_PORT.to_string())
         .current_dir(&project_root)


### PR DESCRIPTION
## Summary
The runner measured each search config **exactly once** — a single, often-cold draw (cold OS page cache / index warm-up) with high run-to-run variance, not comparable to v0, which runs each config `REPETITIONS` times (default 3) and whose best-QPS-per-precision-bucket selection implicitly discards the cold first run.

Adds `--repetitions N` (**default 3**, also read from the `REPETITIONS` env var to mirror v0). `run_single_experiment` now runs each measured search `N` times and reports/saves the **best-RPS** run; `--repetitions 1` restores single-shot. Each rep's QPS is printed and the chosen line is marked `(best of reps)`. Calibration is unaffected (runs once, before the timed reps).

Enables clap's `env` feature for the `REPETITIONS` binding.

## CI safety
Default 3 triples only the (sub-second, tiny-dataset) search phase in integration tests; they assert exit 0 + precision ≥ 0.8 + one result file per config — all preserved (best-of saves a single file).

## Verification
`make check` + all 83 bin tests pass. Live on redis/random-100:
```
  rep 1/3: QPS 2077.7
  rep 2/3: QPS 1820.8
  rep 3/3: QPS 1679.1
→ QPS: 2077.7, Recall: 1.0000, ... (best of reps)
```
one result file saved, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)