### PR TITLE
feat(qdrant): hybrid dense+sparse RRF-fusion search

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,28 @@ Or provide a custom file with `--engines-file`:
 vector-db-benchmark --engines-file my_engines.json --datasets glove-25-angular
 ```
 
+### Qdrant hybrid (dense + sparse) search
+
+`experiments/configurations/qdrant-hybrid.json` runs Qdrant's server-side
+reciprocal-rank fusion (RRF) of a dense-vector prefetch and a sparse-vector
+prefetch. It **requires a `type: "hybrid"` dataset** — running it against an
+ordinary dense dataset silently degrades to a plain dense search (there is no
+sparse vector to fuse). A hybrid dataset directory must contain all of:
+
+```
+vectors.npy      # dense document vectors  (npy, row i == point id i)
+queries.npy      # dense query vectors      (npy)
+data.csr         # sparse document vectors  (binary CSR, row-aligned with vectors.npy)
+queries.csr      # sparse query vectors     (binary CSR, row-aligned with queries.npy)
+neighbours.jsonl # fused ground truth: one JSON array of ids per query line
+```
+
+Register it in `datasets/datasets.json` with `"type": "hybrid"` and the dense
+`vector_size`/`distance`. The end-to-end hybrid path (collection with a named
+`dense` + named `sparse` vector, dual-vector upsert, and RRF fusion) is covered
+by `tests/integration_qdrant.rs::test_binary_qdrant_hybrid`, which also
+generates a tiny hybrid fixture you can consult for the exact layout.
+
 ## How to register a dataset?
 
 Datasets are configured in [`datasets/datasets.json`](./datasets/datasets.json). The tool automatically downloads datasets on first use if a download link is provided.

--- a/experiments/configurations/qdrant-hybrid.json
+++ b/experiments/configurations/qdrant-hybrid.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "qdrant-hybrid",
+    "engine": "qdrant",
+    "connection_params": { "timeout": 300 },
+    "collection_params": {
+      "timeout": 300,
+      "hnsw_config": { "m": 16, "ef_construct": 128 },
+      "optimizers_config": { "memmap_threshold": 25000000 }
+    },
+    "search_params": [
+      { "parallel": 1, "search_params": { "prefetch": { "limit": 100 } } },
+      { "parallel": 8, "search_params": { "prefetch": { "limit": 100 } } }
+    ],
+    "upload_params": { "parallel": 16, "batch_size": 1024 }
+  }
+]

--- a/src/bin/vector_db_benchmark/dataset.rs
+++ b/src/bin/vector_db_benchmark/dataset.rs
@@ -241,6 +241,90 @@ impl Dataset {
         Ok((queries, neighbours))
     }
 
+    /// Whether this is a hybrid (dense + sparse) dataset (`dataset_type: "hybrid"`).
+    ///
+    /// A hybrid dataset directory carries BOTH dense npy files (`vectors.npy` /
+    /// `queries.npy`) and sparse CSR files (`data.csr` / `queries.csr`), sharing
+    /// a single `neighbours.jsonl` ground truth. This lets an engine fuse a dense
+    /// prefetch and a sparse prefetch server-side (e.g. Qdrant RRF). It is a
+    /// SUPERSET of the sparse layout: same CSR files, plus the dense npy files.
+    pub fn is_hybrid(&self) -> bool {
+        self.config.dataset_type.as_deref() == Some("hybrid")
+    }
+
+    /// Read hybrid upload data: dense vectors from `<dir>/vectors.npy` (reusing
+    /// the npy reader) and the row-aligned sparse vectors from `<dir>/data.csr`
+    /// (reusing the sparse CSR reader). Ids are the row indices. The dense and
+    /// sparse matrices MUST have the same row count — one dense AND one sparse
+    /// vector per point.
+    #[allow(clippy::type_complexity)]
+    pub fn read_hybrid_data(
+        &self,
+        normalize: bool,
+    ) -> Result<(Vec<i64>, Vec<Vec<f32>>, Vec<SparseVector>), String> {
+        let dir = self.get_path()?;
+        let (_ids, dense_vectors) = read_npy_vectors(
+            dir.join("vectors.npy")
+                .to_str()
+                .ok_or("Invalid vectors.npy path")?,
+            normalize,
+        )?;
+        let sparse = read_sparse_matrix(
+            dir.join("data.csr")
+                .to_str()
+                .ok_or("Invalid data.csr path")?,
+        )?;
+        if dense_vectors.len() != sparse.len() {
+            return Err(format!(
+                "hybrid data row mismatch: {} dense rows vs {} sparse rows",
+                dense_vectors.len(),
+                sparse.len()
+            ));
+        }
+        let ids: Vec<i64> = (0..dense_vectors.len() as i64).collect();
+        Ok((ids, dense_vectors, sparse))
+    }
+
+    /// Read hybrid queries: dense queries from `<dir>/queries.npy`, the
+    /// row-aligned sparse queries from `<dir>/queries.csr`, and shared
+    /// ground-truth neighbours from `<dir>/neighbours.jsonl` (one JSON array of
+    /// ids per line). The ground truth is shared because it describes the FUSED
+    /// result, not either modality alone.
+    #[allow(clippy::type_complexity)]
+    pub fn read_hybrid_queries(
+        &self,
+    ) -> Result<(Vec<Vec<f32>>, Vec<SparseVector>, Vec<Vec<i64>>), String> {
+        let dir = self.get_path()?;
+        let normalize = self.needs_normalization();
+        let (_ids, dense_queries) = read_npy_vectors(
+            dir.join("queries.npy")
+                .to_str()
+                .ok_or("Invalid queries.npy path")?,
+            normalize,
+        )?;
+        let sparse_queries = read_sparse_matrix(
+            dir.join("queries.csr")
+                .to_str()
+                .ok_or("Invalid queries.csr path")?,
+        )?;
+        if dense_queries.len() != sparse_queries.len() {
+            return Err(format!(
+                "hybrid query row mismatch: {} dense vs {} sparse",
+                dense_queries.len(),
+                sparse_queries.len()
+            ));
+        }
+
+        let gt_path = dir.join("neighbours.jsonl");
+        let neighbours: Vec<Vec<i64>> = std::fs::read_to_string(&gt_path)
+            .map_err(|e| format!("read {}: {}", gt_path.display(), e))?
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str::<Vec<i64>>(l).map_err(|e| e.to_string()))
+            .collect::<Result<_, _>>()?;
+        Ok((dense_queries, sparse_queries, neighbours))
+    }
+
     /// Read queries from HDF5 file (test + neighbors datasets).
     #[allow(clippy::type_complexity)]
     fn read_hdf5_queries(&self, path_str: &str) -> Result<(Vec<Vec<f32>>, Vec<Vec<i64>>), String> {
@@ -286,5 +370,104 @@ impl Dataset {
             .collect();
 
         Ok((queries, neighbors))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DatasetConfig;
+    use vector_db_benchmark::readers::{write_npy_vectors, write_sparse_matrix};
+
+    /// Build a `Dataset` whose `path` is an absolute temp dir (so `get_path`
+    /// resolves to it directly — `datasets_dir().join(abs)` == `abs`).
+    fn hybrid_dataset(dir: &std::path::Path) -> Dataset {
+        Dataset::new(DatasetConfig {
+            name: "hybrid-unit".to_string(),
+            dataset_type: Some("hybrid".to_string()),
+            path: serde_json::Value::String(dir.to_str().unwrap().to_string()),
+            distance: Some("l2".to_string()),
+            vector_size: Some(3),
+            vector_count: Some(2),
+            link: None,
+            schema: None,
+            description: None,
+        })
+    }
+
+    #[test]
+    fn is_hybrid_only_for_hybrid_type() {
+        let dir = tempfile::tempdir().unwrap();
+        let ds = hybrid_dataset(dir.path());
+        assert!(ds.is_hybrid());
+        assert!(!ds.is_sparse());
+
+        let mut cfg = ds.config.clone();
+        cfg.dataset_type = Some("sparse".to_string());
+        let sparse = Dataset::new(cfg);
+        assert!(!sparse.is_hybrid());
+        assert!(sparse.is_sparse());
+    }
+
+    #[test]
+    fn reads_hybrid_data_and_queries() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path();
+
+        let dense = vec![vec![1.0f32, 0.0, 0.0], vec![0.0, 2.0, 0.0]];
+        let sparse = vec![
+            SparseVector {
+                indices: vec![0, 2],
+                values: vec![1.0, 3.0],
+            },
+            SparseVector {
+                indices: vec![1],
+                values: vec![5.0],
+            },
+        ];
+        write_npy_vectors(p.join("vectors.npy").to_str().unwrap(), &dense).unwrap();
+        write_sparse_matrix(p.join("data.csr").to_str().unwrap(), &sparse).unwrap();
+
+        let dense_q = vec![vec![1.0f32, 1.0, 1.0]];
+        let sparse_q = vec![SparseVector {
+            indices: vec![0],
+            values: vec![2.0],
+        }];
+        write_npy_vectors(p.join("queries.npy").to_str().unwrap(), &dense_q).unwrap();
+        write_sparse_matrix(p.join("queries.csr").to_str().unwrap(), &sparse_q).unwrap();
+        std::fs::write(p.join("neighbours.jsonl"), "[0, 1]\n").unwrap();
+
+        let ds = hybrid_dataset(p);
+        let (ids, d, s) = ds.read_hybrid_data(false).unwrap();
+        assert_eq!(ids, vec![0, 1]);
+        assert_eq!(d, dense);
+        assert_eq!(s, sparse);
+
+        let (dq, sq, nb) = ds.read_hybrid_queries().unwrap();
+        assert_eq!(dq, dense_q);
+        assert_eq!(sq, sparse_q);
+        assert_eq!(nb, vec![vec![0i64, 1]]);
+    }
+
+    #[test]
+    fn read_hybrid_data_rejects_row_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path();
+        // 2 dense rows but only 1 sparse row → must error.
+        write_npy_vectors(
+            p.join("vectors.npy").to_str().unwrap(),
+            &[vec![1.0f32, 0.0, 0.0], vec![0.0, 1.0, 0.0]],
+        )
+        .unwrap();
+        write_sparse_matrix(
+            p.join("data.csr").to_str().unwrap(),
+            &[SparseVector {
+                indices: vec![0],
+                values: vec![1.0],
+            }],
+        )
+        .unwrap();
+        let ds = hybrid_dataset(p);
+        assert!(ds.read_hybrid_data(false).is_err());
     }
 }

--- a/src/bin/vector_db_benchmark/dataset.rs
+++ b/src/bin/vector_db_benchmark/dataset.rs
@@ -316,12 +316,18 @@ impl Dataset {
         }
 
         let gt_path = dir.join("neighbours.jsonl");
-        let neighbours: Vec<Vec<i64>> = std::fs::read_to_string(&gt_path)
-            .map_err(|e| format!("read {}: {}", gt_path.display(), e))?
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .map(|l| serde_json::from_str::<Vec<i64>>(l).map_err(|e| e.to_string()))
-            .collect::<Result<_, _>>()?;
+        let neighbours = read_neighbours_strict(&gt_path)?;
+
+        // Ground truth must be row-aligned with the queries: a short (or long)
+        // neighbours.jsonl would otherwise index out of bounds mid-run, or
+        // silently score the wrong rows.
+        if neighbours.len() != dense_queries.len() {
+            return Err(format!(
+                "hybrid ground-truth row mismatch: {} queries vs {} neighbour rows",
+                dense_queries.len(),
+                neighbours.len()
+            ));
+        }
         Ok((dense_queries, sparse_queries, neighbours))
     }
 
@@ -371,6 +377,37 @@ impl Dataset {
 
         Ok((queries, neighbors))
     }
+}
+
+/// Parse a `neighbours.jsonl` ground-truth file (one JSON id-array per line)
+/// with STRICT line alignment: every line must be a valid id-array so that row
+/// `i` is unambiguously query `i`'s ground truth. A blank OR unparseable line in
+/// the interior is rejected (a blanket "skip empty lines" would shift every
+/// subsequent row up by one and silently corrupt recall). Exactly one trailing
+/// newline is tolerated.
+fn read_neighbours_strict(path: &std::path::Path) -> Result<Vec<Vec<i64>>, String> {
+    let raw =
+        std::fs::read_to_string(path).map_err(|e| format!("read {}: {}", path.display(), e))?;
+    let mut lines: Vec<&str> = raw.split('\n').collect();
+    // Tolerate a single trailing newline (final split element is "").
+    if lines.last() == Some(&"") {
+        lines.pop();
+    }
+    let mut out = Vec::with_capacity(lines.len());
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return Err(format!(
+                "{}: blank line at row {} (ground-truth rows must be contiguous)",
+                path.display(),
+                i + 1
+            ));
+        }
+        let row: Vec<i64> = serde_json::from_str(trimmed)
+            .map_err(|e| format!("{}: parse row {}: {}", path.display(), i + 1, e))?;
+        out.push(row);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -447,6 +484,87 @@ mod tests {
         assert_eq!(dq, dense_q);
         assert_eq!(sq, sparse_q);
         assert_eq!(nb, vec![vec![0i64, 1]]);
+    }
+
+    /// Helper: write the four hybrid data files (2 docs / 1 query) into `p`,
+    /// leaving `neighbours.jsonl` for the caller to control.
+    fn write_hybrid_files_without_neighbours(p: &std::path::Path) {
+        write_npy_vectors(
+            p.join("vectors.npy").to_str().unwrap(),
+            &[vec![1.0f32, 0.0, 0.0], vec![0.0, 1.0, 0.0]],
+        )
+        .unwrap();
+        write_sparse_matrix(
+            p.join("data.csr").to_str().unwrap(),
+            &[
+                SparseVector {
+                    indices: vec![0],
+                    values: vec![1.0],
+                },
+                SparseVector {
+                    indices: vec![1],
+                    values: vec![1.0],
+                },
+            ],
+        )
+        .unwrap();
+        write_npy_vectors(
+            p.join("queries.npy").to_str().unwrap(),
+            &[vec![1.0f32, 1.0, 1.0]],
+        )
+        .unwrap();
+        write_sparse_matrix(
+            p.join("queries.csr").to_str().unwrap(),
+            &[SparseVector {
+                indices: vec![0],
+                values: vec![1.0],
+            }],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn read_hybrid_queries_rejects_neighbour_count_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path();
+        write_hybrid_files_without_neighbours(p);
+        // 1 query but 2 ground-truth rows → must error (finding 3).
+        std::fs::write(p.join("neighbours.jsonl"), "[0]\n[1]\n").unwrap();
+        let ds = hybrid_dataset(p);
+        let err = ds.read_hybrid_queries().unwrap_err();
+        assert!(err.contains("ground-truth row mismatch"), "got: {err}");
+    }
+
+    #[test]
+    fn read_hybrid_queries_rejects_interior_blank_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path();
+        write_hybrid_files_without_neighbours(p);
+        // Interior blank line would silently shift rows → must error (finding 5).
+        std::fs::write(p.join("neighbours.jsonl"), "\n[0]\n").unwrap();
+        let ds = hybrid_dataset(p);
+        let err = ds.read_hybrid_queries().unwrap_err();
+        assert!(err.contains("blank line"), "got: {err}");
+    }
+
+    #[test]
+    fn read_neighbours_strict_tolerates_single_trailing_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("neighbours.jsonl");
+        std::fs::write(&p, "[1, 2]\n[3]\n").unwrap();
+        let nb = read_neighbours_strict(&p).unwrap();
+        assert_eq!(nb, vec![vec![1i64, 2], vec![3]]);
+
+        // No trailing newline is also fine.
+        std::fs::write(&p, "[1, 2]\n[3]").unwrap();
+        assert_eq!(
+            read_neighbours_strict(&p).unwrap(),
+            vec![vec![1i64, 2], vec![3]]
+        );
+
+        // A doubled trailing newline leaves an interior blank → rejected.
+        std::fs::write(&p, "[1]\n\n").unwrap();
+        assert!(read_neighbours_strict(&p).is_err());
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -13,11 +13,11 @@ use qdrant_client::qdrant::quantization_config::Quantization;
 use qdrant_client::qdrant::vectors_config::Config;
 use qdrant_client::qdrant::{
     BinaryQuantization, Condition, CreateCollectionBuilder, DatetimeRange, DeleteCollectionBuilder,
-    Distance, FieldType, Filter, HnswConfigDiff, MaxOptimizationThreads, NamedVectors,
+    Distance, FieldType, Filter, Fusion, HnswConfigDiff, MaxOptimizationThreads, NamedVectors,
     OptimizersConfigDiff, PointStruct, PrefetchQueryBuilder, QuantizationSearchParams,
-    QuantizationType, QueryPointsBuilder, ScalarQuantization, SearchParams as QdrantSearchParams,
-    SparseVectorParamsBuilder, SparseVectorsConfigBuilder, Timestamp, Vector, VectorInput,
-    VectorParamsBuilder, VectorsConfig,
+    QuantizationType, Query, QueryPointsBuilder, ScalarQuantization,
+    SearchParams as QdrantSearchParams, SparseVectorParamsBuilder, SparseVectorsConfigBuilder,
+    Timestamp, Vector, VectorInput, VectorParamsBuilder, VectorsConfig, VectorsConfigBuilder,
 };
 use qdrant_client::{Payload, Qdrant};
 
@@ -176,6 +176,9 @@ impl QdrantEngine {
     }
 
     fn create_collection(&self, dataset: &Dataset) -> Result<(), String> {
+        if dataset.is_hybrid() {
+            return self.create_hybrid_collection(dataset);
+        }
         if dataset.is_sparse() {
             return self.create_sparse_collection(dataset);
         }
@@ -332,6 +335,111 @@ impl QdrantEngine {
             .map_err(|e| format!("Failed to create sparse collection: {}", e))?;
         self.create_payload_indexes(dataset);
         Ok(())
+    }
+
+    /// Create a HYBRID collection with a named dense vector ("dense") AND a named
+    /// sparse vector ("sparse"), so searches can fuse a dense-vector prefetch and
+    /// a sparse-vector prefetch server-side (RRF). The dense vector carries the
+    /// dataset's distance metric (and HNSW config, if configured); the sparse
+    /// vector uses Qdrant's default sparse index.
+    fn create_hybrid_collection(&self, dataset: &Dataset) -> Result<(), String> {
+        let distance = dataset.distance();
+        let vector_size = dataset.vector_size();
+        let qdrant_distance = match distance.to_lowercase().as_str() {
+            "l2" | "euclidean" => Distance::Euclid,
+            "cosine" | "angular" => Distance::Cosine,
+            "dot" | "ip" => Distance::Dot,
+            other => return Err(format!("Unsupported distance metric for Qdrant: {}", other)),
+        };
+
+        // Named dense vector "dense" (per-vector HNSW config if requested).
+        let mut dense_params = VectorParamsBuilder::new(vector_size as u64, qdrant_distance);
+        if self.hnsw_m.is_some() || self.hnsw_ef_construct.is_some() {
+            let mut hnsw_config = HnswConfigDiff::default();
+            if let Some(m) = self.hnsw_m {
+                hnsw_config.m = Some(m);
+            }
+            if let Some(ef) = self.hnsw_ef_construct {
+                hnsw_config.ef_construct = Some(ef);
+            }
+            dense_params = dense_params.hnsw_config(hnsw_config);
+        }
+        let mut dense_cfg = VectorsConfigBuilder::default();
+        dense_cfg.add_named_vector_params("dense", dense_params);
+
+        // Named sparse vector "sparse" (mirrors create_sparse_collection).
+        let mut sparse_cfg = SparseVectorsConfigBuilder::default();
+        sparse_cfg.add_named_vector_params("sparse", SparseVectorParamsBuilder::default());
+
+        let create_builder = CreateCollectionBuilder::new(&self.collection_name)
+            .vectors_config(dense_cfg)
+            .sparse_vectors_config(sparse_cfg);
+        self.rt
+            .block_on(self.client.create_collection(create_builder))
+            .map_err(|e| format!("Failed to create hybrid collection: {}", e))?;
+        self.create_payload_indexes(dataset);
+        Ok(())
+    }
+
+    /// Upload points carrying BOTH named vectors ("dense" + "sparse"), batched.
+    fn upload_hybrid(&mut self, dataset: &Dataset) -> Result<UploadStats, String> {
+        let normalize = dataset.needs_normalization();
+        let dataset_path = dataset.get_path()?;
+        println!("Reading hybrid dataset from {}...", dataset_path.display());
+        let read_start = Instant::now();
+        let (ids, dense, sparse) = dataset.read_hybrid_data(normalize)?;
+        let read_time = read_start.elapsed().as_secs_f64();
+        println!("Read {} hybrid vectors in {:.3}s", ids.len(), read_time);
+
+        println!("Starting hybrid upload, batch size {}...", self.batch_size);
+        let upload_start = Instant::now();
+        let pb = self.create_progress_bar(ids.len());
+        for start in (0..ids.len()).step_by(self.batch_size) {
+            let end = (start + self.batch_size).min(ids.len());
+            let points: Vec<PointStruct> = (start..end)
+                .map(|i| {
+                    PointStruct::new(
+                        ids[i] as u64,
+                        NamedVectors::default()
+                            .add_vector("dense", dense[i].clone())
+                            .add_vector(
+                                "sparse",
+                                Vector::new_sparse(
+                                    sparse[i].indices.clone(),
+                                    sparse[i].values.clone(),
+                                ),
+                            ),
+                        Payload::new(),
+                    )
+                })
+                .collect();
+            self.rt
+                .block_on(
+                    self.client.upsert_points(
+                        qdrant_client::qdrant::UpsertPointsBuilder::new(
+                            &self.collection_name,
+                            points,
+                        )
+                        .wait(true),
+                    ),
+                )
+                .map_err(|e| format!("Hybrid upsert failed: {}", e))?;
+            pb.inc((end - start) as u64);
+        }
+        pb.finish_with_message("Upload complete");
+        let upload_time = upload_start.elapsed().as_secs_f64();
+        let index_start = Instant::now();
+        self.wait_collection_green()?;
+        let index_time = index_start.elapsed().as_secs_f64();
+
+        Ok(UploadStats {
+            upload_time,
+            total_time: read_time + upload_time + index_time,
+            upload_count: ids.len(),
+            parallel: 1,
+            batch_size: self.batch_size,
+            memory_usage: None,
+        })
     }
 
     /// Upload sparse vectors under the named "sparse" vector, batched.
@@ -768,6 +876,9 @@ impl Engine for QdrantEngine {
     }
 
     fn upload(&mut self, dataset: &Dataset) -> Result<UploadStats, String> {
+        if dataset.is_hybrid() {
+            return self.upload_hybrid(dataset);
+        }
         if dataset.is_sparse() {
             return self.upload_sparse(dataset);
         }
@@ -881,10 +992,20 @@ impl Engine for QdrantEngine {
         let query_path = dataset.get_path()?;
         println!("\tReading queries from {}...", query_path.display());
 
-        // Dense and sparse queries are read into separate vectors; only one is
-        // populated. Filters/prefetch/quantization apply to the dense path only.
+        // Dense and sparse queries are read into separate vectors. For dense-only
+        // and sparse-only runs exactly one is populated; for HYBRID runs BOTH are
+        // populated (row-aligned) and fused server-side. Filters/prefetch/
+        // quantization apply to the dense-only path.
         let is_sparse = dataset.is_sparse();
-        let (queries, sparse_queries, neighbors, parsed_filters) = if is_sparse {
+        let is_hybrid = dataset.is_hybrid();
+        // Per-prefetch candidate depth for hybrid fusion: reuse the configured
+        // search_params.prefetch.limit if present, else a generous default (>= any
+        // sensible top-k). Larger = better fusion recall, more work.
+        let hybrid_prefetch_limit = prefetch_limit.unwrap_or(50);
+        let (queries, sparse_queries, neighbors, parsed_filters) = if is_hybrid {
+            let (dq, sq, nb) = dataset.read_hybrid_queries()?;
+            (dq, sq, nb, Vec::<Option<Filter>>::new())
+        } else if is_sparse {
             let (sq, nb) = dataset.read_sparse_queries()?;
             (Vec::<Vec<f32>>::new(), sq, nb, Vec::<Option<Filter>>::new())
         } else {
@@ -992,7 +1113,31 @@ impl Engine for QdrantEngine {
                             }
                         });
 
-                        let mut query_builder = if is_sparse {
+                        let mut query_builder = if is_hybrid {
+                            // Hybrid: two prefetches (dense NN + sparse NN) fused
+                            // server-side with reciprocal-rank fusion (RRF). Each
+                            // prefetch pulls `hybrid_prefetch_limit` candidates from
+                            // its own named vector; RRF ranks by combined rank.
+                            let dense_pf = PrefetchQueryBuilder::default()
+                                .using("dense")
+                                .query(Query::new_nearest(queries[idx].clone()))
+                                .limit(hybrid_prefetch_limit)
+                                .build();
+                            let sv = &sparse_queries[idx];
+                            let sparse_pf = PrefetchQueryBuilder::default()
+                                .using("sparse")
+                                .query(VectorInput::new_sparse(
+                                    sv.indices.clone(),
+                                    sv.values.clone(),
+                                ))
+                                .limit(hybrid_prefetch_limit)
+                                .build();
+                            QueryPointsBuilder::new(collection_name.clone())
+                                .query(Query::new_fusion(Fusion::Rrf))
+                                .prefetch(vec![dense_pf, sparse_pf])
+                                .limit(top as u64)
+                                .with_payload(false)
+                        } else if is_sparse {
                             let sv = &sparse_queries[idx];
                             QueryPointsBuilder::new(collection_name.clone())
                                 .query(VectorInput::new_sparse(
@@ -1020,7 +1165,7 @@ impl Engine for QdrantEngine {
                             qb
                         };
 
-                        if !is_sparse && prefetch_enabled {
+                        if !is_sparse && !is_hybrid && prefetch_enabled {
                             let mut pf =
                                 PrefetchQueryBuilder::default().query(queries[idx].clone());
                             if let Some(l) = prefetch_limit {

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -227,9 +227,31 @@ impl QdrantEngine {
             create_builder = create_builder.hnsw_config(hnsw_config);
         }
 
-        // Pass through optimizers_config (e.g. the rps-tuned default_segment_number /
-        // max_segment_size / memmap_threshold) — mirrors the python engine, which
-        // forwards collection_params verbatim.
+        // Pass through optimizers_config + quantization_config (shared with the
+        // hybrid create path).
+        create_builder = self.apply_optimizers_and_quantization(create_builder)?;
+
+        self.rt
+            .block_on(self.client.create_collection(create_builder))
+            .map_err(|e| format!("Failed to create collection: {}", e))?;
+
+        // Disable optimization during indexing.
+        self.disable_indexing_optimizers();
+
+        self.create_payload_indexes(dataset);
+
+        Ok(())
+    }
+
+    /// Apply `collection_params.optimizers_config` (rps-tuned segment / memmap
+    /// knobs) and `collection_params.quantization_config` (scalar/binary) to a
+    /// `CreateCollectionBuilder`. Shared verbatim by the dense-only and hybrid
+    /// create paths so the hybrid collection honours the SAME tuning (e.g.
+    /// qdrant-hybrid.json's `memmap_threshold`).
+    fn apply_optimizers_and_quantization(
+        &self,
+        mut create_builder: CreateCollectionBuilder,
+    ) -> Result<CreateCollectionBuilder, String> {
         if let Some(opt) = self.collection_params_extra.get("optimizers_config") {
             let mut diff = OptimizersConfigDiff::default();
             if let Some(v) = opt.get("default_segment_number").and_then(|v| v.as_u64()) {
@@ -244,7 +266,6 @@ impl QdrantEngine {
             create_builder = create_builder.optimizers_config(diff);
         }
 
-        // Pass through quantization_config (sq/bq tuned setups).
         if let Some(q) = self.collection_params_extra.get("quantization_config") {
             let quantization = if let Some(s) = q.get("scalar") {
                 let qtype = match s.get("type").and_then(|v| v.as_str()) {
@@ -270,12 +291,12 @@ impl QdrantEngine {
                 create_builder = create_builder.quantization_config(quantization);
             }
         }
+        Ok(create_builder)
+    }
 
-        self.rt
-            .block_on(self.client.create_collection(create_builder))
-            .map_err(|e| format!("Failed to create collection: {}", e))?;
-
-        // Disable optimization during indexing
+    /// Throttle optimizer threads to 0 during bulk indexing (re-enabled to auto
+    /// by `wait_collection_green`). Shared by the dense and hybrid create paths.
+    fn disable_indexing_optimizers(&self) {
         let _ = self.rt.block_on(
             self.client.update_collection(
                 qdrant_client::qdrant::UpdateCollectionBuilder::new(&self.collection_name)
@@ -289,10 +310,6 @@ impl QdrantEngine {
                     }),
             ),
         );
-
-        self.create_payload_indexes(dataset);
-
-        Ok(())
     }
 
     /// Create Qdrant payload indexes for the dataset's schema fields.
@@ -371,12 +388,20 @@ impl QdrantEngine {
         let mut sparse_cfg = SparseVectorsConfigBuilder::default();
         sparse_cfg.add_named_vector_params("sparse", SparseVectorParamsBuilder::default());
 
-        let create_builder = CreateCollectionBuilder::new(&self.collection_name)
+        let mut create_builder = CreateCollectionBuilder::new(&self.collection_name)
             .vectors_config(dense_cfg)
             .sparse_vectors_config(sparse_cfg);
+        // Honour the SAME optimizers_config / quantization_config tuning as the
+        // dense-only path (finding: hybrid previously dropped e.g. memmap_threshold).
+        create_builder = self.apply_optimizers_and_quantization(create_builder)?;
+
         self.rt
             .block_on(self.client.create_collection(create_builder))
             .map_err(|e| format!("Failed to create hybrid collection: {}", e))?;
+
+        // Throttle optimizer threads during indexing, same as the dense path.
+        self.disable_indexing_optimizers();
+
         self.create_payload_indexes(dataset);
         Ok(())
     }
@@ -1116,12 +1141,15 @@ impl Engine for QdrantEngine {
                         let mut query_builder = if is_hybrid {
                             // Hybrid: two prefetches (dense NN + sparse NN) fused
                             // server-side with reciprocal-rank fusion (RRF). Each
-                            // prefetch pulls `hybrid_prefetch_limit` candidates from
-                            // its own named vector; RRF ranks by combined rank.
+                            // prefetch pulls `pf_limit` candidates from its own named
+                            // vector; RRF ranks by combined rank. Floor the depth at
+                            // `top` so the fusion pool is never smaller than the
+                            // requested result count (which would understate recall).
+                            let pf_limit = hybrid_prefetch_limit.max(top as u64);
                             let dense_pf = PrefetchQueryBuilder::default()
                                 .using("dense")
                                 .query(Query::new_nearest(queries[idx].clone()))
-                                .limit(hybrid_prefetch_limit)
+                                .limit(pf_limit)
                                 .build();
                             let sv = &sparse_queries[idx];
                             let sparse_pf = PrefetchQueryBuilder::default()
@@ -1130,7 +1158,7 @@ impl Engine for QdrantEngine {
                                     sv.indices.clone(),
                                     sv.values.clone(),
                                 ))
-                                .limit(hybrid_prefetch_limit)
+                                .limit(pf_limit)
                                 .build();
                             QueryPointsBuilder::new(collection_name.clone())
                                 .query(Query::new_fusion(Fusion::Rrf))

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use vector_db_benchmark::readers::write_npy_vectors;
+use vector_db_benchmark::readers::{write_npy_vectors, write_sparse_matrix, SparseVector};
 
 /// Keyword values assigned round-robin to documents by `id % 4`.
 ///
@@ -444,6 +444,302 @@ pub fn write_tenant_project(
         },
         |q, id| id % N_TENANTS == q % N_TENANTS,
     )
+}
+
+// ── Sparse-vector fixture ───────────────────────────────────────────────────
+//
+// Builds a small sparse (`type: "sparse"`) dataset: `data.csr` + `queries.csr`
+// + `neighbours.jsonl`. Ground truth is brute-forced by sparse DOT PRODUCT and
+// sorted DESCENDING (sparse similarity is MIPS — larger dot = more similar), so
+// a high recall proves the engine ran a real sparse-index search. Sorting the
+// wrong way (ascending, as if it were an L2 distance) would pick the least
+// similar docs and silently zero out recall — hence the explicit `b.cmp a`.
+
+/// A built sparse-benchmark project.
+pub struct SparseProject {
+    pub root: PathBuf,
+    pub dataset_name: String,
+    pub top: usize,
+}
+
+/// Build a temp project with a deterministic random sparse dataset and its
+/// dot-product (descending) ground truth. `engine_configs_json` is the verbatim
+/// `experiments/configurations/test.json`.
+pub fn write_sparse_project(dataset_name: &str, engine_configs_json: &str) -> SparseProject {
+    const DIM: usize = 300;
+    const NNZ: usize = 10;
+    const N: usize = 150;
+    const Q: usize = 10;
+    const TOP: usize = 10;
+
+    // Fixed seed → reproducible data/queries/ground-truth across engines & runs.
+    let mut rng = StdRng::seed_from_u64(0x5A5A_5EED);
+    let mut make = |count: usize| -> Vec<SparseVector> {
+        (0..count)
+            .map(|_| {
+                let mut idx: Vec<u32> = Vec::with_capacity(NNZ);
+                while idx.len() < NNZ {
+                    let c = rng.gen_range(0..DIM as u32);
+                    if !idx.contains(&c) {
+                        idx.push(c);
+                    }
+                }
+                idx.sort_unstable();
+                let values: Vec<f32> = (0..NNZ).map(|_| rng.gen_range(0.1..1.0)).collect();
+                SparseVector {
+                    indices: idx,
+                    values,
+                }
+            })
+            .collect()
+    };
+    let data = make(N);
+    let queries = make(Q);
+
+    // Brute-force sparse dot product; sort DESCENDING (MIPS).
+    let dot = |a: &SparseVector, b: &SparseVector| -> f64 {
+        let mut s = 0.0f64;
+        for (i, &ai) in a.indices.iter().enumerate() {
+            if let Some(j) = b.indices.iter().position(|&bi| bi == ai) {
+                s += a.values[i] as f64 * b.values[j] as f64;
+            }
+        }
+        s
+    };
+    let neighbors: Vec<Vec<i64>> = queries
+        .iter()
+        .map(|qv| {
+            let mut scored: Vec<(i64, f64)> = data
+                .iter()
+                .enumerate()
+                .map(|(i, d)| (i as i64, dot(qv, d)))
+                .collect();
+            // DESCENDING by dot product (b vs a). Do NOT flip this.
+            scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+            scored.iter().take(TOP).map(|(id, _)| *id).collect()
+        })
+        .collect();
+
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().to_path_buf();
+    std::mem::forget(tmp);
+
+    let ds_dir = root.join("datasets").join(dataset_name);
+    fs::create_dir_all(&ds_dir).unwrap();
+    fs::create_dir_all(root.join("experiments/configurations")).unwrap();
+    fs::create_dir_all(root.join("results")).unwrap();
+    write_sparse_matrix(ds_dir.join("data.csr").to_str().unwrap(), &data).unwrap();
+    write_sparse_matrix(ds_dir.join("queries.csr").to_str().unwrap(), &queries).unwrap();
+    write_neighbours(&ds_dir, &neighbors);
+
+    let datasets_json = serde_json::json!([{
+        "name": dataset_name, "type": "sparse", "path": dataset_name,
+        "distance": "dot", "vector_size": DIM, "vector_count": N,
+    }]);
+    fs::write(
+        root.join("datasets/datasets.json"),
+        serde_json::to_string_pretty(&datasets_json).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        root.join("experiments/configurations/test.json"),
+        engine_configs_json,
+    )
+    .unwrap();
+
+    SparseProject {
+        root,
+        dataset_name: dataset_name.to_string(),
+        top: TOP,
+    }
+}
+
+// ── Hybrid (dense + sparse) fixture ─────────────────────────────────────────
+//
+// Builds a `type: "hybrid"` dataset: dense `vectors.npy`/`queries.npy` (L2) +
+// sparse `data.csr`/`queries.csr` (dot/MIPS) + a SHARED `neighbours.jsonl`.
+//
+// GROUND-TRUTH / RECALL-FLOOR CHOICE (documented on purpose):
+// We deliberately do NOT brute-force the exact RRF order — its constant `k` is a
+// server detail and reproducing it is fiddly and brittle. Instead we PLANT, for
+// each query, a set of K "relevant" docs (R) that are simultaneously the top-K
+// nearest by BOTH modalities:
+//   * dense: R sits ~0.04 (L2) from the query centre; a ring of dense-only
+//     distractors (U) sits at exactly 1.0 (ranks K..2K); everything else ~10.
+//   * sparse: R has dot = 2·K with the query; a ring of sparse-only distractors
+//     (T) has dot = K (ranks K..2K); everything else 0.
+// Under RRF, an R doc scores 1/(k+rank_dense) + 1/(k+rank_sparse) with BOTH
+// ranks < K, while U scores only from dense (rank ≥ K) and T only from sparse
+// (rank ≥ K). Since 2/(k+K-1) > 1/(k+K) for every k ≥ 0, the fused top-K is
+// exactly R for ANY RRF constant. The ground truth is therefore R, and a
+// correct hybrid pipeline yields recall ≈ 1.0; we assert a 0.9 FLOOR to absorb
+// ANN approximation. The distractors give the test teeth: they make each
+// modality individually return a wrong ranking beyond rank K, and an inverted
+// sparse ordering (ascending, as if L2) drops R out of the sparse list and
+// pushes T up, cutting recall below the floor. (Limitation: because R is top-K
+// in both modalities, this validates end-to-end fusion + orientation, not an
+// exclusively-fusion contribution.)
+
+/// A built hybrid-benchmark project.
+pub struct HybridProject {
+    pub root: PathBuf,
+    pub dataset_name: String,
+    pub top: usize,
+}
+
+/// Build a temp project with a deterministic planted hybrid dataset (dense +
+/// sparse) whose fused (RRF) top-K ground truth is the planted relevant set.
+pub fn write_hybrid_project(dataset_name: &str, engine_configs_json: &str) -> HybridProject {
+    const K: usize = 8; // top-k / relevant-set size
+    const Q: usize = 6; // queries (and dense centre axes)
+    const DENSE_DIM: usize = 16; // >= Q (centre dims) + K (distractor bump dims)
+    const FILLER: usize = 6;
+    const N: usize = Q * 3 * K + FILLER; // R + U + T per query, then filler = 150
+    const BUMP_DIMS: usize = DENSE_DIM - Q; // dims Q..DENSE_DIM used for U bumps
+
+    // Sparse layout: query q owns index block F_q = [q*K .. q*K+K); U/filler use
+    // a disjoint "junk" block J so their dot with any query is 0.
+    const SPARSE_DIM: usize = Q * K + K; // per-query blocks + junk block
+
+    let mut rng = StdRng::seed_from_u64(0xB19_1DEA);
+    let tiny = |rng: &mut StdRng| -> f32 { rng.gen_range(-0.01f32..0.01) };
+
+    // Doc-id block layout for query q: base = q*3K.
+    let base = |q: usize| q * 3 * K;
+    let r_id = |q: usize, j: usize| base(q) + j; // relevant  [base, base+K)
+    let u_id = |q: usize, j: usize| base(q) + K + j; // dense-only [base+K, base+2K)
+    let t_id = |q: usize, j: usize| base(q) + 2 * K + j; // sparse-only[base+2K, base+3K)
+    let filler_start = Q * 3 * K;
+
+    // Dense centre for query q: 10.0 on axis q, else 0. Regions are ~14 apart.
+    let centre = |q: usize| -> Vec<f32> {
+        let mut v = vec![0.0f32; DENSE_DIM];
+        v[q] = 10.0;
+        v
+    };
+
+    // Build dense + sparse per doc.
+    let mut dense: Vec<Vec<f32>> = vec![vec![0.0f32; DENSE_DIM]; N];
+    let mut sparse: Vec<SparseVector> = vec![
+        SparseVector {
+            indices: vec![],
+            values: vec![]
+        };
+        N
+    ];
+    let junk: Vec<u32> = (Q * K..Q * K + K).map(|i| i as u32).collect();
+
+    for q in 0..Q {
+        let c = centre(q);
+        let f_q: Vec<u32> = (q * K..q * K + K).map(|i| i as u32).collect();
+        for j in 0..K {
+            // R: dense ≈ centre (~0.04 away); sparse dot = 2·K (top).
+            let mut rv = c.clone();
+            for x in rv.iter_mut() {
+                *x += tiny(&mut rng);
+            }
+            dense[r_id(q, j)] = rv;
+            sparse[r_id(q, j)] = SparseVector {
+                indices: f_q.clone(),
+                values: vec![2.0f32; K],
+            };
+
+            // U: dense = centre + unit bump (exactly 1.0 away → ranks K..2K);
+            // sparse = junk block → dot 0 (absent from sparse list).
+            let mut uv = c.clone();
+            uv[Q + (j % BUMP_DIMS)] += 1.0;
+            dense[u_id(q, j)] = uv;
+            sparse[u_id(q, j)] = SparseVector {
+                indices: junk.clone(),
+                values: vec![1.0f32; K],
+            };
+
+            // T: dense ≈ origin (~10 away → absent from dense list); sparse dot =
+            // K (ranks K..2K, below R's 2·K).
+            let mut tv = vec![0.0f32; DENSE_DIM];
+            for x in tv.iter_mut() {
+                *x += tiny(&mut rng);
+            }
+            dense[t_id(q, j)] = tv;
+            sparse[t_id(q, j)] = SparseVector {
+                indices: f_q.clone(),
+                values: vec![1.0f32; K],
+            };
+        }
+    }
+    // Filler: dense ≈ origin, sparse in junk block (dot 0 with every query).
+    for (i, id) in (filler_start..N).enumerate() {
+        let _ = i;
+        let mut fv = vec![0.0f32; DENSE_DIM];
+        for x in fv.iter_mut() {
+            *x += tiny(&mut rng);
+        }
+        dense[id] = fv;
+        sparse[id] = SparseVector {
+            indices: junk.clone(),
+            values: vec![1.0f32; K],
+        };
+    }
+
+    // Queries: dense = centre_q, sparse = ones on F_q. Ground truth = R_q.
+    let mut dense_q: Vec<Vec<f32>> = Vec::with_capacity(Q);
+    let mut sparse_q: Vec<SparseVector> = Vec::with_capacity(Q);
+    let mut neighbours: Vec<Vec<i64>> = Vec::with_capacity(Q);
+    for q in 0..Q {
+        dense_q.push(centre(q));
+        sparse_q.push(SparseVector {
+            indices: (q * K..q * K + K).map(|i| i as u32).collect(),
+            values: vec![1.0f32; K],
+        });
+        neighbours.push((0..K).map(|j| r_id(q, j) as i64).collect());
+    }
+    debug_assert_eq!(SPARSE_DIM, Q * K + K);
+
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().to_path_buf();
+    std::mem::forget(tmp);
+
+    let ds_dir = root.join("datasets").join(dataset_name);
+    fs::create_dir_all(&ds_dir).unwrap();
+    fs::create_dir_all(root.join("experiments/configurations")).unwrap();
+    fs::create_dir_all(root.join("results")).unwrap();
+
+    write_npy_vectors(ds_dir.join("vectors.npy").to_str().unwrap(), &dense).unwrap();
+    write_npy_vectors(ds_dir.join("queries.npy").to_str().unwrap(), &dense_q).unwrap();
+    write_sparse_matrix(ds_dir.join("data.csr").to_str().unwrap(), &sparse).unwrap();
+    write_sparse_matrix(ds_dir.join("queries.csr").to_str().unwrap(), &sparse_q).unwrap();
+    write_neighbours(&ds_dir, &neighbours);
+
+    let datasets_json = serde_json::json!([{
+        "name": dataset_name, "type": "hybrid", "path": dataset_name,
+        "distance": "l2", "vector_size": DENSE_DIM, "vector_count": N,
+    }]);
+    fs::write(
+        root.join("datasets/datasets.json"),
+        serde_json::to_string_pretty(&datasets_json).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        root.join("experiments/configurations/test.json"),
+        engine_configs_json,
+    )
+    .unwrap();
+
+    HybridProject {
+        root,
+        dataset_name: dataset_name.to_string(),
+        top: K,
+    }
+}
+
+/// Write `neighbours.jsonl` (one JSON id-array per line) into `ds_dir`.
+fn write_neighbours(ds_dir: &Path, neighbours: &[Vec<i64>]) {
+    let nb = neighbours
+        .iter()
+        .map(|nn| serde_json::to_string(nn).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(ds_dir.join("neighbours.jsonl"), nb).unwrap();
 }
 
 /// Path to the compiled binary under test. Cargo exports

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -559,66 +559,92 @@ pub fn write_sparse_project(dataset_name: &str, engine_configs_json: &str) -> Sp
 // Builds a `type: "hybrid"` dataset: dense `vectors.npy`/`queries.npy` (L2) +
 // sparse `data.csr`/`queries.csr` (dot/MIPS) + a SHARED `neighbours.jsonl`.
 //
-// GROUND-TRUTH / RECALL-FLOOR CHOICE (documented on purpose):
-// We deliberately do NOT brute-force the exact RRF order — its constant `k` is a
-// server detail and reproducing it is fiddly and brittle. Instead we PLANT, for
-// each query, a set of K "relevant" docs (R) that are simultaneously the top-K
-// nearest by BOTH modalities:
-//   * dense: R sits ~0.04 (L2) from the query centre; a ring of dense-only
-//     distractors (U) sits at exactly 1.0 (ranks K..2K); everything else ~10.
-//   * sparse: R has dot = 2·K with the query; a ring of sparse-only distractors
-//     (T) has dot = K (ranks K..2K); everything else 0.
-// Under RRF, an R doc scores 1/(k+rank_dense) + 1/(k+rank_sparse) with BOTH
-// ranks < K, while U scores only from dense (rank ≥ K) and T only from sparse
-// (rank ≥ K). Since 2/(k+K-1) > 1/(k+K) for every k ≥ 0, the fused top-K is
-// exactly R for ANY RRF constant. The ground truth is therefore R, and a
-// correct hybrid pipeline yields recall ≈ 1.0; we assert a 0.9 FLOOR to absorb
-// ANN approximation. The distractors give the test teeth: they make each
-// modality individually return a wrong ranking beyond rank K, and an inverted
-// sparse ordering (ascending, as if L2) drops R out of the sparse list and
-// pushes T up, cutting recall below the floor. (Limitation: because R is top-K
-// in both modalities, this validates end-to-end fusion + orientation, not an
-// exclusively-fusion contribution.)
+// GROUND-TRUTH / RECALL-FLOOR CHOICE — the ground truth R is recoverable ONLY
+// via fusion; NEITHER modality alone reaches the floor.
+//
+// We deliberately do NOT brute-force the exact RRF order (its constant `k` is a
+// server detail). Instead we PLANT, per query, K ground-truth docs split into
+// two halves and two rings of single-modality distractors:
+//   * R_dense (K/2 docs): dense ranks 0..K/2 (nearest by L2), but only MODERATE
+//     sparse dot → in the sparse ranking they land at ranks K..3K/2 (below both
+//     R_sparse and the sparse distractors).
+//   * R_sparse (K/2 docs): sparse ranks 0..K/2 (highest dot), but only MODERATE
+//     dense distance → in the dense ranking they land at ranks K..3K/2.
+//   * D_d (K/2 dense-only distractors): dense ranks K/2..K (just past R_dense),
+//     ~zero sparse dot → absent from the meaningful sparse list.
+//   * D_s (K/2 sparse-only distractors): sparse ranks K/2..K (just below
+//     R_sparse), dense-far → absent from the meaningful dense list.
+//
+// Consequence:
+//   * dense-only top-K  = R_dense + D_d  → recall(R) ≈ 0.5
+//   * sparse-only top-K = R_sparse + D_s → recall(R) ≈ 0.5
+//   * fused (RRF) top-K = R (all K)      → recall(R) ≈ 1.0
+// Under RRF every R doc appears in BOTH prefetches (its "off" modality ranks it
+// at K..3K/2, still inside the prefetch depth), so it collects TWO 1/(k+rank)
+// terms — and one of them has rank < K/2. Every distractor appears in only ONE
+// prefetch with rank ≥ K/2, so its best (only meaningful) term is ≤ 1/(k+K/2) <
+// 1/(k+K/2−1). Thus every R doc outscores every distractor for ANY k ≥ 0, and
+// the fused top-K is exactly R. We assert a 0.9 FLOOR on the fused recall to
+// absorb ANN slack, and the companion `*-dense` view (registered below) drives
+// the SAME data through a plain dense search as a NEGATIVE CONTROL that MUST
+// score < 0.6 — proving the dataset genuinely requires fusion. An inverted
+// sparse orientation (ascending, as if L2), a dropped sparse prefetch, or a
+// broken `Fusion::Rrf` all collapse the fused result toward one modality and
+// fail the floor.
 
-/// A built hybrid-benchmark project.
+/// A built hybrid-benchmark project. `dataset_name` is the `type:"hybrid"`
+/// dataset; `dense_dataset_name` is a dense-only (`type:"jsonl"`) VIEW over the
+/// SAME dense vectors + SAME ground truth, used as a negative control.
 pub struct HybridProject {
     pub root: PathBuf,
     pub dataset_name: String,
+    pub dense_dataset_name: String,
     pub top: usize,
 }
 
-/// Build a temp project with a deterministic planted hybrid dataset (dense +
-/// sparse) whose fused (RRF) top-K ground truth is the planted relevant set.
+/// Build a temp project with a deterministic planted hybrid dataset whose fused
+/// (RRF) top-K ground truth is recoverable ONLY by combining both modalities.
 pub fn write_hybrid_project(dataset_name: &str, engine_configs_json: &str) -> HybridProject {
-    const K: usize = 8; // top-k / relevant-set size
+    const K: usize = 8; // top-k / ground-truth-set size (must be even)
+    const HALF: usize = K / 2; // per-half / per-distractor-ring size
     const Q: usize = 6; // queries (and dense centre axes)
-    const DENSE_DIM: usize = 16; // >= Q (centre dims) + K (distractor bump dims)
-    const FILLER: usize = 6;
-    const N: usize = Q * 3 * K + FILLER; // R + U + T per query, then filler = 150
-    const BUMP_DIMS: usize = DENSE_DIM - Q; // dims Q..DENSE_DIM used for U bumps
+    const DENSE_DIM: usize = 16; // >= Q centre dims + HALF distractor bump dims
+    const PER_Q: usize = 4 * HALF; // R_dense + R_sparse + D_d + D_s per query
+    const FILLER: usize = 24;
+    const N: usize = Q * PER_Q + FILLER; // = 120
+    const BIG: f32 = 100.0; // centre magnitude → regions ~141 apart, origin ~100
 
-    // Sparse layout: query q owns index block F_q = [q*K .. q*K+K); U/filler use
-    // a disjoint "junk" block J so their dot with any query is 0.
-    const SPARSE_DIM: usize = Q * K + K; // per-query blocks + junk block
+    // Sparse layout: query q owns index block F_q = [q*HALF .. q*HALF+HALF);
+    // dense-only distractors / filler use a disjoint "junk" block J (dot 0).
+    const F_TOTAL: usize = Q * HALF;
 
     let mut rng = StdRng::seed_from_u64(0xB19_1DEA);
     let tiny = |rng: &mut StdRng| -> f32 { rng.gen_range(-0.01f32..0.01) };
 
-    // Doc-id block layout for query q: base = q*3K.
-    let base = |q: usize| q * 3 * K;
-    let r_id = |q: usize, j: usize| base(q) + j; // relevant  [base, base+K)
-    let u_id = |q: usize, j: usize| base(q) + K + j; // dense-only [base+K, base+2K)
-    let t_id = |q: usize, j: usize| base(q) + 2 * K + j; // sparse-only[base+2K, base+3K)
-    let filler_start = Q * 3 * K;
+    // Doc-id block layout for query q: base = q*PER_Q, then four HALF-sized rings.
+    let base = |q: usize| q * PER_Q;
+    let r_dense_id = |q: usize, j: usize| base(q) + j; //            [base,       base+HALF)
+    let r_sparse_id = |q: usize, j: usize| base(q) + HALF + j; //    [base+HALF,  base+2HALF)
+    let d_d_id = |q: usize, j: usize| base(q) + 2 * HALF + j; //     [base+2HALF, base+3HALF)
+    let d_s_id = |q: usize, j: usize| base(q) + 3 * HALF + j; //     [base+3HALF, base+4HALF)
+    let filler_start = Q * PER_Q;
 
-    // Dense centre for query q: 10.0 on axis q, else 0. Regions are ~14 apart.
+    // Dense centre for query q: BIG on axis q, else 0.
     let centre = |q: usize| -> Vec<f32> {
         let mut v = vec![0.0f32; DENSE_DIM];
-        v[q] = 10.0;
+        v[q] = BIG;
+        v
+    };
+    // A dense doc = centre + `mag` along a distractor axis (dims Q..DENSE_DIM),
+    // so its L2 distance from the query (= centre) is exactly `mag`.
+    let offset_from = |c: &[f32], mag: f32, j: usize| -> Vec<f32> {
+        let mut v = c.to_vec();
+        v[Q + (j % (DENSE_DIM - Q))] += mag;
         v
     };
 
-    // Build dense + sparse per doc.
+    let junk: Vec<u32> = (F_TOTAL..F_TOTAL + HALF).map(|i| i as u32).collect();
+
     let mut dense: Vec<Vec<f32>> = vec![vec![0.0f32; DENSE_DIM]; N];
     let mut sparse: Vec<SparseVector> = vec![
         SparseVector {
@@ -627,49 +653,40 @@ pub fn write_hybrid_project(dataset_name: &str, engine_configs_json: &str) -> Hy
         };
         N
     ];
-    let junk: Vec<u32> = (Q * K..Q * K + K).map(|i| i as u32).collect();
 
     for q in 0..Q {
         let c = centre(q);
-        let f_q: Vec<u32> = (q * K..q * K + K).map(|i| i as u32).collect();
-        for j in 0..K {
-            // R: dense ≈ centre (~0.04 away); sparse dot = 2·K (top).
-            let mut rv = c.clone();
-            for x in rv.iter_mut() {
+        let f_q: Vec<u32> = (q * HALF..q * HALF + HALF).map(|i| i as u32).collect();
+        // Per-doc tiny increments break ties so tiers stay crisply ordered.
+        let sp = |indices: &[u32], val: f32, j: usize| SparseVector {
+            indices: indices.to_vec(),
+            values: indices.iter().map(|_| val + 0.001 * j as f32).collect(),
+        };
+        for j in 0..HALF {
+            // R_dense: dense dist 1.0 (ranks 0..HALF); sparse dot ~ HALF*1 (low).
+            dense[r_dense_id(q, j)] = offset_from(&c, 1.0, j);
+            sparse[r_dense_id(q, j)] = sp(&f_q, 1.0, j);
+
+            // D_d: dense dist 2.0 (ranks HALF..K); sparse = junk → dot 0.
+            dense[d_d_id(q, j)] = offset_from(&c, 2.0, HALF + j);
+            sparse[d_d_id(q, j)] = sp(&junk, 1.0, j);
+
+            // R_sparse: dense dist 3.0 (ranks K..3K/2); sparse dot ~ HALF*3 (top).
+            dense[r_sparse_id(q, j)] = offset_from(&c, 3.0, 2 * HALF + j);
+            sparse[r_sparse_id(q, j)] = sp(&f_q, 3.0, j);
+
+            // D_s: dense ≈ origin (dist ~BIG, absent from dense top); sparse dot ~
+            // HALF*2 (ranks HALF..K, between R_sparse and R_dense).
+            let mut ds_v = vec![0.0f32; DENSE_DIM];
+            for x in ds_v.iter_mut() {
                 *x += tiny(&mut rng);
             }
-            dense[r_id(q, j)] = rv;
-            sparse[r_id(q, j)] = SparseVector {
-                indices: f_q.clone(),
-                values: vec![2.0f32; K],
-            };
-
-            // U: dense = centre + unit bump (exactly 1.0 away → ranks K..2K);
-            // sparse = junk block → dot 0 (absent from sparse list).
-            let mut uv = c.clone();
-            uv[Q + (j % BUMP_DIMS)] += 1.0;
-            dense[u_id(q, j)] = uv;
-            sparse[u_id(q, j)] = SparseVector {
-                indices: junk.clone(),
-                values: vec![1.0f32; K],
-            };
-
-            // T: dense ≈ origin (~10 away → absent from dense list); sparse dot =
-            // K (ranks K..2K, below R's 2·K).
-            let mut tv = vec![0.0f32; DENSE_DIM];
-            for x in tv.iter_mut() {
-                *x += tiny(&mut rng);
-            }
-            dense[t_id(q, j)] = tv;
-            sparse[t_id(q, j)] = SparseVector {
-                indices: f_q.clone(),
-                values: vec![1.0f32; K],
-            };
+            dense[d_s_id(q, j)] = ds_v;
+            sparse[d_s_id(q, j)] = sp(&f_q, 2.0, j);
         }
     }
     // Filler: dense ≈ origin, sparse in junk block (dot 0 with every query).
-    for (i, id) in (filler_start..N).enumerate() {
-        let _ = i;
+    for id in filler_start..N {
         let mut fv = vec![0.0f32; DENSE_DIM];
         for x in fv.iter_mut() {
             *x += tiny(&mut rng);
@@ -677,23 +694,25 @@ pub fn write_hybrid_project(dataset_name: &str, engine_configs_json: &str) -> Hy
         dense[id] = fv;
         sparse[id] = SparseVector {
             indices: junk.clone(),
-            values: vec![1.0f32; K],
+            values: vec![1.0f32; HALF],
         };
     }
 
-    // Queries: dense = centre_q, sparse = ones on F_q. Ground truth = R_q.
+    // Queries: dense = centre_q, sparse = ones on F_q. Ground truth R_q =
+    // R_dense ∪ R_sparse (the full K planted docs).
     let mut dense_q: Vec<Vec<f32>> = Vec::with_capacity(Q);
     let mut sparse_q: Vec<SparseVector> = Vec::with_capacity(Q);
     let mut neighbours: Vec<Vec<i64>> = Vec::with_capacity(Q);
     for q in 0..Q {
         dense_q.push(centre(q));
         sparse_q.push(SparseVector {
-            indices: (q * K..q * K + K).map(|i| i as u32).collect(),
-            values: vec![1.0f32; K],
+            indices: (q * HALF..q * HALF + HALF).map(|i| i as u32).collect(),
+            values: vec![1.0f32; HALF],
         });
-        neighbours.push((0..K).map(|j| r_id(q, j) as i64).collect());
+        let mut gt: Vec<i64> = (0..HALF).map(|j| r_dense_id(q, j) as i64).collect();
+        gt.extend((0..HALF).map(|j| r_sparse_id(q, j) as i64));
+        neighbours.push(gt);
     }
-    debug_assert_eq!(SPARSE_DIM, Q * K + K);
 
     let tmp = tempfile::tempdir().expect("temp dir");
     let root = tmp.path().to_path_buf();
@@ -710,10 +729,25 @@ pub fn write_hybrid_project(dataset_name: &str, engine_configs_json: &str) -> Hy
     write_sparse_matrix(ds_dir.join("queries.csr").to_str().unwrap(), &sparse_q).unwrap();
     write_neighbours(&ds_dir, &neighbours);
 
-    let datasets_json = serde_json::json!([{
-        "name": dataset_name, "type": "hybrid", "path": dataset_name,
-        "distance": "l2", "vector_size": DENSE_DIM, "vector_count": N,
-    }]);
+    // Dense-only VIEW (negative control): same dense vectors + same ground truth
+    // as a plain jsonl dataset, so an ordinary dense search can be run on it.
+    let dense_dataset_name = format!("{dataset_name}-dense");
+    let dv_dir = root.join("datasets").join(&dense_dataset_name);
+    fs::create_dir_all(&dv_dir).unwrap();
+    write_jsonl_vectors(&dv_dir.join("vectors.jsonl"), &dense);
+    write_jsonl_vectors(&dv_dir.join("queries.jsonl"), &dense_q);
+    write_neighbours(&dv_dir, &neighbours);
+
+    let datasets_json = serde_json::json!([
+        {
+            "name": dataset_name, "type": "hybrid", "path": dataset_name,
+            "distance": "l2", "vector_size": DENSE_DIM, "vector_count": N,
+        },
+        {
+            "name": dense_dataset_name, "type": "jsonl", "path": format!("{dense_dataset_name}/"),
+            "distance": "l2", "vector_size": DENSE_DIM, "vector_count": N,
+        },
+    ]);
     fs::write(
         root.join("datasets/datasets.json"),
         serde_json::to_string_pretty(&datasets_json).unwrap(),
@@ -728,8 +762,20 @@ pub fn write_hybrid_project(dataset_name: &str, engine_configs_json: &str) -> Hy
     HybridProject {
         root,
         dataset_name: dataset_name.to_string(),
+        dense_dataset_name,
         top: K,
     }
+}
+
+/// Write `vectors` as a `.jsonl` file (one JSON float-array per line), the
+/// layout the `type:"jsonl"` reader expects.
+fn write_jsonl_vectors(path: &Path, vectors: &[Vec<f32>]) {
+    let body = vectors
+        .iter()
+        .map(|v| serde_json::to_string(&v.iter().map(|x| *x as f64).collect::<Vec<_>>()).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(path, body).unwrap();
 }
 
 /// Write `neighbours.jsonl` (one JSON id-array per line) into `ds_dir`.

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -576,33 +576,71 @@ fn test_binary_qdrant_sparse() {
     assert!(precision >= 0.9, "sparse precision {:.3} < 0.9", precision);
 }
 
-/// End-to-end HYBRID (dense + sparse) coverage: build a planted hybrid dataset
-/// (via `write_hybrid_project`), run the real engine (hybrid collection with a
-/// named "dense" + named "sparse" vector, upsert of both, and a query that fuses
-/// a dense prefetch and a sparse prefetch server-side with RRF), and assert the
-/// fused recall clears the 0.9 floor. See `write_hybrid_project` for the
-/// ground-truth / floor justification.
+/// End-to-end HYBRID (dense + sparse) coverage WITH a negative control.
+///
+/// The planted dataset's ground truth is recoverable ONLY by fusing both
+/// modalities (see `write_hybrid_project`). We assert two things against live
+/// qdrant:
+///   1. the HYBRID engine (named "dense" + "sparse" vectors, upsert of both, a
+///      query fusing a dense prefetch and a sparse prefetch via RRF) clears the
+///      0.9 recall floor, and
+///   2. a NEGATIVE CONTROL — a plain dense search over the SAME dense vectors +
+///      SAME ground truth (the `*-dense` jsonl view) — stays strictly LOW
+///      (< 0.6). Together these prove the dataset genuinely requires fusion and
+///      the hybrid path is doing real work, not silently collapsing to one
+///      modality.
 #[test]
 fn test_binary_qdrant_hybrid() {
     wait_for_qdrant();
 
-    let configs = serde_json::json!([{
-        "name": "qdrant-hybrid-cov", "engine": "qdrant",
-        "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
-        // prefetch.limit sets the per-modality candidate depth fused by RRF.
-        "search_params": [{"parallel": 1, "search_params": {"prefetch": {"limit": 32}}}],
-        "upload_params": {"parallel": 1, "batch_size": 50}
-    }]);
+    let configs = serde_json::json!([
+        {
+            "name": "qdrant-hybrid-cov", "engine": "qdrant",
+            "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+            // prefetch.limit sets the per-modality candidate depth fused by RRF
+            // (>= 2*top so each ground-truth doc is visible in both prefetches).
+            "search_params": [{"parallel": 1, "search_params": {"prefetch": {"limit": 32}}}],
+            "upload_params": {"parallel": 1, "batch_size": 50}
+        },
+        {
+            "name": "qdrant-hybrid-dense-neg", "engine": "qdrant",
+            "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+            "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 128}}],
+            "upload_params": {"parallel": 1, "batch_size": 50}
+        }
+    ]);
     let proj =
         common::write_hybrid_project("hybrid-cov", &serde_json::to_string(&configs).unwrap());
 
+    // 1. Fused hybrid recall must clear the floor.
     assert!(
-        run_qdrant_binary(&proj.root, "qdrant-hybrid-cov", "hybrid-cov"),
+        run_qdrant_binary(&proj.root, "qdrant-hybrid-cov", &proj.dataset_name),
         "hybrid run failed"
     );
     let recall = common::read_recall(&proj.root, "qdrant-hybrid-cov");
     println!("qdrant hybrid recall={:.3} (top={})", recall, proj.top);
     assert!(recall >= 0.9, "hybrid recall {:.3} < 0.9", recall);
+
+    // 2. Negative control: plain dense search over the SAME data must be LOW,
+    //    proving the ground truth is unreachable without the sparse modality.
+    assert!(
+        run_qdrant_binary(
+            &proj.root,
+            "qdrant-hybrid-dense-neg",
+            &proj.dense_dataset_name
+        ),
+        "dense-only negative-control run failed"
+    );
+    let dense_recall = common::read_recall(&proj.root, "qdrant-hybrid-dense-neg");
+    println!("qdrant hybrid dense-only negative-control recall={dense_recall:.3}");
+    assert!(
+        dense_recall < 0.6,
+        "negative control recall {dense_recall:.3} >= 0.6 — dataset does NOT require fusion",
+    );
+    assert!(
+        recall > dense_recall + 0.3,
+        "fusion ({recall:.3}) must beat dense-only ({dense_recall:.3}) by a wide margin",
+    );
 }
 
 /// End-to-end `match_any` coverage. Qdrant already supports `match_any`, so this

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -548,112 +548,61 @@ fn test_binary_qdrant_query_points_and_prefetch() {
     );
 }
 
-/// End-to-end sparse-vector coverage: build a small sparse dataset, run the real
-/// engine (sparse collection + upsert + query_points using="sparse"), and assert
-/// recall vs brute-force dot-product ground truth.
+/// End-to-end sparse-vector coverage: build a small sparse dataset (via the
+/// shared `write_sparse_project` fixture), run the real engine (sparse collection,
+/// upsert, and a `query_points` search using the named "sparse" vector), then
+/// assert recall against brute-force dot-product (descending / MIPS) ground truth.
 #[test]
 fn test_binary_qdrant_sparse() {
-    use std::fs;
-    use vector_db_benchmark::readers::{write_sparse_matrix, SparseVector};
-
     wait_for_qdrant();
 
-    let dim = 300usize;
-    let nnz = 10usize;
-    let n = 150usize;
-    let q = 10usize;
-    let top = 10usize;
-    let mut rng = rand::thread_rng();
-
-    let mut make = |count: usize| -> Vec<SparseVector> {
-        (0..count)
-            .map(|_| {
-                let mut idx: Vec<u32> = Vec::with_capacity(nnz);
-                while idx.len() < nnz {
-                    let c = rng.gen_range(0..dim as u32);
-                    if !idx.contains(&c) {
-                        idx.push(c);
-                    }
-                }
-                idx.sort_unstable();
-                let values: Vec<f32> = (0..nnz).map(|_| rng.gen_range(0.1..1.0)).collect();
-                SparseVector {
-                    indices: idx,
-                    values,
-                }
-            })
-            .collect()
-    };
-    let data = make(n);
-    let queries = make(q);
-
-    // Brute-force sparse dot product for ground truth.
-    let dot = |a: &SparseVector, b: &SparseVector| -> f64 {
-        let mut s = 0.0f64;
-        for (i, &ai) in a.indices.iter().enumerate() {
-            if let Some(j) = b.indices.iter().position(|&bi| bi == ai) {
-                s += a.values[i] as f64 * b.values[j] as f64;
-            }
-        }
-        s
-    };
-    let neighbors: Vec<Vec<i64>> = queries
-        .iter()
-        .map(|qv| {
-            let mut scored: Vec<(i64, f64)> = data
-                .iter()
-                .enumerate()
-                .map(|(i, d)| (i as i64, dot(qv, d)))
-                .collect();
-            scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-            scored.iter().take(top).map(|(id, _)| *id).collect()
-        })
-        .collect();
-
-    // Temp project with CSR sparse dataset.
-    let tmp = tempfile::tempdir().expect("temp dir");
-    let root = tmp.path().to_path_buf();
-    std::mem::forget(tmp);
-    let ds_dir = root.join("datasets").join("sparse-cov");
-    fs::create_dir_all(&ds_dir).unwrap();
-    fs::create_dir_all(root.join("experiments/configurations")).unwrap();
-    fs::create_dir_all(root.join("results")).unwrap();
-    write_sparse_matrix(ds_dir.join("data.csr").to_str().unwrap(), &data).unwrap();
-    write_sparse_matrix(ds_dir.join("queries.csr").to_str().unwrap(), &queries).unwrap();
-    let nb = neighbors
-        .iter()
-        .map(|nn| serde_json::to_string(nn).unwrap())
-        .collect::<Vec<_>>()
-        .join("\n");
-    fs::write(ds_dir.join("neighbours.jsonl"), nb).unwrap();
-
-    let datasets_json = serde_json::json!([{
-        "name": "sparse-cov", "type": "sparse", "path": "sparse-cov",
-        "distance": "dot", "vector_size": dim, "vector_count": n,
-    }]);
-    fs::write(
-        root.join("datasets/datasets.json"),
-        serde_json::to_string_pretty(&datasets_json).unwrap(),
-    )
-    .unwrap();
     let configs = serde_json::json!([{
         "name": "qdrant-sparse-cov", "engine": "qdrant",
         "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
         "search_params": [{"parallel": 1}], "upload_params": {"parallel": 1, "batch_size": 50}
     }]);
-    fs::write(
-        root.join("experiments/configurations/test.json"),
-        serde_json::to_string(&configs).unwrap(),
-    )
-    .unwrap();
+    let proj =
+        common::write_sparse_project("sparse-cov", &serde_json::to_string(&configs).unwrap());
 
     assert!(
-        run_qdrant_binary(&root, "qdrant-sparse-cov", "sparse-cov"),
+        run_qdrant_binary(&proj.root, "qdrant-sparse-cov", "sparse-cov"),
         "sparse run failed"
     );
-    let precision = read_precision(&root, "qdrant-sparse-cov");
-    println!("qdrant sparse precision={:.3}", precision);
+    let precision = read_precision(&proj.root, "qdrant-sparse-cov");
+    println!(
+        "qdrant sparse precision={:.3} (top={})",
+        precision, proj.top
+    );
     assert!(precision >= 0.9, "sparse precision {:.3} < 0.9", precision);
+}
+
+/// End-to-end HYBRID (dense + sparse) coverage: build a planted hybrid dataset
+/// (via `write_hybrid_project`), run the real engine (hybrid collection with a
+/// named "dense" + named "sparse" vector, upsert of both, and a query that fuses
+/// a dense prefetch and a sparse prefetch server-side with RRF), and assert the
+/// fused recall clears the 0.9 floor. See `write_hybrid_project` for the
+/// ground-truth / floor justification.
+#[test]
+fn test_binary_qdrant_hybrid() {
+    wait_for_qdrant();
+
+    let configs = serde_json::json!([{
+        "name": "qdrant-hybrid-cov", "engine": "qdrant",
+        "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+        // prefetch.limit sets the per-modality candidate depth fused by RRF.
+        "search_params": [{"parallel": 1, "search_params": {"prefetch": {"limit": 32}}}],
+        "upload_params": {"parallel": 1, "batch_size": 50}
+    }]);
+    let proj =
+        common::write_hybrid_project("hybrid-cov", &serde_json::to_string(&configs).unwrap());
+
+    assert!(
+        run_qdrant_binary(&proj.root, "qdrant-hybrid-cov", "hybrid-cov"),
+        "hybrid run failed"
+    );
+    let recall = common::read_recall(&proj.root, "qdrant-hybrid-cov");
+    println!("qdrant hybrid recall={:.3} (top={})", recall, proj.top);
+    assert!(recall >= 0.9, "hybrid recall {:.3} < 0.9", recall);
 }
 
 /// End-to-end `match_any` coverage. Qdrant already supports `match_any`, so this


### PR DESCRIPTION
## Qdrant hybrid search (feature 3 of the qdrant-parity loop)

Adds an end-to-end **hybrid (dense + sparse) RRF-fusion** benchmark path for Qdrant, plus a reusable sparse/hybrid test fixture. Sparse-only support already existed on master; this makes Qdrant fuse a dense-vector prefetch and a sparse-vector prefetch server-side via Reciprocal Rank Fusion — genuinely beyond upstream's sparse-only story.

### What's here
- `dataset.rs`: `is_hybrid()` + `read_hybrid_data()/read_hybrid_queries()` for `type:"hybrid"` dirs (dense `vectors.npy`/`queries.npy` + sparse `data.csr`/`queries.csr` + shared `neighbours.jsonl`). **No `Engine` trait change** — dispatch branches internally on the dataset, exactly like the existing sparse path.
- `engine/qdrant.rs`: `create_hybrid_collection` (named `"dense"` + `"sparse"` vectors), `upload_hybrid`, and a hybrid `search` that issues a dense NN prefetch + a sparse NN prefetch fused with `Fusion::Rrf`.
- `tests/common/mod.rs`: reusable `write_sparse_project` (extracted from the inline sparse test) + `write_hybrid_project`.
- `experiments/configurations/qdrant-hybrid.json` + README "Qdrant hybrid" subsection.

### Made *better* than a first cut — 7-agent adversarial review applied
The review caught a **critical** flaw in the first implementation: the hybrid fixture planted the relevant set as the top-K under *each* modality independently, so the test passed even if fusion were completely broken. Fixed by redesigning the geometry so the ground truth is recoverable **only via fusion**, backed by a **dense-only negative control**:

| Path | recall | meaning |
|------|-------:|---------|
| Hybrid (fused RRF) | **1.000** | fusion recovers all K |
| Dense-only (same data, no fusion) | **0.500** | single modality cannot |
| Sparse-only test | 1.000 | unchanged |

The test now asserts `hybrid ≥ 0.9`, `dense_only < 0.6`, and `fusion > dense_only + 0.3` — it fails loudly if the sparse prefetch or RRF fusion regresses.

Also fixed (medium/low): `create_hybrid_collection` now honors `optimizers_config`/`quantization_config` + the indexing-thread throttle (was silently dropped); `read_hybrid_queries` validates neighbours row count (was an OOB-panic risk) and rejects interior blank lines via `read_neighbours_strict`; hybrid prefetch depth is floored at `top`; README documents the required hybrid dataset layout (no fabricated dataset/link).

### Verification (independently re-run on this branch)
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean
- 136 unit tests pass (incl. 3 new dataset-IO guards)
- qdrant integration 8/8: hybrid 1.000, dense-only control 0.500, sparse 1.000

🤖 Generated with [Claude Code](https://claude.com/claude-code)