### PR TITLE
fix(redis,valkey): support RESP3 FT.SEARCH responses (+ dual-protocol tests)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -1171,7 +1171,9 @@ fn ft_search_knn(
         }
     }
 
-    let response: Vec<redis::Value> = cmd
+    // Query the raw Value (not Vec<Value>) so both a RESP2 array and a RESP3 map
+    // deserialize; parse_ft_search_response dispatches on the shape.
+    let response: redis::Value = cmd
         .query(conn)
         .map_err(|e| format!("FT.SEARCH error: {}", e))?;
 
@@ -1180,26 +1182,31 @@ fn ft_search_knn(
 
 /// Parse FT.SEARCH response into (id, score) pairs.
 /// Response format: [total_count, doc_id, [field_values...], doc_id, [field_values...], ...]
-fn parse_ft_search_response(response: &[redis::Value]) -> Result<Vec<(i64, f64)>, String> {
-    let mut results = Vec::new();
-    if response.is_empty() {
-        return Ok(results);
+/// Parse an FT.SEARCH reply under EITHER protocol:
+/// - RESP2: a flat array `[count, id, fields, id, fields, ...]`
+/// - RESP3: a map `{ results: [ { id, extra_attributes: { vector_score, .. }, .. } ], .. }`
+///
+/// The engine connects with RESP2 by default, but a caller can negotiate RESP3
+/// (e.g. `REDIS_URI=redis://host/?protocol=resp3`), which returns a completely
+/// different shape. Handling both keeps recall correct regardless of protocol.
+fn parse_ft_search_response(response: &redis::Value) -> Result<Vec<(i64, f64)>, String> {
+    match response {
+        redis::Value::Array(items) => Ok(parse_ft_search_resp2(items)),
+        redis::Value::Map(pairs) => Ok(parse_ft_search_resp3(pairs)),
+        // Nil (no index/empty) or any unexpected shape → no hits.
+        _ => Ok(Vec::new()),
     }
+}
 
-    // First element is total count
+/// RESP2 flat array: `[count, id, fields, id, fields, ...]`.
+fn parse_ft_search_resp2(response: &[redis::Value]) -> Vec<(i64, f64)> {
+    let mut results = Vec::new();
+    // First element is total count.
     let mut i = 1;
     while i < response.len() {
-        // doc_id
-        let id = match &response[i] {
-            redis::Value::BulkString(data) => {
-                String::from_utf8_lossy(data).parse::<i64>().unwrap_or(0)
-            }
-            redis::Value::Int(n) => *n,
-            _ => 0,
-        };
+        let id = value_as_i64(&response[i]);
         i += 1;
 
-        // field values array
         if i < response.len() {
             let score = match &response[i] {
                 redis::Value::Array(fields) => extract_vector_score(fields),
@@ -1209,8 +1216,67 @@ fn parse_ft_search_response(response: &[redis::Value]) -> Result<Vec<(i64, f64)>
             i += 1;
         }
     }
+    results
+}
 
-    Ok(results)
+/// RESP3 map: top-level map with a `results` array; each result is a map with an
+/// `id` and an `extra_attributes` map carrying `vector_score`.
+fn parse_ft_search_resp3(pairs: &[(redis::Value, redis::Value)]) -> Vec<(i64, f64)> {
+    let docs = match pairs
+        .iter()
+        .find(|(k, _)| value_as_string(k).as_deref() == Some("results"))
+        .map(|(_, v)| v)
+    {
+        Some(redis::Value::Array(docs)) => docs.as_slice(),
+        _ => return Vec::new(),
+    };
+
+    let mut out = Vec::with_capacity(docs.len());
+    for doc in docs {
+        let redis::Value::Map(fields) = doc else {
+            continue;
+        };
+        let mut id = 0i64;
+        let mut score = 0.0f64;
+        for (k, v) in fields {
+            match value_as_string(k).as_deref() {
+                Some("id") => id = value_as_string(v).and_then(|s| s.parse().ok()).unwrap_or(0),
+                Some("extra_attributes") => {
+                    if let redis::Value::Map(attrs) = v {
+                        for (ak, av) in attrs {
+                            if value_as_string(ak).as_deref() == Some("vector_score") {
+                                score = value_as_string(av)
+                                    .and_then(|s| s.parse().ok())
+                                    .unwrap_or(0.0);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        out.push((id, score));
+    }
+    out
+}
+
+/// Best-effort string view of a RESP value (BulkString/SimpleString).
+fn value_as_string(v: &redis::Value) -> Option<String> {
+    match v {
+        redis::Value::BulkString(b) => Some(String::from_utf8_lossy(b).into_owned()),
+        redis::Value::SimpleString(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Parse a RESP value as an i64 doc id (bulk/simple string or integer).
+fn value_as_i64(v: &redis::Value) -> i64 {
+    match v {
+        redis::Value::BulkString(data) => String::from_utf8_lossy(data).parse::<i64>().unwrap_or(0),
+        redis::Value::Int(n) => *n,
+        redis::Value::SimpleString(s) => s.parse().unwrap_or(0),
+        _ => 0,
+    }
 }
 
 /// Extract vector_score from field values array
@@ -1967,23 +2033,59 @@ mod tests {
     }
 
     #[test]
-    fn parse_ft_search_response_reads_id_score_pairs() {
+    fn parse_ft_search_response_resp2_reads_id_score_pairs() {
         // RESP2 FT.SEARCH shape: [count, id1, fields1, id2, fields2, ...]
-        let resp = vec![
+        let resp = Value::Array(vec![
             Value::Int(2),
             bulk("7"),
             Value::Array(vec![bulk("vector_score"), bulk("0.25")]),
             Value::Int(42),
             Value::Array(vec![bulk("vector_score"), bulk("1.5")]),
-        ];
+        ]);
+        let hits = parse_ft_search_response(&resp).unwrap();
+        assert_eq!(hits, vec![(7, 0.25), (42, 1.5)]);
+    }
+
+    #[test]
+    fn parse_ft_search_response_resp3_map_reads_results() {
+        // RESP3 FT.SEARCH shape: a map whose `results` is an array of per-doc
+        // maps with `id` + `extra_attributes` (carrying vector_score).
+        let doc = |id: &str, score: &str| {
+            Value::Map(vec![
+                (bulk("id"), bulk(id)),
+                (
+                    bulk("extra_attributes"),
+                    Value::Map(vec![(bulk("vector_score"), bulk(score))]),
+                ),
+                (bulk("values"), Value::Array(vec![])),
+            ])
+        };
+        let resp = Value::Map(vec![
+            (bulk("attributes"), Value::Array(vec![])),
+            (
+                bulk("results"),
+                Value::Array(vec![doc("7", "0.25"), doc("42", "1.5")]),
+            ),
+            (bulk("total_results"), Value::Int(2)),
+        ]);
         let hits = parse_ft_search_response(&resp).unwrap();
         assert_eq!(hits, vec![(7, 0.25), (42, 1.5)]);
     }
 
     #[test]
     fn parse_ft_search_response_empty_and_unknown_variants() {
-        assert_eq!(parse_ft_search_response(&[]).unwrap(), vec![]);
-        let resp = vec![Value::Int(1), Value::Nil, Value::Nil];
+        assert_eq!(
+            parse_ft_search_response(&Value::Array(vec![])).unwrap(),
+            vec![]
+        );
+        assert_eq!(parse_ft_search_response(&Value::Nil).unwrap(), vec![]);
+        // RESP3 map with no `results` key → no hits.
+        assert_eq!(
+            parse_ft_search_response(&Value::Map(vec![(bulk("total_results"), Value::Int(0))]))
+                .unwrap(),
+            vec![]
+        );
+        let resp = Value::Array(vec![Value::Int(1), Value::Nil, Value::Nil]);
         assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(0, 0.0)]);
     }
 

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -131,7 +131,13 @@ impl ValkeyEngine {
             _ => String::new(),
         };
 
-        let url = format!("redis://{}{}:{}/", auth_part, host, port);
+        let url = format!(
+            "redis://{}{}:{}/{}",
+            auth_part,
+            host,
+            port,
+            valkey_url_suffix()
+        );
         let client = redis::Client::open(url.as_str()).map_err(|e| e.to_string())?;
         let conn = client.get_connection().map_err(|e| e.to_string())?;
         // Safety timeout: prevents indefinite hangs from pipeline stalls.
@@ -512,7 +518,13 @@ impl ValkeyEngine {
                         (None, Some(p)) => format!(":{}@", p),
                         _ => String::new(),
                     };
-                    let url = format!("redis://{}{}:{}/", auth_part, host, port);
+                    let url = format!(
+                        "redis://{}{}:{}/{}",
+                        auth_part,
+                        host,
+                        port,
+                        valkey_url_suffix()
+                    );
                     let client = match redis::Client::open(url.as_str()) {
                         Ok(c) => c,
                         Err(_) => return,
@@ -1174,28 +1186,36 @@ fn ft_search_knn(
         }
     }
 
-    let response: Vec<redis::Value> = cmd
+    // Query the raw Value (not Vec<Value>) so both a RESP2 array and a RESP3 map
+    // deserialize; parse_ft_search_response dispatches on the shape.
+    let response: redis::Value = cmd
         .query(conn)
         .map_err(|e| format!("FT.SEARCH error: {}", e))?;
 
     parse_ft_search_response(&response)
 }
 
-fn parse_ft_search_response(response: &[redis::Value]) -> Result<Vec<(i64, f64)>, String> {
-    let mut results = Vec::new();
-    if response.is_empty() {
-        return Ok(results);
+/// Parse an FT.SEARCH reply under EITHER protocol:
+/// - RESP2: a flat array `[count, id, fields, id, fields, ...]`
+/// - RESP3: a map `{ results: [ { id, extra_attributes: { vector_score, .. }, .. } ], .. }`
+///
+/// The engine connects with RESP2 by default, but a caller can negotiate RESP3
+/// (e.g. `REDIS_URI=redis://host/?protocol=resp3`), which returns a different
+/// shape. Handling both keeps recall correct regardless of protocol.
+fn parse_ft_search_response(response: &redis::Value) -> Result<Vec<(i64, f64)>, String> {
+    match response {
+        redis::Value::Array(items) => Ok(parse_ft_search_resp2(items)),
+        redis::Value::Map(pairs) => Ok(parse_ft_search_resp3(pairs)),
+        _ => Ok(Vec::new()),
     }
+}
 
+/// RESP2 flat array: `[count, id, fields, id, fields, ...]`.
+fn parse_ft_search_resp2(response: &[redis::Value]) -> Vec<(i64, f64)> {
+    let mut results = Vec::new();
     let mut i = 1;
     while i < response.len() {
-        let id = match &response[i] {
-            redis::Value::BulkString(data) => {
-                String::from_utf8_lossy(data).parse::<i64>().unwrap_or(0)
-            }
-            redis::Value::Int(n) => *n,
-            _ => 0,
-        };
+        let id = value_as_i64(&response[i]);
         i += 1;
 
         if i < response.len() {
@@ -1207,8 +1227,81 @@ fn parse_ft_search_response(response: &[redis::Value]) -> Result<Vec<(i64, f64)>
             i += 1;
         }
     }
+    results
+}
 
-    Ok(results)
+/// RESP3 map: top-level map with a `results` array; each result is a map with an
+/// `id` and an `extra_attributes` map carrying `vector_score`.
+fn parse_ft_search_resp3(pairs: &[(redis::Value, redis::Value)]) -> Vec<(i64, f64)> {
+    let docs = match pairs
+        .iter()
+        .find(|(k, _)| value_as_string(k).as_deref() == Some("results"))
+        .map(|(_, v)| v)
+    {
+        Some(redis::Value::Array(docs)) => docs.as_slice(),
+        _ => return Vec::new(),
+    };
+
+    let mut out = Vec::with_capacity(docs.len());
+    for doc in docs {
+        let redis::Value::Map(fields) = doc else {
+            continue;
+        };
+        let mut id = 0i64;
+        let mut score = 0.0f64;
+        for (k, v) in fields {
+            match value_as_string(k).as_deref() {
+                Some("id") => id = value_as_string(v).and_then(|s| s.parse().ok()).unwrap_or(0),
+                Some("extra_attributes") => {
+                    if let redis::Value::Map(attrs) = v {
+                        for (ak, av) in attrs {
+                            if value_as_string(ak).as_deref() == Some("vector_score") {
+                                score = value_as_string(av)
+                                    .and_then(|s| s.parse().ok())
+                                    .unwrap_or(0.0);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        out.push((id, score));
+    }
+    out
+}
+
+/// Best-effort string view of a RESP value (BulkString/SimpleString).
+fn value_as_string(v: &redis::Value) -> Option<String> {
+    match v {
+        redis::Value::BulkString(b) => Some(String::from_utf8_lossy(b).into_owned()),
+        redis::Value::SimpleString(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Parse a RESP value as an i64 doc id (bulk/simple string or integer).
+fn value_as_i64(v: &redis::Value) -> i64 {
+    match v {
+        redis::Value::BulkString(data) => String::from_utf8_lossy(data).parse::<i64>().unwrap_or(0),
+        redis::Value::Int(n) => *n,
+        redis::Value::SimpleString(s) => s.parse().unwrap_or(0),
+        _ => 0,
+    }
+}
+
+/// Optional connection-URL suffix so Valkey can be benchmarked over RESP3
+/// (`VALKEY_PROTOCOL=resp3`). Defaults to RESP2 (empty suffix). The FT.SEARCH
+/// response parser handles both shapes, so recall is identical either way.
+fn valkey_url_suffix() -> &'static str {
+    if std::env::var("VALKEY_PROTOCOL")
+        .map(|v| v.eq_ignore_ascii_case("resp3"))
+        .unwrap_or(false)
+    {
+        "?protocol=resp3"
+    } else {
+        ""
+    }
 }
 
 fn extract_vector_score(fields: &[redis::Value]) -> f64 {
@@ -1455,7 +1548,13 @@ impl Engine for ValkeyEngine {
                         (None, Some(p)) => format!(":{}@", p),
                         _ => String::new(),
                     };
-                    let url = format!("redis://{}{}:{}/", auth_part, host, port);
+                    let url = format!(
+                        "redis://{}{}:{}/{}",
+                        auth_part,
+                        host,
+                        port,
+                        valkey_url_suffix()
+                    );
                     let client = match redis::Client::open(url.as_str()) {
                         Ok(c) => c,
                         Err(_) => return (t, p, r, mr, nd),
@@ -1925,24 +2024,51 @@ mod tests {
     }
 
     #[test]
-    fn parse_ft_search_response_reads_id_score_pairs() {
+    fn parse_ft_search_response_resp2_reads_id_score_pairs() {
         // RESP2 FT.SEARCH shape: [count, id1, fields1, id2, fields2, ...]
-        let resp = vec![
+        let resp = Value::Array(vec![
             Value::Int(2),
             bulk("7"),
             Value::Array(vec![bulk("vector_score"), bulk("0.25")]),
             Value::Int(42), // id may also arrive as an integer
             Value::Array(vec![bulk("vector_score"), bulk("1.5")]),
-        ];
+        ]);
+        let hits = parse_ft_search_response(&resp).unwrap();
+        assert_eq!(hits, vec![(7, 0.25), (42, 1.5)]);
+    }
+
+    #[test]
+    fn parse_ft_search_response_resp3_map_reads_results() {
+        // RESP3 FT.SEARCH shape: map with a `results` array of per-doc maps.
+        let doc = |id: &str, score: &str| {
+            Value::Map(vec![
+                (bulk("id"), bulk(id)),
+                (
+                    bulk("extra_attributes"),
+                    Value::Map(vec![(bulk("vector_score"), bulk(score))]),
+                ),
+            ])
+        };
+        let resp = Value::Map(vec![
+            (
+                bulk("results"),
+                Value::Array(vec![doc("7", "0.25"), doc("42", "1.5")]),
+            ),
+            (bulk("total_results"), Value::Int(2)),
+        ]);
         let hits = parse_ft_search_response(&resp).unwrap();
         assert_eq!(hits, vec![(7, 0.25), (42, 1.5)]);
     }
 
     #[test]
     fn parse_ft_search_response_empty_and_unknown_variants() {
-        assert_eq!(parse_ft_search_response(&[]).unwrap(), vec![]);
+        assert_eq!(
+            parse_ft_search_response(&Value::Array(vec![])).unwrap(),
+            vec![]
+        );
+        assert_eq!(parse_ft_search_response(&Value::Nil).unwrap(), vec![]);
         // A non-string/int id falls back to 0; a non-array field block → score 0.
-        let resp = vec![Value::Int(1), Value::Nil, Value::Nil];
+        let resp = Value::Array(vec![Value::Int(1), Value::Nil, Value::Nil]);
         assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(0, 0.0)]);
     }
 

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -1838,3 +1838,46 @@ fn test_binary_redis_match_any() {
     println!("redis match_any recall={:.3}", recall);
     assert!(recall >= 0.9, "redis match_any recall {:.3} < 0.9", recall);
 }
+
+/// Same filtered (`match_any`) search as above, but forces the **RESP3** protocol
+/// via `REDIS_URI=…?protocol=resp3`. RESP3 returns FT.SEARCH results as a map
+/// (`{results:[{id, extra_attributes:{vector_score}}]}`) rather than the RESP2
+/// flat array, so this exercises the RESP3 branch of the response parser
+/// end-to-end. Recall must match the RESP2 path.
+#[test]
+fn test_binary_redis_match_any_resp3() {
+    wait_for_redis();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "redis-ma-r3", "engine": "redis",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "match-any-test-r3",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+
+    let resp3_uri = format!("redis://localhost:{}/?protocol=resp3", TEST_PORT);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "redis-ma-r3",
+            "match-any-test-r3",
+            "localhost",
+            &[("REDIS_URI", &resp3_uri)],
+        ),
+        "redis match_any (RESP3) run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, "redis-ma-r3");
+    println!("redis match_any RESP3 recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "redis RESP3 match_any recall {:.3} < 0.9 — RESP3 FT.SEARCH parsing broken?",
+        recall
+    );
+}

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -1151,3 +1151,45 @@ fn test_binary_valkey_match_any() {
     println!("valkey match_any recall={:.3}", recall);
     assert!(recall >= 0.9, "valkey match_any recall {:.3} < 0.9", recall);
 }
+
+/// Same filtered (`match_any`) search as above, but over the **RESP3** protocol
+/// (`VALKEY_PROTOCOL=resp3`). Valkey Search returns FT.SEARCH results as a RESP3
+/// map rather than the RESP2 array, so this exercises the RESP3 branch of the
+/// response parser end-to-end. Recall must match the RESP2 path.
+#[test]
+fn test_binary_valkey_match_any_resp3() {
+    wait_for_valkey();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "valkey-ma-r3", "engine": "valkey",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "match-any-test-r3",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = test_port().to_string();
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "valkey-ma-r3",
+            "match-any-test-r3",
+            "127.0.0.1",
+            &[("VALKEY_PORT", port.as_str()), ("VALKEY_PROTOCOL", "resp3")],
+        ),
+        "valkey match_any (RESP3) run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, "valkey-ma-r3");
+    println!("valkey match_any RESP3 recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "valkey RESP3 match_any recall {:.3} < 0.9 — RESP3 FT.SEARCH parsing broken?",
+        recall
+    );
+}


### PR DESCRIPTION
## Why
Follow-up to the redis-rs 1.3 upgrade (#99). Question raised: *are we actually testing that RESP2 **and** RESP3 work, including filtered search?*

**Answer before this PR: no — and RESP3 was silently broken.** The engines connect RESP2 by default, but a user can negotiate RESP3 (`REDIS_URI=redis://host/?protocol=resp3`). Under RESP3, RediSearch/ValkeySearch return FT.SEARCH results as a **map** `{results:[{id, extra_attributes:{vector_score}}], …}` — a completely different shape from the RESP2 flat array. The parser only handled RESP2, so a RESP3 connection produced wrong results. **Verified: redis/random-100 recall `1.000` on RESP2 → `0.100` on RESP3.**

## Fix
`parse_ft_search_response` now takes the raw `redis::Value` and **dispatches on shape** — `Array` → RESP2, `Map` → RESP3 (reads `results[].id` + `extra_attributes.vector_score`) — in both `redis.rs` and `valkey.rs`. The query now fetches `redis::Value` instead of `Vec<redis::Value>` so both shapes deserialize. Valkey gains a `VALKEY_PROTOCOL=resp3` switch (shared URL-suffix helper) so it can be driven over RESP3 too.

## Coverage added
- **Unit tests** for both the RESP2 array and RESP3 map shapes (redis + valkey).
- **Integration tests** running the **filtered `match_any`** search over RESP3: `test_binary_redis_match_any_resp3`, `test_binary_valkey_match_any_resp3`.

## Verified end-to-end (real servers)
- Recall now **1.000 under BOTH RESP2 and RESP3** (redis 8.8.0, unfiltered KNN).
- Filtered `match_any` recall **≥ 0.9 under RESP3** on both engines.
- `make check` (fmt + strict clippy) clean; **102** bin unit tests; **redis 16/16**, **valkey 11/11** integration.

**Scope note:** VectorSets (VSIM) is RESP2-only by design (no protocol switch) and was not extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)