### PR TITLE
chore(deps): upgrade redis-rs 0.27 → 1.3 (+ redis::Value parser tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,13 +105,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.9.2"
+name = "arcstr"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
-dependencies = [
- "rustversion",
-]
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
 name = "ascii"
@@ -1628,15 +1625,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2470,7 +2458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -2716,22 +2704,22 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.27.6"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+checksum = "2fa6f8e4b491d7a8ef3a9550a4d71969bd0064f46e32b8dbbcc7fc60dad94fed"
 dependencies = [
- "arc-swap",
+ "arcstr",
  "combine",
  "crc16",
- "itertools 0.13.0",
  "itoa",
  "num-bigint",
  "percent-encoding",
- "rand 0.8.6",
+ "rand 0.10.2",
  "ryu",
  "sha1_smol",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4352,6 +4340,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "vector_db_benchmark"
 crate-type = ["lib"]
 
 [dependencies]
-redis = { version = "0.27", features = ["cluster"] }
+redis = { version = "1", features = ["cluster"] }
 rayon = "1.10"
 half = "2.4"
 indicatif = "0.18.4"

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -1955,4 +1955,55 @@ mod tests {
         let bytes = encode_vector("UINT8", &[0.0, 255.0, 300.0, -5.0, 12.6]);
         assert_eq!(bytes, vec![0, 255, 255, 0, 13]);
     }
+
+    // ── redis::Value (RESP FT.SEARCH) response parsing ─────────────────────
+    // Guards the manual RESP-array parsing against a redis-crate / RESP2-vs-RESP3
+    // change (the surface most exposed by the redis-rs 0.27 → 1.x upgrade).
+    use super::{extract_vector_score, parse_ft_search_response, redis_value_to_json};
+    use redis::Value;
+
+    fn bulk(s: &str) -> Value {
+        Value::BulkString(s.as_bytes().to_vec())
+    }
+
+    #[test]
+    fn parse_ft_search_response_reads_id_score_pairs() {
+        // RESP2 FT.SEARCH shape: [count, id1, fields1, id2, fields2, ...]
+        let resp = vec![
+            Value::Int(2),
+            bulk("7"),
+            Value::Array(vec![bulk("vector_score"), bulk("0.25")]),
+            Value::Int(42),
+            Value::Array(vec![bulk("vector_score"), bulk("1.5")]),
+        ];
+        let hits = parse_ft_search_response(&resp).unwrap();
+        assert_eq!(hits, vec![(7, 0.25), (42, 1.5)]);
+    }
+
+    #[test]
+    fn parse_ft_search_response_empty_and_unknown_variants() {
+        assert_eq!(parse_ft_search_response(&[]).unwrap(), vec![]);
+        let resp = vec![Value::Int(1), Value::Nil, Value::Nil];
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(0, 0.0)]);
+    }
+
+    #[test]
+    fn extract_vector_score_finds_field_or_defaults_zero() {
+        let fields = vec![bulk("vector_score"), bulk("0.75")];
+        assert!((extract_vector_score(&fields) - 0.75).abs() < 1e-9);
+        assert_eq!(extract_vector_score(&[bulk("other"), bulk("x")]), 0.0);
+    }
+
+    #[test]
+    fn redis_value_to_json_covers_scalars_and_fallthrough() {
+        assert_eq!(redis_value_to_json(&Value::Int(5)), serde_json::json!(5));
+        assert_eq!(redis_value_to_json(&bulk("hi")), serde_json::json!("hi"));
+        assert_eq!(
+            redis_value_to_json(&Value::Array(vec![Value::Int(1), bulk("a")])),
+            serde_json::json!([1, "a"])
+        );
+        // Non-exhaustive/other variant → non-empty JSON string, never dropped.
+        let okay = redis_value_to_json(&Value::Okay);
+        assert!(okay.as_str().map(|s| !s.is_empty()).unwrap_or(false));
+    }
 }

--- a/src/bin/vector_db_benchmark/engine/redis_utils.rs
+++ b/src/bin/vector_db_benchmark/engine/redis_utils.rs
@@ -97,3 +97,38 @@ pub fn check_commandstats(
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::parse_failed_calls;
+
+    #[test]
+    fn parses_failed_calls_and_uppercases_command() {
+        let info = "cmdstat_FT.SEARCH:calls=10,usec=1234,failed_calls=3\r\n\
+                    cmdstat_hset:calls=100,usec=50,rejected_calls=0,failed_calls=0\r\n";
+        let m = parse_failed_calls(info);
+        assert_eq!(m.get("FT.SEARCH"), Some(&3));
+        // lowercase `cmdstat_hset` → command name uppercased to HSET
+        assert_eq!(m.get("HSET"), Some(&0));
+        assert_eq!(m.len(), 2);
+    }
+
+    #[test]
+    fn skips_lines_without_colon_or_failed_calls() {
+        // Header lines, blank lines, and stat lines with no failed_calls field
+        // must be ignored rather than producing spurious/zero entries.
+        let info = "# Commandstats\r\n\r\ncmdstat_ping:calls=1,usec=1\r\n";
+        let m = parse_failed_calls(info);
+        assert!(m.is_empty(), "got {:?}", m);
+    }
+
+    #[test]
+    fn handles_missing_cmdstat_prefix_and_bad_number() {
+        // A line without the `cmdstat_` prefix keeps its name as-is (uppercased);
+        // an unparseable failed_calls value is skipped.
+        let info = "FT.CREATE:failed_calls=2\r\ncmdstat_bad:failed_calls=notanumber";
+        let m = parse_failed_calls(info);
+        assert_eq!(m.get("FT.CREATE"), Some(&2));
+        assert!(!m.contains_key("BAD"));
+    }
+}

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -1913,4 +1913,77 @@ mod tests {
         let (q, _) = parse_conditions(&cond).unwrap();
         assert!(q.contains("@color:{red}"), "q={}", q);
     }
+
+    // ── redis::Value response parsing ──────────────────────────────────────
+    // These guard the manual RESP-array parsing (the surface most exposed to a
+    // redis-crate upgrade / RESP2-vs-RESP3 change).
+    use super::{extract_vector_score, parse_ft_search_response, redis_value_to_json};
+    use redis::Value;
+
+    fn bulk(s: &str) -> Value {
+        Value::BulkString(s.as_bytes().to_vec())
+    }
+
+    #[test]
+    fn parse_ft_search_response_reads_id_score_pairs() {
+        // RESP2 FT.SEARCH shape: [count, id1, fields1, id2, fields2, ...]
+        let resp = vec![
+            Value::Int(2),
+            bulk("7"),
+            Value::Array(vec![bulk("vector_score"), bulk("0.25")]),
+            Value::Int(42), // id may also arrive as an integer
+            Value::Array(vec![bulk("vector_score"), bulk("1.5")]),
+        ];
+        let hits = parse_ft_search_response(&resp).unwrap();
+        assert_eq!(hits, vec![(7, 0.25), (42, 1.5)]);
+    }
+
+    #[test]
+    fn parse_ft_search_response_empty_and_unknown_variants() {
+        assert_eq!(parse_ft_search_response(&[]).unwrap(), vec![]);
+        // A non-string/int id falls back to 0; a non-array field block → score 0.
+        let resp = vec![Value::Int(1), Value::Nil, Value::Nil];
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(0, 0.0)]);
+    }
+
+    #[test]
+    fn extract_vector_score_finds_field_or_defaults_zero() {
+        let fields = vec![
+            bulk("__key"),
+            bulk("doc:1"),
+            bulk("vector_score"),
+            bulk("0.75"),
+        ];
+        assert!((extract_vector_score(&fields) - 0.75).abs() < 1e-9);
+        // Missing field → 0.0
+        assert_eq!(extract_vector_score(&[bulk("other"), bulk("x")]), 0.0);
+    }
+
+    #[test]
+    fn redis_value_to_json_covers_scalars_arrays_maps_and_fallthrough() {
+        assert_eq!(redis_value_to_json(&Value::Nil), serde_json::Value::Null);
+        assert_eq!(redis_value_to_json(&Value::Int(5)), serde_json::json!(5));
+        assert_eq!(
+            redis_value_to_json(&Value::Boolean(true)),
+            serde_json::json!(true)
+        );
+        assert_eq!(redis_value_to_json(&bulk("hi")), serde_json::json!("hi"));
+        assert_eq!(
+            redis_value_to_json(&Value::Array(vec![Value::Int(1), bulk("a")])),
+            serde_json::json!([1, "a"])
+        );
+        assert_eq!(
+            redis_value_to_json(&Value::Map(vec![(bulk("k"), Value::Int(9))])),
+            serde_json::json!({"k": 9})
+        );
+        // Non-exhaustive/other variants (e.g. Okay) must not panic and must not be
+        // silently dropped — they debug-format to a non-empty string rather than
+        // vanish. (The exact string is a redis-crate impl detail, so don't pin it.)
+        let okay = redis_value_to_json(&Value::Okay);
+        assert!(
+            okay.as_str().map(|s| !s.is_empty()).unwrap_or(false),
+            "Okay should map to a non-empty JSON string, got {:?}",
+            okay
+        );
+    }
 }

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -356,53 +356,6 @@ fn parse_vsim_response(response: &[redis::Value]) -> Vec<(i64, f64)> {
     results
 }
 
-#[cfg(test)]
-mod vsim_parse_tests {
-    use super::parse_vsim_response;
-    use redis::Value;
-
-    #[test]
-    fn parses_resp2_bulk_id_and_score_as_distance() {
-        // RESP2: id + score both bulk strings; score 0.9 similarity → 0.1 distance.
-        let resp = vec![
-            Value::BulkString(b"7".to_vec()),
-            Value::BulkString(b"0.9".to_vec()),
-        ];
-        let hits = parse_vsim_response(&resp);
-        assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].0, 7);
-        assert!((hits[0].1 - 0.1).abs() < 1e-9, "distance={}", hits[0].1);
-    }
-
-    #[test]
-    fn parses_resp3_int_id_and_double_score() {
-        // RESP3: id as Int, score as Double similarity 1.0 → distance 0.0.
-        let resp = vec![Value::Int(42), Value::Double(1.0)];
-        let hits = parse_vsim_response(&resp);
-        assert_eq!(hits, vec![(42, 0.0)]);
-    }
-
-    #[test]
-    fn multiple_pairs_and_trailing_odd_element_ignored() {
-        let resp = vec![
-            Value::Int(1),
-            Value::Double(0.5),
-            Value::Int(2),
-            Value::Double(0.25),
-            Value::Int(3), // dangling id with no score → dropped
-        ];
-        let hits = parse_vsim_response(&resp);
-        assert_eq!(hits, vec![(1, 0.5), (2, 0.75)]);
-    }
-
-    #[test]
-    fn unknown_variants_fall_back_without_panicking() {
-        let resp = vec![Value::Nil, Value::Nil];
-        assert_eq!(parse_vsim_response(&resp), vec![(0, 0.0)]);
-        assert_eq!(parse_vsim_response(&[]), vec![]);
-    }
-}
-
 /// Single-record VADD update (for mixed benchmark).
 fn vadd_single(
     conn: &mut Connection,
@@ -1124,5 +1077,52 @@ fn format_number(value: &serde_json::Value) -> String {
         f.to_string()
     } else {
         "0".to_string()
+    }
+}
+
+#[cfg(test)]
+mod vsim_parse_tests {
+    use super::parse_vsim_response;
+    use redis::Value;
+
+    #[test]
+    fn parses_resp2_bulk_id_and_score_as_distance() {
+        // RESP2: id + score both bulk strings; score 0.9 similarity → 0.1 distance.
+        let resp = vec![
+            Value::BulkString(b"7".to_vec()),
+            Value::BulkString(b"0.9".to_vec()),
+        ];
+        let hits = parse_vsim_response(&resp);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, 7);
+        assert!((hits[0].1 - 0.1).abs() < 1e-9, "distance={}", hits[0].1);
+    }
+
+    #[test]
+    fn parses_resp3_int_id_and_double_score() {
+        // RESP3: id as Int, score as Double similarity 1.0 → distance 0.0.
+        let resp = vec![Value::Int(42), Value::Double(1.0)];
+        let hits = parse_vsim_response(&resp);
+        assert_eq!(hits, vec![(42, 0.0)]);
+    }
+
+    #[test]
+    fn multiple_pairs_and_trailing_odd_element_ignored() {
+        let resp = vec![
+            Value::Int(1),
+            Value::Double(0.5),
+            Value::Int(2),
+            Value::Double(0.25),
+            Value::Int(3), // dangling id with no score → dropped
+        ];
+        let hits = parse_vsim_response(&resp);
+        assert_eq!(hits, vec![(1, 0.5), (2, 0.75)]);
+    }
+
+    #[test]
+    fn unknown_variants_fall_back_without_panicking() {
+        let resp = vec![Value::Nil, Value::Nil];
+        assert_eq!(parse_vsim_response(&resp), vec![(0, 0.0)]);
+        assert_eq!(parse_vsim_response(&[]), vec![]);
     }
 }

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -320,8 +320,15 @@ fn vsim_search(
     }
 
     let response: Vec<redis::Value> = cmd.query(conn).map_err(|e| format!("VSIM error: {}", e))?;
+    Ok(parse_vsim_response(&response))
+}
 
-    // Parse alternating [id, score, id, score, ...]
+/// Parse a `VSIM … WITHSCORES` reply — an alternating `[id, score, id, score, …]`
+/// array. IDs arrive as bulk strings (RESP2) or integers; scores as bulk strings
+/// (RESP2) or doubles (RESP3). VectorSets returns similarity (1 = identical), so
+/// each score is converted to a distance via `1.0 - score`. Unrecognized value
+/// variants fall back to `0`/`0.0` rather than panicking.
+fn parse_vsim_response(response: &[redis::Value]) -> Vec<(i64, f64)> {
     let mut results = Vec::new();
     let mut i = 0;
     while i + 1 < response.len() {
@@ -346,7 +353,54 @@ fn vsim_search(
         i += 2;
     }
 
-    Ok(results)
+    results
+}
+
+#[cfg(test)]
+mod vsim_parse_tests {
+    use super::parse_vsim_response;
+    use redis::Value;
+
+    #[test]
+    fn parses_resp2_bulk_id_and_score_as_distance() {
+        // RESP2: id + score both bulk strings; score 0.9 similarity → 0.1 distance.
+        let resp = vec![
+            Value::BulkString(b"7".to_vec()),
+            Value::BulkString(b"0.9".to_vec()),
+        ];
+        let hits = parse_vsim_response(&resp);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, 7);
+        assert!((hits[0].1 - 0.1).abs() < 1e-9, "distance={}", hits[0].1);
+    }
+
+    #[test]
+    fn parses_resp3_int_id_and_double_score() {
+        // RESP3: id as Int, score as Double similarity 1.0 → distance 0.0.
+        let resp = vec![Value::Int(42), Value::Double(1.0)];
+        let hits = parse_vsim_response(&resp);
+        assert_eq!(hits, vec![(42, 0.0)]);
+    }
+
+    #[test]
+    fn multiple_pairs_and_trailing_odd_element_ignored() {
+        let resp = vec![
+            Value::Int(1),
+            Value::Double(0.5),
+            Value::Int(2),
+            Value::Double(0.25),
+            Value::Int(3), // dangling id with no score → dropped
+        ];
+        let hits = parse_vsim_response(&resp);
+        assert_eq!(hits, vec![(1, 0.5), (2, 0.75)]);
+    }
+
+    #[test]
+    fn unknown_variants_fall_back_without_panicking() {
+        let resp = vec![Value::Nil, Value::Nil];
+        assert_eq!(parse_vsim_response(&resp), vec![(0, 0.0)]);
+        assert_eq!(parse_vsim_response(&[]), vec![]);
+    }
 }
 
 /// Single-record VADD update (for mixed benchmark).


### PR DESCRIPTION
## Summary
Upgrades the `redis` crate from **0.27.6 → 1.3.0**. It backs the Redis/RediSearch, Valkey, and VectorSets engines plus `src/redis_client.rs`.

**The 0.27 → 1.x jump is a no-op for this codebase's API surface** (researched against the redis-rs CHANGELOG + `version1.md` migration doc and confirmed by a clean build):
- The `Value::BulkString/SimpleString/Array` renames and RESP3 variants landed in **0.26**; the code already uses the new names with wildcard `_ =>` match arms, so `#[non_exhaustive]` on `Value` (added in 1.0) compiles fine.
- `Cmd/Pipeline::execute()` was **removed** in 1.0 (→ `exec()`), but this code uses it on **no** redis command — the 26 `.execute()` calls are all `postgres`.
- `Client::open`, `get_connection`, `set_read_timeout`, `cmd`/`pipe`/`query`/`.arg`/`.ignore` are unchanged.
- **No source edits were needed to compile.** Sync + `cluster` path only, so the new default async 500ms response-timeout doesn't apply.

⚠️ **redis 1.3 requires Rust ≥ 1.88 / edition 2024 in the compiler.** CI's `ubuntu-latest` runner ships a recent stable (≥ 1.9x), so it's satisfied — the check/build job confirms it.

## Added test coverage (the "high coverage" ask)
The highest-risk surface is the **manual RESP-array parsing** (a RESP2↔RESP3 shift could silently reshape responses). These parsers previously had **zero** unit tests; now covered:
- `redis_utils.rs::parse_failed_calls` — INFO COMMANDSTATS parsing (prefix/upcasing, `failed_calls`, malformed-line skipping).
- `valkey.rs` + `redis.rs` `parse_ft_search_response` / `extract_vector_score` / `redis_value_to_json` — RESP2 FT.SEARCH id/score pairs, `vector_score` lookup, `Value`→JSON for every variant **including the non-exhaustive fallthrough** (unknown variant → non-empty string, never silently dropped — the exact risk the migration flagged).
- `vectorsets.rs` — extracted the inline VSIM reply parsing into a testable `parse_vsim_response` (behavior identical) + tests for RESP2 bulk and RESP3 Int/Double shapes and the `1.0 - score` → distance conversion.

## Verification (on redis 1.3.0, against real servers)
- `make check` — fmt + **strict clippy** (`-D warnings`), 0 warnings
- **49 lib + 100 bin** unit tests (+15 new)
- **15/15** redis+vectorsets integration (redis 8.8.0), **10/10** valkey integration (valkey-bundle latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)