### PR TITLE
docs: sync engine protocols/versions with the code (full sweep)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ make check              # Run formatting (rustfmt) + linting (clippy) — MUST p
 make vector-db-benchmark # Build the main CLI binary (release mode)
 make build              # Build all binaries (release mode)
 make test               # Run unit tests (no Docker needed)
-make integration-test   # Run integration tests (starts redis:8.6.0 Docker on port 6399)
+make integration-test   # Run integration tests (starts redis:8.8.0 Docker on port 6399)
 make v0-check           # Compare Rust vs Python v0 (precision, QPS, latency) — starts Docker
 make fmt                # Auto-format code
 make clean              # Clean build artifacts
@@ -56,7 +56,7 @@ src/
         vectorsets.rs             # VectorSets engine (VADD, VSIM)
         redis_utils.rs            # Shared utils: commandstats validation
 tests/
-  integration_redis.rs            # Integration tests (requires redis:8.6.0 on port 6399)
+  integration_redis.rs            # Integration tests (requires redis:8.8.0 on port 6399)
 datasets/
   datasets.json                   # Dataset registry (names, paths, download links)
 experiments/
@@ -82,7 +82,7 @@ Datasets are auto-downloaded from the `link` URL in `datasets.json` when not fou
 
 - `HDF5_DIR`: Path to HDF5 library (default: `/usr/lib/x86_64-linux-gnu/hdf5/serial`)
 - `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`: Redis connection (default: `localhost:6379`)
-- Docker: `tests/docker-compose.test.yml` runs redis:8.6.0 on port 6399 for integration tests
+- Docker: `tests/docker-compose.test.yml` runs redis:8.8.0 on port 6399 for integration tests
 
 ## Migration from Python (v0/)
 
@@ -98,8 +98,8 @@ The `v0/` directory contains the original Python implementation. The Rust versio
 | Milvus | `milvus` | `milvus` | `reqwest` (REST API v2) |
 | OpenSearch | `opensearch` | `opensearch` | `opensearch` 2.3 |
 | pgvector | `pgvector` | `pgvector` | `postgres` 0.19 + `pgvector` 0.4 |
-| Qdrant | `qdrant` | `qdrant` | `qdrant-client` 1.13 (gRPC) |
-| Weaviate | `weaviate` | `weaviate` | `reqwest` (REST API) |
+| Qdrant | `qdrant` | `qdrant` | `qdrant-client` 1.17 (gRPC) |
+| Weaviate | `weaviate` | `weaviate` | `tonic`/`prost` (gRPC search) + `reqwest` (REST schema) |
 | MongoDB | — | `mongodb` | `mongodb` 3 (sync) |
 | Valkey | — | `valkey` | `redis` 0.27 \* |
 | Turbopuffer | — | `turbopuffer` | `turbopuffer-client` 0.0.4 |

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -10,9 +10,9 @@ A Rust-based benchmarking tool for vector databases. Measures upload throughput,
 | **VectorSets** | `redis` 0.27 | Redis protocol |
 | **Elasticsearch** | `elasticsearch` 8.15 | HTTP/REST |
 | **OpenSearch** | `opensearch` 2.3 | HTTP/REST |
-| **Qdrant** | `qdrant-client` 1.13 | gRPC |
+| **Qdrant** | `qdrant-client` 1.17 | gRPC |
 | **PgVector** | `postgres` 0.19 + `pgvector` 0.4 | PostgreSQL |
-| **Weaviate** | `reqwest` (REST API) | HTTP/REST + GraphQL |
+| **Weaviate** | `tonic` 0.12 / `prost` 0.13 (gRPC) + `reqwest` (REST) | gRPC (search) + HTTP/REST (schema) |
 | **Milvus** | `reqwest` (REST API v2) | HTTP/REST |
 | **MongoDB** (Atlas Search) | `mongodb` 3 (sync) | MongoDB protocol |
 | **Valkey** (Valkey Search) | `redis` 0.27 | RESP protocol |
@@ -35,7 +35,7 @@ docker run --rm redis/vector-db-benchmark --describe engines
 
 ```bash
 # Start Redis
-docker run -d --name redis -p 6379:6379 redis:8.6.0
+docker run -d --name redis -p 6379:6379 redis:8.8.0
 
 # Run benchmark against localhost Redis
 docker run --rm --network host \
@@ -93,7 +93,7 @@ The image includes the `random-100` dataset (228KB) for quick smoke tests. For l
 ```yaml
 services:
   redis:
-    image: redis:8.6.0
+    image: redis:8.8.0
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 1s

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A benchmarking tool for vector databases, written in Rust. Measures upload throu
 | **VectorSets** | `redis` 0.27 | Redis protocol | L2, Cosine | Yes |
 | **Elasticsearch** | `elasticsearch` 8.15 | HTTP/REST | L2, Cosine | Yes |
 | **OpenSearch** | `opensearch` 2.3 | HTTP/REST | L2, Cosine | Yes |
-| **Qdrant** | `qdrant-client` 1.13 | gRPC | L2, Cosine, Dot | Yes |
+| **Qdrant** | `qdrant-client` 1.17 | gRPC | L2, Cosine, Dot | Yes |
 | **PgVector** | `postgres` 0.19 + `pgvector` 0.4 | PostgreSQL | L2, Cosine | Yes |
-| **Weaviate** | `reqwest` (REST API) | HTTP/REST + GraphQL | L2, Cosine, Dot | Yes |
+| **Weaviate** | `tonic` 0.12 / `prost` 0.13 (gRPC) + `reqwest` (REST) | gRPC (search) + HTTP/REST (schema) [\*\*](#weaviate-protocol-note) | L2, Cosine, Dot | Yes |
 | **Milvus** | `reqwest` (REST API v2) | HTTP/REST | L2, Cosine, IP | Yes |
 | **MongoDB** (Atlas Search) | `mongodb` 3 (sync) | MongoDB protocol | Euclidean, Cosine, Dot | Yes |
 | **Valkey** (Valkey Search) | `redis` 0.27 [\*](#valkey-client-note) | RESP protocol | L2, Cosine, IP | Yes |
@@ -20,6 +20,9 @@ A benchmarking tool for vector databases, written in Rust. Measures upload throu
 
 <a id="valkey-client-note"></a>
 \* **Valkey client note:** Valkey GLIDE has no published Rust crate ([valkey-io/valkey-glide#828](https://github.com/valkey-io/valkey-glide/issues/828), closed NOT_PLANNED). The GLIDE maintainers recommend using `redis-rs` for Rust and upstream their improvements to it. The `redis` crate works with Valkey since it speaks the same RESP protocol.
+
+<a id="weaviate-protocol-note"></a>
+\*\* **Weaviate protocol note:** Vector search runs over Weaviate's **gRPC** API (port 50051) by default — the high-throughput query path used by the official clients (packed binary vectors). Schema management, upload, and search-time `ef` tuning use the REST API (v1). The tool falls back to the slower GraphQL-over-HTTP search path when a metadata filter is present (gRPC filter translation is not implemented) or when `WEAVIATE_USE_GRAPHQL` is set. Override the gRPC port with `WEAVIATE_GRPC_PORT`.
 
 ```
 docker run --rm --network=host redis/vector-db-benchmark:latest \
@@ -68,7 +71,7 @@ docker run --rm --network=host \
 
 ```bash
 # Start Redis
-docker run -d --name redis -p 6379:6379 redis:8.6.0
+docker run -d --name redis -p 6379:6379 redis:8.8.0
 
 # Run benchmark
 docker run --rm --network=host \
@@ -300,14 +303,14 @@ make docker-build       # Build Docker image
 Each engine has a dedicated integration test that runs against a Docker container:
 
 ```bash
-make integration-test                  # Redis (default)
-make integration-test-elasticsearch    # Elasticsearch 8.10.2
-make integration-test-opensearch       # OpenSearch 2.19.2
-make integration-test-pgvector         # PgVector (PostgreSQL 16)
-make integration-test-qdrant           # Qdrant v1.13.4
-make integration-test-weaviate         # Weaviate 1.28.9
-make integration-test-milvus           # Milvus 2.5.6
-make integration-test-mongodb          # MongoDB Atlas Local 8.0.4
+make integration-test                  # Redis 8.8.0 (default)
+make integration-test-elasticsearch    # Elasticsearch 9.4.3
+make integration-test-opensearch       # OpenSearch 3.7.0
+make integration-test-pgvector         # PgVector (PostgreSQL 18)
+make integration-test-qdrant           # Qdrant v1.18.2
+make integration-test-weaviate         # Weaviate 1.38.2
+make integration-test-milvus           # Milvus v2.6.19
+make integration-test-mongodb          # MongoDB Atlas Local 8.0.17
 make integration-test-valkey           # Valkey Bundle (latest)
 ```
 
@@ -339,7 +342,8 @@ src/
         opensearch.rs                 # OpenSearch engine
         qdrant.rs                     # Qdrant engine (gRPC)
         pgvector.rs                   # PgVector engine (PostgreSQL)
-        weaviate.rs                   # Weaviate engine (REST)
+        weaviate_grpc.rs              # Weaviate gRPC client (generated from vendored v1 protos)
+        weaviate.rs                   # Weaviate engine (gRPC search + REST schema)
         milvus.rs                     # Milvus engine (REST)
         mongodb_engine.rs             # MongoDB Atlas Search engine
         valkey.rs                     # Valkey engine (RESP protocol)


### PR DESCRIPTION
## Summary
The README engine table, integration-test version list, and the duplicate tables in `AGENTS.md` / `DOCKER_README.md` had drifted from reality. Swept all three docs against the actual source of truth — client crates in `Cargo.toml` and server images in `tests/docker-compose.test.yml`.

### Corrections
**Weaviate (the main one)** — was documented as `reqwest` (REST API) / `HTTP/REST + GraphQL`. It now searches over **gRPC by default** (`tonic 0.12` / `prost 0.13`, packed binary vectors) with REST for schema/upload/ef-tuning, and GraphQL only as a fallback (filtered queries or `WEAVIATE_USE_GRAPHQL`). Added a protocol note + `weaviate_grpc.rs` to the structure listing.

**Qdrant client**: `qdrant-client 1.13` → **1.17**.

**Integration-test server versions** (README list):
| Engine | Was | Now (compose) |
|---|---|---|
| Elasticsearch | 8.10.2 | 9.4.3 |
| OpenSearch | 2.19.2 | 3.7.0 |
| PgVector | PostgreSQL 16 | PostgreSQL 18 |
| Qdrant | v1.13.4 | v1.18.2 |
| Weaviate | 1.28.9 | 1.38.2 |
| Milvus | 2.5.6 | v2.6.19 |
| MongoDB | 8.0.4 | 8.0.17 |
| Redis (default) | — | 8.8.0 |

**Redis quick-start example**: `redis:8.6.0` → `redis:8.8.0` (matches the tested image); same in AGENTS.md / DOCKER_README.md.

Client rows verified unchanged/correct: Redis/Valkey/VectorSets `redis 0.27`, Elasticsearch `8.15`, OpenSearch `2.3`, PgVector `postgres 0.19 + pgvector 0.4`, Milvus `reqwest` (REST v2), MongoDB `mongodb 3`, Turbopuffer `turbopuffer-client 0.0.4`.

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)