### PR TITLE
feat(redis,valkey): bool/uuid/full-text/datetime filter datatypes

### DIFF
--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -2216,7 +2216,10 @@ mod tests {
     #[test]
     fn datetime_tolerates_naive_and_date_only() {
         // Better than upstream (RFC-3339 only): accept naive + date-only bounds.
-        assert_eq!(datetime_to_epoch_secs("2021-01-01").map(|f| f as i64), Some(1609459200));
+        assert_eq!(
+            datetime_to_epoch_secs("2021-01-01").map(|f| f as i64),
+            Some(1609459200)
+        );
         assert_eq!(
             datetime_to_epoch_secs("2021-01-01T00:00:00").map(|f| f as i64),
             Some(1609459200)
@@ -2233,11 +2236,19 @@ mod tests {
         let (gt, _) =
             super::parse_conditions(&serde_json::json!({"and":[{"n":{"range":{"gt": 5}}}]}))
                 .unwrap();
-        assert!(gt.contains("@n:[($n_0_gt +inf]"), "gt not exclusive: {}", gt);
+        assert!(
+            gt.contains("@n:[($n_0_gt +inf]"),
+            "gt not exclusive: {}",
+            gt
+        );
         let (gte, _) =
             super::parse_conditions(&serde_json::json!({"and":[{"n":{"range":{"gte": 5}}}]}))
                 .unwrap();
-        assert!(gte.contains("@n:[$n_0_gte +inf]") && !gte.contains("[("), "gte: {}", gte);
+        assert!(
+            gte.contains("@n:[$n_0_gte +inf]") && !gte.contains("[("),
+            "gte: {}",
+            gte
+        );
     }
 
     #[test]
@@ -2246,7 +2257,11 @@ mod tests {
         let (q, params) =
             super::parse_conditions(&serde_json::json!({"and":[{"n":{"range":{"gte": "nope"}}}]}))
                 .unwrap_or_default();
-        assert!(!q.contains("$n_0_gte") || params.contains_key("n_0_gte"), "dangling: {}", q);
+        assert!(
+            !q.contains("$n_0_gte") || params.contains_key("n_0_gte"),
+            "dangling: {}",
+            q
+        );
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -980,25 +980,25 @@ fn build_range_filter(
     let mut params = HashMap::new();
     let mut clauses = Vec::new();
 
-    if let Some(lt) = criteria.get("lt") {
-        let pname = format!("{}_lt", param_prefix);
-        insert_number_param(&mut params, &pname, lt);
-        clauses.push(format!("@{}:[-inf (${}]", field_name, pname));
-    }
-    if let Some(gt) = criteria.get("gt") {
-        let pname = format!("{}_gt", param_prefix);
-        insert_number_param(&mut params, &pname, gt);
-        clauses.push(format!("@{}:[${} +inf]", field_name, pname));
-    }
-    if let Some(lte) = criteria.get("lte") {
-        let pname = format!("{}_lte", param_prefix);
-        insert_number_param(&mut params, &pname, lte);
-        clauses.push(format!("@{}:[-inf ${}]", field_name, pname));
-    }
-    if let Some(gte) = criteria.get("gte") {
-        let pname = format!("{}_gte", param_prefix);
-        insert_number_param(&mut params, &pname, gte);
-        clauses.push(format!("@{}:[${} +inf]", field_name, pname));
+    // (suffix, condition key, clause template). `gt` is EXCLUSIVE (`[($p +inf]`),
+    // `gte` inclusive; `lt` exclusive, `lte` inclusive.
+    let bounds = [
+        ("lt", "lt", "@{f}:[-inf (${p}]"),
+        ("gt", "gt", "@{f}:[(${p} +inf]"),
+        ("lte", "lte", "@{f}:[-inf ${p}]"),
+        ("gte", "gte", "@{f}:[${p} +inf]"),
+    ];
+    for (key, suffix, tmpl) in bounds {
+        if let Some(v) = criteria.get(key) {
+            let pname = format!("{}_{}", param_prefix, suffix);
+            insert_number_param(&mut params, &pname, v);
+            // Only emit the clause when the bound actually parsed into a param —
+            // otherwise a `$param` with no PARAMS entry makes FT.SEARCH
+            // hard-error ("Parameter not found").
+            if params.contains_key(&pname) {
+                clauses.push(tmpl.replace("{f}", field_name).replace("{p}", &pname));
+            }
+        }
     }
 
     if clauses.is_empty() {
@@ -1445,9 +1445,22 @@ fn datetime_fields_from_schema(dataset: &Dataset) -> HashSet<String> {
 /// for non-datetime strings (e.g. a plain numeric-epoch string), letting callers
 /// fall back to numeric handling.
 fn datetime_to_epoch_secs(s: &str) -> Option<f64> {
-    chrono::DateTime::parse_from_rfc3339(s)
-        .ok()
-        .map(|dt| dt.timestamp() as f64)
+    // RFC-3339 (with offset / `Z`) first.
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Some(dt.timestamp() as f64);
+    }
+    // Naive datetime (no offset) → interpret as UTC. Accepts both the `T` and
+    // space separators (upstream tolerates these; RFC-3339 does not).
+    for fmt in ["%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"] {
+        if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(s, fmt) {
+            return Some(ndt.and_utc().timestamp() as f64);
+        }
+    }
+    // Date only → midnight UTC.
+    if let Ok(nd) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        return Some(nd.and_hms_opt(0, 0, 0)?.and_utc().timestamp() as f64);
+    }
+    None
 }
 
 // ── Engine trait implementation ──────────────────────────────────────────
@@ -2198,6 +2211,42 @@ mod tests {
         );
         assert!(datetime_to_epoch_secs("not-a-date").is_none());
         assert!(datetime_to_epoch_secs("1609459200").is_none());
+    }
+
+    #[test]
+    fn datetime_tolerates_naive_and_date_only() {
+        // Better than upstream (RFC-3339 only): accept naive + date-only bounds.
+        assert_eq!(datetime_to_epoch_secs("2021-01-01").map(|f| f as i64), Some(1609459200));
+        assert_eq!(
+            datetime_to_epoch_secs("2021-01-01T00:00:00").map(|f| f as i64),
+            Some(1609459200)
+        );
+        assert_eq!(
+            datetime_to_epoch_secs("2021-01-01 00:00:00").map(|f| f as i64),
+            Some(1609459200)
+        );
+    }
+
+    #[test]
+    fn range_gt_is_exclusive_gte_inclusive() {
+        // gt must be exclusive `[($p +inf]`; gte inclusive `[$p +inf]`.
+        let (gt, _) =
+            super::parse_conditions(&serde_json::json!({"and":[{"n":{"range":{"gt": 5}}}]}))
+                .unwrap();
+        assert!(gt.contains("@n:[($n_0_gt +inf]"), "gt not exclusive: {}", gt);
+        let (gte, _) =
+            super::parse_conditions(&serde_json::json!({"and":[{"n":{"range":{"gte": 5}}}]}))
+                .unwrap();
+        assert!(gte.contains("@n:[$n_0_gte +inf]") && !gte.contains("[("), "gte: {}", gte);
+    }
+
+    #[test]
+    fn range_unparseable_bound_emits_no_dangling_param() {
+        // A bound that can't parse must NOT leave a `$param` with no PARAMS entry.
+        let (q, params) =
+            super::parse_conditions(&serde_json::json!({"and":[{"n":{"range":{"gte": "nope"}}}]}))
+                .unwrap_or_default();
+        assert!(!q.contains("$n_0_gte") || params.contains_key("n_0_gte"), "dangling: {}", q);
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -1057,7 +1057,11 @@ fn insert_number_param(
         params.insert(name.to_string(), FilterParamValue::Float(f));
     } else if let Some(s) = value.as_str() {
         if let Some(epoch) = datetime_to_epoch_secs(s) {
-            params.insert(name.to_string(), FilterParamValue::Float(epoch));
+            // Epoch is whole seconds — emit as an integer param (more robust than
+            // a float across RediSearch/ValkeySearch NUMERIC param substitution).
+            params.insert(name.to_string(), FilterParamValue::Int(epoch as i64));
+        } else if let Ok(i) = s.parse::<i64>() {
+            params.insert(name.to_string(), FilterParamValue::Int(i));
         } else if let Ok(f) = s.parse::<f64>() {
             params.insert(name.to_string(), FilterParamValue::Float(f));
         }
@@ -2164,12 +2168,15 @@ mod tests {
         assert!(q.contains("@ts:[$ts_0_gte +inf]"), "q={}", q);
         assert!(q.contains("@ts:[-inf ($ts_0_lt]"), "q={}", q);
         // 2021-01-01T00:00:00Z == 1609459200, 2022-01-01T00:00:00Z == 1640995200.
-        assert!(
-            matches!(params.get("ts_0_gte"), Some(FilterParamValue::Float(f)) if (*f - 1609459200.0).abs() < 1.0)
-        );
-        assert!(
-            matches!(params.get("ts_0_lt"), Some(FilterParamValue::Float(f)) if (*f - 1640995200.0).abs() < 1.0)
-        );
+        // Emitted as integer epoch params.
+        assert!(matches!(
+            params.get("ts_0_gte"),
+            Some(FilterParamValue::Int(1609459200))
+        ));
+        assert!(matches!(
+            params.get("ts_0_lt"),
+            Some(FilterParamValue::Int(1640995200))
+        ));
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -2,7 +2,7 @@
 //!
 //! Implements the Engine trait for RediSearch vector similarity.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -31,6 +31,12 @@ pub struct RedisEngineConfig {
     pub batch_size: usize,
     pub parallel: usize,
     pub skip_vector_index: bool,
+    /// Schema field names declared as `datetime`. Values for these fields are
+    /// ISO-8601 strings in the payload; they are converted to epoch seconds at
+    /// HSET time so the NUMERIC index/range filters match. Populated in
+    /// `configure()` from the dataset schema. Wrapped in `Arc` so the per-thread
+    /// config clones share one set.
+    pub datetime_fields: Arc<HashSet<String>>,
 }
 
 pub struct RedisEngine {
@@ -91,6 +97,7 @@ impl RedisEngine {
                 batch_size,
                 parallel,
                 skip_vector_index: engine_config.skip_vector_index,
+                datetime_fields: Arc::new(HashSet::new()),
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             commandstats_baseline: None,
@@ -152,7 +159,11 @@ impl RedisEngine {
                 for (field_name, field_type) in schema_obj {
                     let ft = field_type.as_str().unwrap_or("");
                     match ft {
-                        "keyword" => {
+                        // keyword/uuid/bool are all exact-match TAG fields.
+                        // uuid & bool values are single tokens (a UUID string, or
+                        // "true"/"false"); SEPARATOR ; + SORTABLE UNF matches the
+                        // keyword treatment so exact TAG matching works.
+                        "keyword" | "uuid" | "bool" => {
                             cmd.arg(field_name)
                                 .arg("TAG")
                                 .arg("SEPARATOR")
@@ -161,6 +172,12 @@ impl RedisEngine {
                                 .arg("UNF");
                         }
                         "int" | "float" => {
+                            cmd.arg(field_name).arg("NUMERIC").arg("SORTABLE");
+                        }
+                        // datetime is stored as epoch seconds (see upload) and
+                        // indexed NUMERIC so range filters work with either ISO or
+                        // numeric bounds.
+                        "datetime" => {
                             cmd.arg(field_name).arg("NUMERIC").arg("SORTABLE");
                         }
                         "text" => {
@@ -666,7 +683,10 @@ fn upload_batch_internal(
             for (k, v) in &meta.fields {
                 match v {
                     MetadataValue::String(s) => {
-                        fields.push((k.as_bytes().to_vec(), s.as_bytes().to_vec()));
+                        fields.push((
+                            k.as_bytes().to_vec(),
+                            encode_string_field(config, k, s).into_bytes(),
+                        ));
                     }
                     MetadataValue::Labels(labels) => {
                         fields.push((k.as_bytes().to_vec(), labels.join(";").into_bytes()));
@@ -786,9 +806,12 @@ fn build_filter(
 ) -> Option<ParsedFilter> {
     match condition_type {
         "match" => {
-            // match_any (IN-list) takes precedence over exact {value}.
+            // match_any (IN-list) takes precedence over exact {value}, which
+            // takes precedence over full-text {text}.
             if let Some(any) = criteria.get("any").and_then(|v| v.as_array()) {
                 Some(build_match_any_filter(field_name, any, counter))
+            } else if let Some(text) = criteria.get("text").and_then(|v| v.as_str()) {
+                Some(build_text_filter(field_name, text, counter))
             } else {
                 build_exact_match_filter(field_name, criteria, counter)
             }
@@ -883,6 +906,15 @@ fn build_exact_match_filter(
 
     let mut params = HashMap::new();
 
+    // bool → TAG match on the literal "true"/"false" token. Checked before the
+    // numeric arms because serde treats JSON `true`/`false` as neither i64 nor
+    // f64 (and never as a string).
+    if let Some(b) = value.as_bool() {
+        let token = if b { "true" } else { "false" };
+        params.insert(param_name.clone(), FilterParamValue::Str(token.to_string()));
+        return Some((format!("@{}:{{${}}}", field_name, param_name), params));
+    }
+
     if let Some(s) = value.as_str() {
         params.insert(param_name.clone(), FilterParamValue::Str(s.to_string()));
         Some((format!("@{}:{{${}}}", field_name, param_name), params))
@@ -901,6 +933,39 @@ fn build_exact_match_filter(
     } else {
         None
     }
+}
+
+/// Build a full-text filter over a TEXT field: `@field:($param)`.
+///
+/// The search terms are passed as a single Str param (DIALECT 2 substitutes it
+/// into the text-search context), so RediSearch tokenizes and matches them
+/// against the indexed TEXT field. An empty/blank query would be invalid text
+/// syntax, so it degrades to a never-match `(@f:($p) -@f:($p))` contradiction
+/// rather than an empty clause (which, as the sole prefilter, would run kNN over
+/// ALL docs — the inverse of the intended filter).
+fn build_text_filter(field_name: &str, text: &str, counter: &mut usize) -> ParsedFilter {
+    let param_name = format!("{}_{}", field_name, counter);
+    *counter += 1;
+
+    let mut params = HashMap::new();
+    let trimmed = text.trim();
+
+    if trimmed.is_empty() {
+        params.insert(
+            param_name.clone(),
+            FilterParamValue::Str("__text_never_match__".to_string()),
+        );
+        return (
+            format!("(@{0}:(${1}) -@{0}:(${1}))", field_name, param_name),
+            params,
+        );
+    }
+
+    params.insert(
+        param_name.clone(),
+        FilterParamValue::Str(trimmed.to_string()),
+    );
+    (format!("@{}:(${})", field_name, param_name), params)
 }
 
 /// Build range filter: @field:[-inf ($param_lt], @field:[($param_gt +inf], etc.
@@ -971,7 +1036,16 @@ fn build_geo_filter(
     ))
 }
 
-/// Insert a JSON number value into the params map.
+/// Insert a JSON number (or ISO-8601 datetime / numeric string) into the params
+/// map as a NUMERIC bound.
+///
+/// - integer / float JSON → the numeric value.
+/// - ISO-8601 string → epoch **seconds** (datetime range bound). This lets a
+///   `datetime` field be filtered with ISO bounds, e.g.
+///   `{"range":{"gte":"2021-01-01T00:00:00Z"}}`.
+/// - other numeric string → parsed as f64 (accepts a numeric-epoch bound too, so
+///   both ISO and raw-epoch datetime bounds work — better than upstream's
+///   ISO-only handling).
 fn insert_number_param(
     params: &mut HashMap<String, FilterParamValue>,
     name: &str,
@@ -981,6 +1055,12 @@ fn insert_number_param(
         params.insert(name.to_string(), FilterParamValue::Int(i));
     } else if let Some(f) = value.as_f64() {
         params.insert(name.to_string(), FilterParamValue::Float(f));
+    } else if let Some(s) = value.as_str() {
+        if let Some(epoch) = datetime_to_epoch_secs(s) {
+            params.insert(name.to_string(), FilterParamValue::Float(epoch));
+        } else if let Ok(f) = s.parse::<f64>() {
+            params.insert(name.to_string(), FilterParamValue::Float(f));
+        }
     }
 }
 
@@ -1314,7 +1394,7 @@ fn hset_single(
         for (k, v) in &meta.fields {
             match v {
                 MetadataValue::String(s) => {
-                    cmd.arg(k.as_str()).arg(s.as_str());
+                    cmd.arg(k.as_str()).arg(encode_string_field(config, k, s));
                 }
                 MetadataValue::Labels(labels) => {
                     cmd.arg(k.as_str()).arg(labels.join(";"));
@@ -1331,6 +1411,41 @@ fn hset_single(
         .map_err(|e| format!("HSET update error: {}", e))
 }
 
+/// Format a string metadata field for storage. `datetime` schema fields whose
+/// value is an ISO-8601 string are converted to epoch seconds so the NUMERIC
+/// index/range filters match; every other field is stored verbatim. A value
+/// that is already numeric (epoch) is left as-is (RFC3339 parse fails → raw).
+fn encode_string_field(config: &RedisEngineConfig, key: &str, value: &str) -> String {
+    if config.datetime_fields.contains(key) {
+        if let Some(epoch) = datetime_to_epoch_secs(value) {
+            return (epoch as i64).to_string();
+        }
+    }
+    value.to_string()
+}
+
+/// Collect the schema field names typed `datetime`.
+fn datetime_fields_from_schema(dataset: &Dataset) -> HashSet<String> {
+    let mut set = HashSet::new();
+    if let Some(schema) = dataset.config.schema.as_ref().and_then(|s| s.as_object()) {
+        for (field, ty) in schema {
+            if ty.as_str() == Some("datetime") {
+                set.insert(field.clone());
+            }
+        }
+    }
+    set
+}
+
+/// Parse an ISO-8601 / RFC 3339 timestamp to epoch **seconds**. Returns `None`
+/// for non-datetime strings (e.g. a plain numeric-epoch string), letting callers
+/// fall back to numeric handling.
+fn datetime_to_epoch_secs(s: &str) -> Option<f64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp() as f64)
+}
+
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for RedisEngine {
@@ -1344,6 +1459,10 @@ impl Engine for RedisEngine {
 
     fn configure(&mut self, dataset: &Dataset) -> Result<(), String> {
         let mut conn = self.get_connection()?;
+
+        // Record which schema fields are `datetime` so upload can convert their
+        // ISO-8601 payload values to epoch seconds for the NUMERIC index.
+        self.config.datetime_fields = Arc::new(datetime_fields_from_schema(dataset));
 
         if self.config.skip_vector_index {
             println!("Skipping vector index (filter-only mode)");
@@ -1988,6 +2107,115 @@ mod tests {
         let (q, params) = parse_conditions(&cond).unwrap();
         assert!(q.contains("@color:{$color_0}"), "q={}", q);
         assert!(matches!(params.get("color_0"), Some(FilterParamValue::Str(s)) if s == "red"));
+    }
+
+    // ── New filter datatypes: bool / uuid / full-text / datetime ───────────
+    use super::{datetime_to_epoch_secs, encode_string_field, RedisEngineConfig};
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    #[test]
+    fn match_bool_true_emits_tag_true_token() {
+        let cond = serde_json::json!({"and":[{"flag":{"match":{"value": true}}}]});
+        let (q, params) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@flag:{$flag_0}"), "q={}", q);
+        assert!(matches!(params.get("flag_0"), Some(FilterParamValue::Str(s)) if s == "true"));
+    }
+
+    #[test]
+    fn match_bool_false_emits_tag_false_token() {
+        let cond = serde_json::json!({"and":[{"flag":{"match":{"value": false}}}]});
+        let (_q, params) = parse_conditions(&cond).unwrap();
+        assert!(matches!(params.get("flag_0"), Some(FilterParamValue::Str(s)) if s == "false"));
+    }
+
+    #[test]
+    fn match_uuid_value_emits_tag_param() {
+        // uuid is a keyword-style string → TAG param match.
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let cond = serde_json::json!({"and":[{"uid":{"match":{"value": uuid}}}]});
+        let (q, params) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@uid:{$uid_0}"), "q={}", q);
+        assert!(matches!(params.get("uid_0"), Some(FilterParamValue::Str(s)) if s == uuid));
+    }
+
+    #[test]
+    fn match_text_emits_fulltext_clause() {
+        let cond = serde_json::json!({"and":[{"body":{"match":{"text": "quick"}}}]});
+        let (q, params) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@body:($body_0)"), "q={}", q);
+        assert!(matches!(params.get("body_0"), Some(FilterParamValue::Str(s)) if s == "quick"));
+    }
+
+    #[test]
+    fn match_text_empty_is_never_match() {
+        let cond = serde_json::json!({"and":[{"body":{"match":{"text": "   "}}}]});
+        let (q, _) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("-@body:("), "expected never-match, q={}", q);
+    }
+
+    #[test]
+    fn range_datetime_iso_bounds_parse_to_epoch() {
+        let cond = serde_json::json!({"and":[{"ts":{"range":{
+            "gte": "2021-01-01T00:00:00Z",
+            "lt":  "2022-01-01T00:00:00Z"
+        }}}]});
+        let (q, params) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@ts:[$ts_0_gte +inf]"), "q={}", q);
+        assert!(q.contains("@ts:[-inf ($ts_0_lt]"), "q={}", q);
+        // 2021-01-01T00:00:00Z == 1609459200, 2022-01-01T00:00:00Z == 1640995200.
+        assert!(
+            matches!(params.get("ts_0_gte"), Some(FilterParamValue::Float(f)) if (*f - 1609459200.0).abs() < 1.0)
+        );
+        assert!(
+            matches!(params.get("ts_0_lt"), Some(FilterParamValue::Float(f)) if (*f - 1640995200.0).abs() < 1.0)
+        );
+    }
+
+    #[test]
+    fn range_datetime_numeric_epoch_bounds_still_work() {
+        // Numeric-epoch bounds (better-than-upstream: upstream is ISO-only).
+        let cond = serde_json::json!({"and":[{"ts":{"range":{"gte": 1609459200}}}]});
+        let (_q, params) = parse_conditions(&cond).unwrap();
+        assert!(matches!(
+            params.get("ts_0_gte"),
+            Some(FilterParamValue::Int(1609459200))
+        ));
+    }
+
+    #[test]
+    fn datetime_to_epoch_secs_parses_rfc3339_and_rejects_plain() {
+        assert_eq!(
+            datetime_to_epoch_secs("2021-01-01T00:00:00Z").map(|f| f as i64),
+            Some(1609459200)
+        );
+        assert!(datetime_to_epoch_secs("not-a-date").is_none());
+        assert!(datetime_to_epoch_secs("1609459200").is_none());
+    }
+
+    #[test]
+    fn encode_string_field_converts_datetime_and_passes_through_others() {
+        let mut dt = HashSet::new();
+        dt.insert("ts".to_string());
+        let cfg = RedisEngineConfig {
+            m: 16,
+            ef_construction: 128,
+            data_type: "FLOAT32".to_string(),
+            algorithm: "hnsw".to_string(),
+            batch_size: 1,
+            parallel: 1,
+            skip_vector_index: false,
+            datetime_fields: Arc::new(dt),
+        };
+        // datetime field → epoch seconds string
+        assert_eq!(
+            encode_string_field(&cfg, "ts", "2021-01-01T00:00:00Z"),
+            "1609459200"
+        );
+        // datetime field already numeric epoch → left as-is
+        assert_eq!(encode_string_field(&cfg, "ts", "1609459200"), "1609459200");
+        // non-datetime field → verbatim
+        assert_eq!(encode_string_field(&cfg, "color", "red"), "red");
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -917,17 +917,19 @@ fn build_match_any_filter(
     any: &[serde_json::Value],
     counter: &mut usize,
 ) -> ParsedFilter {
-    let mut params = HashMap::new();
+    // All values on the match_any path are inlined (valkey supports neither
+    // $param in TAG {…} nor in NUMERIC […]); params stays empty.
+    let params = HashMap::new();
 
     if !any.is_empty() && any.iter().all(|v| v.is_i64()) {
         let clauses: Vec<String> = any
             .iter()
             .filter_map(|v| v.as_i64())
             .map(|i| {
-                let p = format!("{}_{}", field_name, counter);
+                // Inline the literal — valkey rejects `$param` inside NUMERIC
+                // brackets (see build_range_filter).
                 *counter += 1;
-                params.insert(p.clone(), FilterParamValue::Int(i));
-                format!("@{}:[${} ${}]", field_name, p, p)
+                format!("@{}:[{} {}]", field_name, i, i)
             })
             .collect();
         return (format!("({})", clauses.join(" | ")), params);
@@ -960,39 +962,34 @@ fn build_exact_match_filter(
     counter: &mut usize,
 ) -> Option<ParsedFilter> {
     let value = criteria.get("value")?;
-    let param_name = format!("{}_{}", field_name, counter);
+    // Bump the counter for param-name parity with sibling filters — every value
+    // here is INLINED: Valkey Search supports neither `$param` inside TAG {…} nor
+    // inside NUMERIC […] brackets, so params are never used on this path.
     *counter += 1;
+    let params = HashMap::new();
 
-    let mut params = HashMap::new();
-
-    // bool → inlined TAG match on the literal "true"/"false" token. Checked
-    // before numeric arms (serde bools are neither i64 nor f64 nor str).
+    // bool → inlined TAG match on the literal "true"/"false" token (no escaping
+    // needed). Checked before numeric arms (serde bools are neither i64/f64/str).
     if let Some(b) = value.as_bool() {
         let token = if b { "true" } else { "false" };
         return Some((format!("@{}:{{{}}}", field_name, token), params));
     }
-
+    // keyword/uuid string → inlined, ESCAPED TAG match (must escape TAG
+    // metacharacters `| { } ( ) space \` exactly like build_match_any_filter /
+    // build_text_filter, else a value with those chars yields a malformed query
+    // or the wrong document set).
     if let Some(s) = value.as_str() {
-        // Valkey Search does not support $param references inside TAG {…}
-        // brackets, and does NOT require backslash-escaping of spaces, dots,
-        // or other special characters. Values are passed raw inside {…}.
-        // (uuid strings are handled here too — a uuid is just a keyword.)
-        Some((format!("@{}:{{{}}}", field_name, s), params))
-    } else if let Some(i) = value.as_i64() {
-        params.insert(param_name.clone(), FilterParamValue::Int(i));
-        Some((
-            format!("@{}:[${} ${}]", field_name, param_name, param_name),
+        return Some((
+            format!("@{}:{{{}}}", field_name, escape_tag_value(s)),
             params,
-        ))
-    } else if let Some(f) = value.as_f64() {
-        params.insert(param_name.clone(), FilterParamValue::Float(f));
-        Some((
-            format!("@{}:[${} ${}]", field_name, param_name, param_name),
-            params,
-        ))
-    } else {
-        None
+        ));
     }
+    // numeric (int/float) → inlined NUMERIC point range `[v v]` (literals, not
+    // `$param`, for the same reason as build_range_filter).
+    if let Some(lit) = number_literal(value) {
+        return Some((format!("@{}:[{} {}]", field_name, lit, lit), params));
+    }
+    None
 }
 
 /// Build a full-text filter — DEGRADED on Valkey Search (no TEXT field type) to
@@ -1520,9 +1517,22 @@ fn schema_transform_fields(dataset: &Dataset) -> (HashSet<String>, HashSet<Strin
 /// for non-datetime strings (e.g. a numeric-epoch string), letting callers fall
 /// back to numeric handling.
 fn datetime_to_epoch_secs(s: &str) -> Option<f64> {
-    chrono::DateTime::parse_from_rfc3339(s)
-        .ok()
-        .map(|dt| dt.timestamp() as f64)
+    // RFC-3339 (with offset / `Z`) first.
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Some(dt.timestamp() as f64);
+    }
+    // Naive datetime (no offset) → interpret as UTC. Accepts both the `T` and
+    // space separators (upstream tolerates these; RFC-3339 does not).
+    for fmt in ["%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"] {
+        if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(s, fmt) {
+            return Some(ndt.and_utc().timestamp() as f64);
+        }
+    }
+    // Date only → midnight UTC.
+    if let Ok(nd) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        return Some(nd.and_hms_opt(0, 0, 0)?.and_utc().timestamp() as f64);
+    }
+    None
 }
 
 // ── Engine trait implementation ──────────────────────────────────────────
@@ -2129,7 +2139,7 @@ impl Engine for ValkeyEngine {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_conditions, FilterParamValue};
+    use super::parse_conditions;
 
     #[test]
     fn match_any_string_list_emits_inlined_tag_or() {
@@ -2142,13 +2152,11 @@ mod tests {
     #[test]
     fn match_any_int_list_emits_numeric_or() {
         let cond = serde_json::json!({"and":[{"size":{"match":{"any":[1,2]}}}]});
+        // Valkey inlines NUMERIC literals (no $param inside […] brackets).
         let (q, params) = parse_conditions(&cond).unwrap();
-        assert!(q.contains("@size:[$size_0 $size_0]"), "q={}", q);
-        assert!(q.contains("@size:[$size_1 $size_1]"), "q={}", q);
-        assert!(matches!(
-            params.get("size_0"),
-            Some(FilterParamValue::Int(1))
-        ));
+        assert!(q.contains("@size:[1 1]"), "q={}", q);
+        assert!(q.contains("@size:[2 2]"), "q={}", q);
+        assert!(!params.keys().any(|k| k.starts_with("size_")), "no params");
     }
 
     #[test]
@@ -2233,6 +2241,43 @@ mod tests {
         let cond = serde_json::json!({"and":[{"ts":{"range":{"gte": 1609459200}}}]});
         let (q, _params) = parse_conditions(&cond).unwrap();
         assert!(q.contains("@ts:[1609459200 +inf]"), "q={}", q);
+    }
+
+    #[test]
+    fn range_gt_is_exclusive_gte_inclusive() {
+        // gt must be exclusive `[(v +inf]`; gte inclusive `[v +inf]`.
+        let gt = parse_conditions(&serde_json::json!({"and":[{"n":{"range":{"gt": 5}}}]}))
+            .unwrap()
+            .0;
+        assert!(gt.contains("@n:[(5 +inf]"), "gt not exclusive: {}", gt);
+        let gte = parse_conditions(&serde_json::json!({"and":[{"n":{"range":{"gte": 5}}}]}))
+            .unwrap()
+            .0;
+        assert!(gte.contains("@n:[5 +inf]") && !gte.contains("(5"), "gte: {}", gte);
+    }
+
+    #[test]
+    fn datetime_tolerates_naive_and_date_only() {
+        assert_eq!(datetime_to_epoch_secs("2021-01-01").map(|f| f as i64), Some(1609459200));
+        assert_eq!(
+            datetime_to_epoch_secs("2021-01-01T00:00:00").map(|f| f as i64),
+            Some(1609459200)
+        );
+        assert_eq!(
+            datetime_to_epoch_secs("2021-01-01 00:00:00").map(|f| f as i64),
+            Some(1609459200)
+        );
+    }
+
+    #[test]
+    fn two_field_and_combines_both_clauses() {
+        let cond = serde_json::json!({"and":[
+            {"color":{"match":{"value":"red"}}},
+            {"size":{"range":{"gte": 10}}}
+        ]});
+        let (q, _) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@color:{red}"), "q={}", q);
+        assert!(q.contains("@size:[10 +inf]"), "q={}", q);
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -1029,38 +1029,51 @@ fn build_range_filter(
     criteria: &serde_json::Value,
     counter: &mut usize,
 ) -> Option<ParsedFilter> {
-    let param_prefix = format!("{}_{}", field_name, counter);
+    // Bump the counter for param-name parity with sibling filters even though the
+    // bounds are INLINED: Valkey Search does not substitute `$param` inside
+    // NUMERIC range brackets (`@f:[$p +inf]` → "Invalid number"); only literal
+    // numbers are accepted there (unlike RediSearch). Bounds are numbers /
+    // epochs from trusted dataset conditions, so inlining is safe.
     *counter += 1;
 
-    let mut params = HashMap::new();
     let mut clauses = Vec::new();
-
-    if let Some(lt) = criteria.get("lt") {
-        let pname = format!("{}_lt", param_prefix);
-        insert_number_param(&mut params, &pname, lt);
-        clauses.push(format!("@{}:[-inf (${}]", field_name, pname));
+    if let Some(v) = criteria.get("lt").and_then(number_literal) {
+        clauses.push(format!("@{}:[-inf ({}]", field_name, v));
     }
-    if let Some(gt) = criteria.get("gt") {
-        let pname = format!("{}_gt", param_prefix);
-        insert_number_param(&mut params, &pname, gt);
-        clauses.push(format!("@{}:[${} +inf]", field_name, pname));
+    if let Some(v) = criteria.get("gt").and_then(number_literal) {
+        clauses.push(format!("@{}:[({} +inf]", field_name, v));
     }
-    if let Some(lte) = criteria.get("lte") {
-        let pname = format!("{}_lte", param_prefix);
-        insert_number_param(&mut params, &pname, lte);
-        clauses.push(format!("@{}:[-inf ${}]", field_name, pname));
+    if let Some(v) = criteria.get("lte").and_then(number_literal) {
+        clauses.push(format!("@{}:[-inf {}]", field_name, v));
     }
-    if let Some(gte) = criteria.get("gte") {
-        let pname = format!("{}_gte", param_prefix);
-        insert_number_param(&mut params, &pname, gte);
-        clauses.push(format!("@{}:[${} +inf]", field_name, pname));
+    if let Some(v) = criteria.get("gte").and_then(number_literal) {
+        clauses.push(format!("@{}:[{} +inf]", field_name, v));
     }
 
     if clauses.is_empty() {
         return None;
     }
+    Some((clauses.join(" "), HashMap::new()))
+}
 
-    Some((clauses.join(" "), params))
+/// Render a JSON number / ISO-8601 datetime / numeric string as a literal NUMERIC
+/// bound (integers verbatim, ISO-8601 → epoch seconds, numeric strings as-is).
+fn number_literal(value: &serde_json::Value) -> Option<String> {
+    if let Some(i) = value.as_i64() {
+        Some(i.to_string())
+    } else if let Some(f) = value.as_f64() {
+        Some(format!("{}", f))
+    } else if let Some(s) = value.as_str() {
+        if let Some(epoch) = datetime_to_epoch_secs(s) {
+            Some((epoch as i64).to_string())
+        } else if s.parse::<f64>().is_ok() {
+            Some(s.to_string())
+        } else {
+            None
+        }
+    } else {
+        None
+    }
 }
 
 fn build_geo_filter(
@@ -1105,7 +1118,13 @@ fn insert_number_param(
         params.insert(name.to_string(), FilterParamValue::Float(f));
     } else if let Some(s) = value.as_str() {
         if let Some(epoch) = datetime_to_epoch_secs(s) {
-            params.insert(name.to_string(), FilterParamValue::Float(epoch));
+            // Epoch is whole seconds — emit as an integer param. Valkey Search's
+            // NUMERIC-range param substitution rejects the float rendering
+            // ("Invalid number"), whereas integer params are accepted (as the
+            // match_any NUMERIC path already relies on).
+            params.insert(name.to_string(), FilterParamValue::Int(epoch as i64));
+        } else if let Ok(i) = s.parse::<i64>() {
+            params.insert(name.to_string(), FilterParamValue::Int(i));
         } else if let Ok(f) = s.parse::<f64>() {
             params.insert(name.to_string(), FilterParamValue::Float(f));
         }
@@ -2195,30 +2214,25 @@ mod tests {
     }
 
     #[test]
-    fn range_datetime_iso_bounds_parse_to_epoch() {
+    fn range_datetime_iso_bounds_inline_epoch() {
         let cond = serde_json::json!({"and":[{"ts":{"range":{
             "gte": "2021-01-01T00:00:00Z",
             "lt":  "2022-01-01T00:00:00Z"
         }}}]});
+        // 2021-01-01T00:00:00Z == 1609459200, 2022-01-01T00:00:00Z == 1640995200.
+        // Valkey doesn't substitute $param in NUMERIC brackets → bounds are
+        // inlined as integer epochs; no params emitted for the range.
         let (q, params) = parse_conditions(&cond).unwrap();
-        assert!(q.contains("@ts:[$ts_0_gte +inf]"), "q={}", q);
-        assert!(q.contains("@ts:[-inf ($ts_0_lt]"), "q={}", q);
-        assert!(
-            matches!(params.get("ts_0_gte"), Some(FilterParamValue::Float(f)) if (*f - 1609459200.0).abs() < 1.0)
-        );
-        assert!(
-            matches!(params.get("ts_0_lt"), Some(FilterParamValue::Float(f)) if (*f - 1640995200.0).abs() < 1.0)
-        );
+        assert!(q.contains("@ts:[1609459200 +inf]"), "q={}", q);
+        assert!(q.contains("@ts:[-inf (1640995200]"), "q={}", q);
+        assert!(!params.keys().any(|k| k.starts_with("ts_")), "no range params");
     }
 
     #[test]
-    fn range_datetime_numeric_epoch_bounds_still_work() {
+    fn range_datetime_numeric_epoch_bounds_inline() {
         let cond = serde_json::json!({"and":[{"ts":{"range":{"gte": 1609459200}}}]});
-        let (_q, params) = parse_conditions(&cond).unwrap();
-        assert!(matches!(
-            params.get("ts_0_gte"),
-            Some(FilterParamValue::Int(1609459200))
-        ));
+        let (q, _params) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@ts:[1609459200 +inf]"), "q={}", q);
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -18,7 +18,7 @@
 //!
 //! Reference: <https://github.com/valkey-io/valkey-glide/issues/828>
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -46,6 +46,18 @@ pub struct ValkeyEngineConfig {
     pub batch_size: usize,
     pub parallel: usize,
     pub skip_vector_index: bool,
+    /// Schema fields declared `datetime`: their ISO-8601 payload values are
+    /// converted to epoch seconds at HSET time so the NUMERIC index/range
+    /// filters match. Populated in `configure()`. `Arc` so per-thread config
+    /// clones share one set.
+    pub datetime_fields: Arc<HashSet<String>>,
+    /// Schema fields declared `text`. Valkey Search has no TEXT field type, so
+    /// full-text is DEGRADED to a whitespace-tokenised multi-value TAG: on upload
+    /// the text is split on whitespace and stored as a `;`-joined TAG set, and a
+    /// `{"match":{"text":"word"}}` query becomes a single-token TAG match. This
+    /// supports single-term full-text matching (any doc containing the term); it
+    /// does NOT support phrase / multi-term full-text queries.
+    pub text_tag_fields: Arc<HashSet<String>>,
 }
 
 pub struct ValkeyEngine {
@@ -111,6 +123,8 @@ impl ValkeyEngine {
                 batch_size,
                 parallel,
                 skip_vector_index: engine_config.skip_vector_index,
+                datetime_fields: Arc::new(HashSet::new()),
+                text_tag_fields: Arc::new(HashSet::new()),
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             commandstats_baseline: None,
@@ -198,14 +212,25 @@ impl ValkeyEngine {
                 for (field_name, field_type) in schema_obj {
                     let ft = field_type.as_str().unwrap_or("");
                     match ft {
-                        "keyword" => {
+                        // keyword/uuid/bool are exact-match TAG fields.
+                        "keyword" | "uuid" | "bool" => {
                             cmd.arg(field_name).arg("TAG").arg("SEPARATOR").arg(";");
                         }
                         "int" | "float" => {
                             cmd.arg(field_name).arg("NUMERIC");
                         }
-                        // Valkey Search does not support TEXT or GEO field types;
-                        // skip them silently.
+                        // datetime is stored as epoch seconds (see upload) → NUMERIC.
+                        "datetime" => {
+                            cmd.arg(field_name).arg("NUMERIC");
+                        }
+                        // Valkey Search has no TEXT field type: DEGRADE full-text
+                        // to a whitespace-tokenised multi-value TAG (see
+                        // ValkeyEngineConfig::text_tag_fields). Single-term
+                        // full-text matching works; phrase queries do not.
+                        "text" => {
+                            cmd.arg(field_name).arg("TAG").arg("SEPARATOR").arg(";");
+                        }
+                        // Valkey Search does not support GEO; skip silently.
                         _ => {}
                     }
                 }
@@ -707,7 +732,10 @@ fn upload_batch_internal(
             for (k, v) in &meta.fields {
                 match v {
                     MetadataValue::String(s) => {
-                        fields.push((k.as_bytes().to_vec(), s.as_bytes().to_vec()));
+                        fields.push((
+                            k.as_bytes().to_vec(),
+                            encode_string_field(config, k, s).into_bytes(),
+                        ));
                     }
                     MetadataValue::Labels(labels) => {
                         fields.push((k.as_bytes().to_vec(), labels.join(";").into_bytes()));
@@ -843,9 +871,11 @@ fn build_filter(
 ) -> Option<ParsedFilter> {
     match condition_type {
         "match" => {
-            // match_any (IN-list) takes precedence over exact {value}.
+            // match_any (IN-list) > exact {value} > full-text {text}.
             if let Some(any) = criteria.get("any").and_then(|v| v.as_array()) {
                 Some(build_match_any_filter(field_name, any, counter))
+            } else if let Some(text) = criteria.get("text").and_then(|v| v.as_str()) {
+                Some(build_text_filter(field_name, text))
             } else {
                 build_exact_match_filter(field_name, criteria, counter)
             }
@@ -935,10 +965,18 @@ fn build_exact_match_filter(
 
     let mut params = HashMap::new();
 
+    // bool → inlined TAG match on the literal "true"/"false" token. Checked
+    // before numeric arms (serde bools are neither i64 nor f64 nor str).
+    if let Some(b) = value.as_bool() {
+        let token = if b { "true" } else { "false" };
+        return Some((format!("@{}:{{{}}}", field_name, token), params));
+    }
+
     if let Some(s) = value.as_str() {
         // Valkey Search does not support $param references inside TAG {…}
         // brackets, and does NOT require backslash-escaping of spaces, dots,
         // or other special characters. Values are passed raw inside {…}.
+        // (uuid strings are handled here too — a uuid is just a keyword.)
         Some((format!("@{}:{{{}}}", field_name, s), params))
     } else if let Some(i) = value.as_i64() {
         params.insert(param_name.clone(), FilterParamValue::Int(i));
@@ -955,6 +993,35 @@ fn build_exact_match_filter(
     } else {
         None
     }
+}
+
+/// Build a full-text filter — DEGRADED on Valkey Search (no TEXT field type) to
+/// a single-token TAG match. The `text` field is stored as a whitespace-
+/// tokenised TAG multi-value on upload (see `tokenize_text_to_tag`), so a
+/// single-term query `@field:{term}` matches any doc whose text contains that
+/// term. The term is inlined (Valkey rejects `$param` inside TAG `{…}`) and its
+/// TAG-structural characters escaped. A blank query degrades to a never-match
+/// contradiction rather than an empty clause (which would run kNN over ALL docs).
+///
+/// LIMITATION: only single-term matching is supported; a multi-word `text` query
+/// is treated as one TAG token and will generally not match (phrase / multi-term
+/// full-text is not available on Valkey Search).
+fn build_text_filter(field_name: &str, text: &str) -> ParsedFilter {
+    let params = HashMap::new();
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        let never = "__text_never_match__";
+        return (
+            format!("(@{0}:{{{1}}} -@{0}:{{{1}}})", field_name, never),
+            params,
+        );
+    }
+    // Use the first whitespace token; escape TAG-structural chars.
+    let term = trimmed.split_whitespace().next().unwrap_or(trimmed);
+    (
+        format!("@{}:{{{}}}", field_name, escape_tag_value(term)),
+        params,
+    )
 }
 
 fn build_range_filter(
@@ -1023,6 +1090,10 @@ fn build_geo_filter(
     ))
 }
 
+/// Insert a JSON number (or ISO-8601 datetime / numeric string) as a NUMERIC
+/// bound: integers/floats verbatim, ISO-8601 strings as epoch **seconds**, and
+/// other numeric strings parsed as f64 (so both ISO and raw-epoch datetime
+/// bounds work — upstream is ISO-only).
 fn insert_number_param(
     params: &mut HashMap<String, FilterParamValue>,
     name: &str,
@@ -1032,6 +1103,12 @@ fn insert_number_param(
         params.insert(name.to_string(), FilterParamValue::Int(i));
     } else if let Some(f) = value.as_f64() {
         params.insert(name.to_string(), FilterParamValue::Float(f));
+    } else if let Some(s) = value.as_str() {
+        if let Some(epoch) = datetime_to_epoch_secs(s) {
+            params.insert(name.to_string(), FilterParamValue::Float(epoch));
+        } else if let Ok(f) = s.parse::<f64>() {
+            params.insert(name.to_string(), FilterParamValue::Float(f));
+        }
     }
 }
 
@@ -1354,7 +1431,7 @@ fn hset_single(
         for (k, v) in &meta.fields {
             match v {
                 MetadataValue::String(s) => {
-                    cmd.arg(k.as_str()).arg(s.as_str());
+                    cmd.arg(k.as_str()).arg(encode_string_field(config, k, s));
                 }
                 MetadataValue::Labels(labels) => {
                     cmd.arg(k.as_str()).arg(labels.join(";"));
@@ -1371,6 +1448,64 @@ fn hset_single(
         .map_err(|e| format!("HSET update error: {}", e))
 }
 
+/// Format a string metadata field for storage on Valkey.
+///
+/// - `datetime` fields: ISO-8601 → epoch seconds (already-numeric epochs pass
+///   through), for the NUMERIC index.
+/// - `text` fields: whitespace-tokenised into a `;`-joined TAG multi-value so a
+///   single-term full-text query can match via TAG (Valkey has no TEXT type).
+/// - everything else: verbatim.
+fn encode_string_field(config: &ValkeyEngineConfig, key: &str, value: &str) -> String {
+    if config.datetime_fields.contains(key) {
+        if let Some(epoch) = datetime_to_epoch_secs(value) {
+            return (epoch as i64).to_string();
+        }
+        return value.to_string();
+    }
+    if config.text_tag_fields.contains(key) {
+        return tokenize_text_to_tag(value);
+    }
+    value.to_string()
+}
+
+/// Split text on whitespace and re-join with `;` (the TAG separator), escaping
+/// any literal `;` inside a token, so it can be indexed as a multi-value TAG.
+fn tokenize_text_to_tag(text: &str) -> String {
+    text.split_whitespace()
+        .map(|w| w.replace(';', "\\;"))
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+/// Collect schema fields typed `datetime` and `text` (in that order).
+fn schema_transform_fields(dataset: &Dataset) -> (HashSet<String>, HashSet<String>) {
+    let mut datetime_fields = HashSet::new();
+    let mut text_fields = HashSet::new();
+    if let Some(schema) = dataset.config.schema.as_ref().and_then(|s| s.as_object()) {
+        for (field, ty) in schema {
+            match ty.as_str() {
+                Some("datetime") => {
+                    datetime_fields.insert(field.clone());
+                }
+                Some("text") => {
+                    text_fields.insert(field.clone());
+                }
+                _ => {}
+            }
+        }
+    }
+    (datetime_fields, text_fields)
+}
+
+/// Parse an ISO-8601 / RFC 3339 timestamp to epoch **seconds**. Returns `None`
+/// for non-datetime strings (e.g. a numeric-epoch string), letting callers fall
+/// back to numeric handling.
+fn datetime_to_epoch_secs(s: &str) -> Option<f64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp() as f64)
+}
+
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for ValkeyEngine {
@@ -1384,6 +1519,12 @@ impl Engine for ValkeyEngine {
 
     fn configure(&mut self, dataset: &Dataset) -> Result<(), String> {
         let mut conn = self.get_connection()?;
+
+        // Record datetime fields (ISO → epoch seconds) and text fields (degraded
+        // to whitespace-tokenised TAG) so upload can transform their values.
+        let (dt_fields, text_fields) = schema_transform_fields(dataset);
+        self.config.datetime_fields = Arc::new(dt_fields);
+        self.config.text_tag_fields = Arc::new(text_fields);
 
         if self.config.skip_vector_index {
             println!("Skipping vector index (filter-only mode)");
@@ -2011,6 +2152,118 @@ mod tests {
         let cond = serde_json::json!({"and":[{"color":{"match":{"value":"red"}}}]});
         let (q, _) = parse_conditions(&cond).unwrap();
         assert!(q.contains("@color:{red}"), "q={}", q);
+    }
+
+    // ── New filter datatypes: bool / uuid / full-text / datetime ───────────
+    use super::{
+        datetime_to_epoch_secs, encode_string_field, tokenize_text_to_tag, ValkeyEngineConfig,
+    };
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    #[test]
+    fn match_bool_emits_inlined_tag_token() {
+        let cond = serde_json::json!({"and":[{"flag":{"match":{"value": true}}}]});
+        let (q, _) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@flag:{true}"), "q={}", q);
+        let cond = serde_json::json!({"and":[{"flag":{"match":{"value": false}}}]});
+        let (q, _) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@flag:{false}"), "q={}", q);
+    }
+
+    #[test]
+    fn match_uuid_value_inlined_tag() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let cond = serde_json::json!({"and":[{"uid":{"match":{"value": uuid}}}]});
+        let (q, _) = parse_conditions(&cond).unwrap();
+        assert!(q.contains(&format!("@uid:{{{}}}", uuid)), "q={}", q);
+    }
+
+    #[test]
+    fn match_text_degrades_to_single_token_tag() {
+        // Full-text on Valkey → single-term TAG match (degraded).
+        let cond = serde_json::json!({"and":[{"body":{"match":{"text": "quick"}}}]});
+        let (q, _) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@body:{quick}"), "q={}", q);
+    }
+
+    #[test]
+    fn match_text_empty_is_never_match() {
+        let cond = serde_json::json!({"and":[{"body":{"match":{"text": "  "}}}]});
+        let (q, _) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("-@body:{"), "expected never-match, q={}", q);
+    }
+
+    #[test]
+    fn range_datetime_iso_bounds_parse_to_epoch() {
+        let cond = serde_json::json!({"and":[{"ts":{"range":{
+            "gte": "2021-01-01T00:00:00Z",
+            "lt":  "2022-01-01T00:00:00Z"
+        }}}]});
+        let (q, params) = parse_conditions(&cond).unwrap();
+        assert!(q.contains("@ts:[$ts_0_gte +inf]"), "q={}", q);
+        assert!(q.contains("@ts:[-inf ($ts_0_lt]"), "q={}", q);
+        assert!(
+            matches!(params.get("ts_0_gte"), Some(FilterParamValue::Float(f)) if (*f - 1609459200.0).abs() < 1.0)
+        );
+        assert!(
+            matches!(params.get("ts_0_lt"), Some(FilterParamValue::Float(f)) if (*f - 1640995200.0).abs() < 1.0)
+        );
+    }
+
+    #[test]
+    fn range_datetime_numeric_epoch_bounds_still_work() {
+        let cond = serde_json::json!({"and":[{"ts":{"range":{"gte": 1609459200}}}]});
+        let (_q, params) = parse_conditions(&cond).unwrap();
+        assert!(matches!(
+            params.get("ts_0_gte"),
+            Some(FilterParamValue::Int(1609459200))
+        ));
+    }
+
+    #[test]
+    fn datetime_to_epoch_secs_parses_rfc3339_and_rejects_plain() {
+        assert_eq!(
+            datetime_to_epoch_secs("2021-01-01T00:00:00Z").map(|f| f as i64),
+            Some(1609459200)
+        );
+        assert!(datetime_to_epoch_secs("not-a-date").is_none());
+        assert!(datetime_to_epoch_secs("1609459200").is_none());
+    }
+
+    #[test]
+    fn tokenize_text_to_tag_splits_on_whitespace() {
+        assert_eq!(tokenize_text_to_tag("the sky is blue"), "the;sky;is;blue");
+        assert_eq!(tokenize_text_to_tag("solo"), "solo");
+    }
+
+    #[test]
+    fn encode_string_field_transforms_datetime_and_text() {
+        let mut dt = HashSet::new();
+        dt.insert("ts".to_string());
+        let mut txt = HashSet::new();
+        txt.insert("body".to_string());
+        let cfg = ValkeyEngineConfig {
+            m: 16,
+            ef_construction: 128,
+            data_type: "FLOAT32".to_string(),
+            algorithm: "hnsw".to_string(),
+            batch_size: 1,
+            parallel: 1,
+            skip_vector_index: false,
+            datetime_fields: Arc::new(dt),
+            text_tag_fields: Arc::new(txt),
+        };
+        assert_eq!(
+            encode_string_field(&cfg, "ts", "2021-01-01T00:00:00Z"),
+            "1609459200"
+        );
+        assert_eq!(encode_string_field(&cfg, "ts", "1609459200"), "1609459200");
+        assert_eq!(
+            encode_string_field(&cfg, "body", "the sky is blue"),
+            "the;sky;is;blue"
+        );
+        assert_eq!(encode_string_field(&cfg, "color", "red"), "red");
     }
 
     // ── redis::Value response parsing ──────────────────────────────────────

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -2233,7 +2233,10 @@ mod tests {
         let (q, params) = parse_conditions(&cond).unwrap();
         assert!(q.contains("@ts:[1609459200 +inf]"), "q={}", q);
         assert!(q.contains("@ts:[-inf (1640995200]"), "q={}", q);
-        assert!(!params.keys().any(|k| k.starts_with("ts_")), "no range params");
+        assert!(
+            !params.keys().any(|k| k.starts_with("ts_")),
+            "no range params"
+        );
     }
 
     #[test]
@@ -2253,12 +2256,19 @@ mod tests {
         let gte = parse_conditions(&serde_json::json!({"and":[{"n":{"range":{"gte": 5}}}]}))
             .unwrap()
             .0;
-        assert!(gte.contains("@n:[5 +inf]") && !gte.contains("(5"), "gte: {}", gte);
+        assert!(
+            gte.contains("@n:[5 +inf]") && !gte.contains("(5"),
+            "gte: {}",
+            gte
+        );
     }
 
     #[test]
     fn datetime_tolerates_naive_and_date_only() {
-        assert_eq!(datetime_to_epoch_secs("2021-01-01").map(|f| f as i64), Some(1609459200));
+        assert_eq!(
+            datetime_to_epoch_secs("2021-01-01").map(|f| f as i64),
+            Some(1609459200)
+        );
         assert_eq!(
             datetime_to_epoch_secs("2021-01-01T00:00:00").map(|f| f as i64),
             Some(1609459200)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -151,6 +151,211 @@ pub fn write_match_any_project(
     }
 }
 
+// ── Generic filter-datatype fixtures (bool / uuid / full-text / datetime) ──
+//
+// Mirrors `write_match_any_project` but is parameterised by the filter under
+// test. Each builds a compound (`tar`) dataset (`vectors.npy` +
+// `payloads.jsonl` + `tests.jsonl`) whose queries carry a fixed `conditions`
+// filter, with ground truth brute-forced over ONLY the documents that satisfy
+// the filter. A high recall therefore proves the engine actually applied the
+// filter (returned the filtered nearest neighbours, not the whole corpus's).
+
+/// A built filter-benchmark project (same shape as `MatchAnyProject`).
+pub struct FilterProject {
+    pub root: PathBuf,
+    pub dataset_name: String,
+    pub top: usize,
+    /// Number of documents satisfying the filter (sanity bound: >> top).
+    pub matching_docs: usize,
+}
+
+/// Core builder: `schema` is the datasets.json `schema` object, `payload_for`
+/// returns the per-document payload object, `condition` is the (shared) filter
+/// JSON attached to every query, and `matches` decides whether a document id
+/// satisfies the filter (used to brute-force the filtered ground truth).
+fn write_filter_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+    schema: serde_json::Value,
+    payload_for: impl Fn(usize) -> serde_json::Value,
+    condition: serde_json::Value,
+    matches: impl Fn(usize) -> bool,
+) -> FilterProject {
+    let mut rng = StdRng::seed_from_u64(0xF117E);
+    let gen_vec =
+        |rng: &mut StdRng| -> Vec<f32> { (0..dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect() };
+    let vectors: Vec<Vec<f32>> = (0..N_DOCS).map(|_| gen_vec(&mut rng)).collect();
+    let queries: Vec<Vec<f32>> = (0..N_QUERIES).map(|_| gen_vec(&mut rng)).collect();
+
+    let l2 = |a: &[f32], b: &[f32]| -> f64 {
+        a.iter()
+            .zip(b)
+            .map(|(x, y)| (*x as f64 - *y as f64).powi(2))
+            .sum()
+    };
+    let filtered_gt = |q: &[f32]| -> Vec<i64> {
+        let mut scored: Vec<(i64, f64)> = (0..N_DOCS)
+            .filter(|id| matches(*id))
+            .map(|id| (id as i64, l2(q, &vectors[id])))
+            .collect();
+        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        scored.iter().take(TOP).map(|(id, _)| *id).collect()
+    };
+
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().to_path_buf();
+    std::mem::forget(tmp);
+
+    let ds_dir = root.join("datasets").join(dataset_name);
+    fs::create_dir_all(&ds_dir).unwrap();
+    fs::create_dir_all(root.join("experiments/configurations")).unwrap();
+    fs::create_dir_all(root.join("results")).unwrap();
+
+    write_npy_vectors(ds_dir.join("vectors.npy").to_str().unwrap(), &vectors).unwrap();
+
+    let payloads: String = (0..N_DOCS)
+        .map(|id| payload_for(id).to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(ds_dir.join("payloads.jsonl"), payloads).unwrap();
+
+    let tests: String = queries
+        .iter()
+        .map(|q| {
+            serde_json::json!({
+                "query": q.iter().map(|x| *x as f64).collect::<Vec<_>>(),
+                "conditions": condition,
+                "closest_ids": filtered_gt(q),
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(ds_dir.join("tests.jsonl"), tests).unwrap();
+
+    let datasets_json = serde_json::json!([{
+        "name": dataset_name,
+        "type": "tar",
+        "path": format!("{}/", dataset_name),
+        "distance": "l2",
+        "vector_size": dim,
+        "vector_count": N_DOCS,
+        "schema": schema,
+    }]);
+    fs::write(
+        root.join("datasets/datasets.json"),
+        serde_json::to_string_pretty(&datasets_json).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        root.join("experiments/configurations/test.json"),
+        engine_configs_json,
+    )
+    .unwrap();
+
+    FilterProject {
+        root,
+        dataset_name: dataset_name.to_string(),
+        top: TOP,
+        matching_docs: (0..N_DOCS).filter(|id| matches(*id)).count(),
+    }
+}
+
+/// bool filter: field `flag` (schema type `bool`), value `id % 2 == 0`. The
+/// query filters `flag == true`, so half the corpus matches.
+pub fn write_bool_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+) -> FilterProject {
+    write_filter_project(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        serde_json::json!({ "flag": "bool" }),
+        |id| serde_json::json!({ "flag": id % 2 == 0 }),
+        serde_json::json!({ "and": [ { "flag": { "match": { "value": true } } } ] }),
+        |id| id % 2 == 0,
+    )
+}
+
+/// UUID values assigned round-robin by `id % 4`. The query filters on the first
+/// UUID (exact keyword/TAG match), so a quarter of the corpus matches.
+pub const UUIDS: [&str; 4] = [
+    "550e8400-e29b-41d4-a716-446655440000",
+    "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+    "6ba7b811-9dad-11d1-80b4-00c04fd430c8",
+    "6ba7b812-9dad-11d1-80b4-00c04fd430c8",
+];
+
+/// uuid filter: field `uid` (schema type `uuid`), exact match on `UUIDS[0]`.
+pub fn write_uuid_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+) -> FilterProject {
+    write_filter_project(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        serde_json::json!({ "uid": "uuid" }),
+        |id| serde_json::json!({ "uid": UUIDS[id % UUIDS.len()] }),
+        serde_json::json!({ "and": [ { "uid": { "match": { "value": UUIDS[0] } } } ] }),
+        |id| id % UUIDS.len() == 0,
+    )
+}
+
+/// full-text filter: field `body` (schema type `text`). Even docs contain the
+/// term "quick"; odd docs do not. The query is a single-term full-text match on
+/// "quick" (works on Redis TEXT and on Valkey's degraded tokenised-TAG path).
+pub fn write_fulltext_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+) -> FilterProject {
+    write_filter_project(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        serde_json::json!({ "body": "text" }),
+        |id| {
+            let body = if id % 2 == 0 {
+                "the quick brown fox"
+            } else {
+                "lazy dog sleeps here"
+            };
+            serde_json::json!({ "body": body })
+        },
+        serde_json::json!({ "and": [ { "body": { "match": { "text": "quick" } } } ] }),
+        |id| id % 2 == 0,
+    )
+}
+
+/// datetime filter: field `ts` (schema type `datetime`), one ISO-8601 timestamp
+/// per doc spaced one day apart from 2021-01-01. The query is an ISO range
+/// `[day 100, day 300)`, selecting ids 100..=299 (200 docs).
+pub fn write_datetime_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+) -> FilterProject {
+    use chrono::{Duration, TimeZone, Utc};
+    let base = Utc.timestamp_opt(1_609_459_200, 0).unwrap(); // 2021-01-01T00:00:00Z
+    let iso_for = move |day: i64| (base + Duration::days(day)).to_rfc3339();
+    let gte = iso_for(100);
+    let lt = iso_for(300);
+    write_filter_project(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        serde_json::json!({ "ts": "datetime" }),
+        move |id| serde_json::json!({ "ts": iso_for(id as i64) }),
+        serde_json::json!({ "and": [ { "ts": { "range": { "gte": gte, "lt": lt } } } ] }),
+        |id| (100..300).contains(&id),
+    )
+}
+
 /// Path to the compiled binary under test. Cargo exports
 /// `CARGO_BIN_EXE_vector-db-benchmark` to integration tests automatically.
 pub fn binary_path() -> PathBuf {

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -1881,3 +1881,67 @@ fn test_binary_redis_match_any_resp3() {
         recall
     );
 }
+
+// ── New filter datatypes: bool / uuid / full-text / datetime ────────────────
+//
+// Each drives the real binary against a compound dataset whose queries carry a
+// single filter type, with ground truth brute-forced over only the matching
+// docs — a high recall proves the corresponding filter arm (TAG bool, TAG uuid,
+// TEXT full-text, NUMERIC datetime range) is applied end-to-end.
+
+/// Shared driver: build the project with `build`, run the binary, assert recall.
+fn run_filter_recall_test(
+    name: &str,
+    dataset: &str,
+    build: impl Fn(&str, &str, usize) -> common::FilterProject,
+) {
+    wait_for_redis();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": name, "engine": "redis",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = build(dataset, &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(
+        proj.matching_docs >= proj.top,
+        "fixture must have >= top matching docs (got {})",
+        proj.matching_docs
+    );
+
+    assert!(
+        common::run_binary(
+            &proj.root,
+            name,
+            dataset,
+            "localhost",
+            &[("REDIS_PORT", &TEST_PORT.to_string())],
+        ),
+        "redis {} run failed",
+        name
+    );
+
+    let recall = common::read_recall(&proj.root, name);
+    println!("redis {} recall={:.3}", name, recall);
+    assert!(recall >= 0.9, "redis {} recall {:.3} < 0.9", name, recall);
+}
+
+#[test]
+fn test_binary_redis_bool() {
+    run_filter_recall_test("redis-bool", "bool-test", common::write_bool_project);
+}
+
+#[test]
+fn test_binary_redis_uuid() {
+    run_filter_recall_test("redis-uuid", "uuid-test", common::write_uuid_project);
+}
+
+#[test]
+fn test_binary_redis_fulltext() {
+    run_filter_recall_test("redis-text", "text-test", common::write_fulltext_project);
+}
+
+#[test]
+fn test_binary_redis_datetime() {
+    run_filter_recall_test("redis-dt", "dt-test", common::write_datetime_project);
+}

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -1193,3 +1193,69 @@ fn test_binary_valkey_match_any_resp3() {
         recall
     );
 }
+
+// ── New filter datatypes: bool / uuid / full-text / datetime ────────────────
+//
+// Each drives the real binary against a compound dataset whose queries carry a
+// single filter type, with ground truth brute-forced over only the matching
+// docs. Valkey has no TEXT field type, so the full-text case exercises the
+// DEGRADED path (text tokenised to a multi-value TAG on upload + single-term TAG
+// match); single-term recall must still clear the bar.
+
+/// Shared driver: build the project with `build`, run the binary, assert recall.
+fn run_filter_recall_test(
+    name: &str,
+    dataset: &str,
+    build: impl Fn(&str, &str, usize) -> common::FilterProject,
+) {
+    wait_for_valkey();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": name, "engine": "valkey",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = build(dataset, &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(
+        proj.matching_docs >= proj.top,
+        "fixture must have >= top matching docs (got {})",
+        proj.matching_docs
+    );
+
+    let port = test_port().to_string();
+    assert!(
+        common::run_binary(
+            &proj.root,
+            name,
+            dataset,
+            "127.0.0.1",
+            &[("VALKEY_PORT", port.as_str())],
+        ),
+        "valkey {} run failed",
+        name
+    );
+
+    let recall = common::read_recall(&proj.root, name);
+    println!("valkey {} recall={:.3}", name, recall);
+    assert!(recall >= 0.9, "valkey {} recall {:.3} < 0.9", name, recall);
+}
+
+#[test]
+fn test_binary_valkey_bool() {
+    run_filter_recall_test("valkey-bool", "bool-test", common::write_bool_project);
+}
+
+#[test]
+fn test_binary_valkey_uuid() {
+    run_filter_recall_test("valkey-uuid", "uuid-test", common::write_uuid_project);
+}
+
+#[test]
+fn test_binary_valkey_fulltext() {
+    run_filter_recall_test("valkey-text", "text-test", common::write_fulltext_project);
+}
+
+#[test]
+fn test_binary_valkey_datetime() {
+    run_filter_recall_test("valkey-dt", "dt-test", common::write_datetime_project);
+}


### PR DESCRIPTION
## Summary
Closes a parity gap vs upstream `qdrant/vector-db-benchmark`: adds **bool, uuid, full-text, and datetime** filter support to the **redis** and **valkey** engines (upstream benchmarks these; we only had keyword/int/range/geo).

- **Schema:** `bool`/`uuid` → TAG, `datetime` → NUMERIC (epoch seconds), full-text uses TEXT (redis) / tokenized-TAG (valkey; single-term).
- **Conditions:** `match.value:true/false` (bool), `match.value:<uuid>`, `match.text:<words>` (full-text), `range` on datetime.
- **Datetime:** ISO-8601 → epoch in **both** the schema-aware upload path and the range parser. **Better than upstream:** accepts ISO-8601 *and* raw numeric epochs *and* naive/date-only bounds (upstream is RFC-3339-only).
- **Valkey specifics:** valkey Search rejects `$param` inside NUMERIC/TAG brackets, so numeric/epoch bounds and TAG values are **inlined** (escaped); full-text degrades to single-term tokenized-TAG (documented in code).

## Adversarial review
Implemented by an isolated worktree subagent, then **hardened by a 7-agent adversarial review** + local integration testing (which the implementation agent couldn't run). That process caught and fixed real bugs before this PR:
- valkey `$param`-in-NUMERIC datetime range silently errored → inlined;
- redis `gt` was inclusive (== `gte`) → made exclusive;
- valkey exact keyword/uuid match wasn't escaping TAG metachars → fixed;
- valkey int exact/match_any used the rejected `$param` form → inlined;
- datetime bound tolerance + no-dangling-`$param` safety.

(Deferred as noted follow-up: priming the schema-transform sets on the `--skip-upload` non-skip-index mixed path.)

## Coverage
- **130 unit tests** (parser branches for every new type + gt-exclusive, datetime-tolerance, no-dangling-param, two-field-AND gate tests).
- **Integration** (live servers): `test_binary_{redis,valkey}_{bool,uuid,fulltext,datetime}` asserting recall ≥ 0.9 over the *filtered* ground truth.

## Verification
`make check` + `clippy --all-targets -D warnings` clean; **redis 20/20**, **valkey 15/15** integration locally (redis 8.8.0 / valkey-bundle latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)