### PR TITLE
perf: measure Redis-family filter-only/mixed on the same clean footing as search()

### DIFF
--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -362,4 +362,21 @@ mod stats_tests {
         assert!(p99 > 99.0, "p99={} should be above sorted[98]", p99);
         assert!((p99 - 99.01).abs() < 1e-9, "p99={}", p99);
     }
+
+    #[test]
+    fn filter_mixed_stats_use_linear_percentiles() {
+        // The filter-only and mixed harnesses now route their latency samples
+        // through compute_search_stats (linear interpolation) instead of the
+        // old hand-rolled nearest-rank indexing `(len*q) as usize`, which
+        // returned the single max as p99 for N<=100. Feeding a known sample set
+        // (1..=100) through the shared path must yield the numpy-linear
+        // percentiles, proving the biased method is gone for these harnesses.
+        let times: Vec<f64> = (1..=100).map(|i| i as f64).collect();
+        let r = compute_search_stats(&times, &[], &[], &[], &[], 10.0, 0, 4, 100).unwrap();
+        // Nearest-rank would have produced p99 == 100 (the max); linear gives 99.01.
+        assert!((r.p99_time - 99.01).abs() < 1e-9, "p99={}", r.p99_time);
+        assert!((r.p95_time - 95.05).abs() < 1e-9, "p95={}", r.p95_time);
+        assert!((r.p50_time - 50.5).abs() < 1e-9, "p50={}", r.p50_time);
+        assert!(r.p99_time < 100.0, "p99={} must be below max", r.p99_time);
+    }
 }

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -160,8 +160,12 @@ impl MongoDBEngine {
             runnable_indices.len()
         };
 
-        let search_times: Arc<Mutex<Vec<f64>>> =
-            Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
+        // Each worker accumulates latencies into a thread-local buffer and returns
+        // it on join; the main thread concatenates. This keeps the timed hot loop
+        // free of the per-query cross-thread Mutex<Vec> push that serialized
+        // workers at high parallelism (matching the main search() path). The work
+        // counter uses Relaxed (only its own monotonicity matters). Progress is
+        // advanced in batches so the atomic isn't contended once per query.
         let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let query_idx = Arc::new(AtomicUsize::new(0));
 
@@ -172,7 +176,10 @@ impl MongoDBEngine {
         let db_name = self.db_name.clone();
         let collection_name = self.collection_name.clone();
 
+        let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
+
         std::thread::scope(|s| {
+            let mut handles = Vec::with_capacity(parallel);
             for _ in 0..parallel {
                 let uri = uri.clone();
                 let db_name = db_name.clone();
@@ -180,22 +187,26 @@ impl MongoDBEngine {
                 let parsed_filters = &parsed_filters;
                 let runnable_indices = &runnable_indices;
                 let neighbors = &neighbors;
-                let search_times = Arc::clone(&search_times);
                 let errors = Arc::clone(&errors);
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
 
-                s.spawn(move || {
+                handles.push(s.spawn(move || {
+                    // Thread-local sample buffer — no cross-thread lock per query.
+                    let mut t: Vec<f64> = Vec::new();
+                    let mut local_errs: Vec<String> = Vec::new();
+                    let mut pb_pending: u64 = 0;
+
                     let client = match Client::with_uri_str(&uri) {
                         Ok(c) => c,
-                        Err(_) => return,
+                        Err(_) => return t,
                     };
                     let coll = client
                         .database(&db_name)
                         .collection::<Document>(&collection_name);
 
                     loop {
-                        let seq = query_idx.fetch_add(1, Ordering::SeqCst);
+                        let seq = query_idx.fetch_add(1, Ordering::Relaxed);
                         if seq >= num_to_run {
                             break;
                         }
@@ -217,77 +228,71 @@ impl MongoDBEngine {
                         let query_time = query_start.elapsed().as_secs_f64();
 
                         if let Err(e) = result {
-                            let mut errs = errors.lock().unwrap();
+                            if local_errs.len() < 3 {
+                                local_errs.push(e);
+                            }
+                        }
+
+                        t.push(query_time);
+                        pb_pending += 1;
+                        if pb_pending >= 256 {
+                            pb.inc(pb_pending);
+                            pb_pending = 0;
+                        }
+                    }
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
+                    }
+                    if !local_errs.is_empty() {
+                        let mut errs = errors.lock().unwrap();
+                        for e in local_errs {
                             if errs.len() < 3 {
                                 errs.push(e);
                             }
                         }
-
-                        search_times.lock().unwrap().push(query_time);
-                        pb.inc(1);
                     }
-                });
+                    t
+                }));
+            }
+
+            for h in handles {
+                times.extend(h.join().unwrap());
             }
         });
 
-        let logged_errors = errors.lock().unwrap();
-        if !logged_errors.is_empty() {
-            for e in logged_errors.iter() {
-                eprintln!("\tFilter-only search error: {}", e);
+        {
+            let logged_errors = errors.lock().unwrap();
+            if !logged_errors.is_empty() {
+                for e in logged_errors.iter() {
+                    eprintln!("\tFilter-only search error: {}", e);
+                }
             }
         }
 
         pb.finish_and_clear();
         let total_time = start_time.elapsed().as_secs_f64();
 
-        let times = search_times.lock().unwrap();
         if times.is_empty() {
             return Err("No filter-only searches completed".to_string());
         }
 
-        let rps = times.len() as f64 / total_time;
-        let mean_time = times.iter().sum::<f64>() / times.len() as f64;
-        let std_time = (times.iter().map(|t| (t - mean_time).powi(2)).sum::<f64>()
-            / times.len() as f64)
-            .sqrt();
-        let min_time = times.iter().copied().fold(f64::INFINITY, f64::min);
-        let max_time = times.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-
-        let mut sorted_times: Vec<f64> = times.clone();
-        sorted_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
-
-        let p50_idx = (sorted_times.len() as f64 * 0.50) as usize;
-        let p95_idx = (sorted_times.len() as f64 * 0.95) as usize;
-        let p99_idx = (sorted_times.len() as f64 * 0.99) as usize;
-
-        let p50_time = sorted_times.get(p50_idx).copied().unwrap_or(0.0);
-        let p95_time = sorted_times
-            .get(p95_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-        let p99_time = sorted_times
-            .get(p99_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-
-        Ok(SearchResults {
+        // Route latency stats through the shared percentile path (linear
+        // interpolation) so filter-only is measured on the same footing as the
+        // main search(). Filter-only has no precision/recall: signal that with the
+        // mean_precision == -1 sentinel, an empty precisions vec, and top == 0.
+        let mut results = crate::engine::compute_search_stats(
+            &times,
+            &[],
+            &[],
+            &[],
+            &[],
             total_time,
-            mean_time,
-            mean_precision: -1.0,
-            std_time,
-            min_time,
-            max_time,
-            rps,
-            p50_time,
-            p95_time,
-            p99_time,
-            precisions: vec![],
-            latencies: times.to_vec(),
-            top: 0,
-            num_queries: times.len(),
+            0,
             parallel,
-            ..Default::default()
-        })
+            num_to_run,
+        )?;
+        results.mean_precision = -1.0;
+        Ok(results)
     }
 
     fn create_progress_bar(&self, total: usize) -> ProgressBar {
@@ -1282,13 +1287,6 @@ impl Engine for MongoDBEngine {
             queries.len()
         };
 
-        let search_times: Arc<Mutex<Vec<f64>>> =
-            Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let update_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
-        let precisions: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let recalls: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let mrrs: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let ndcgs: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
         let search_idx = Arc::new(AtomicUsize::new(0));
         let update_idx = Arc::new(AtomicUsize::new(0));
 
@@ -1305,7 +1303,21 @@ impl Engine for MongoDBEngine {
         let index_name = self.index_name.clone();
         let schema_types = &self.schema_types;
 
+        // Each worker accumulates search + update samples into thread-local
+        // buffers and returns them on join; the main thread concatenates. This
+        // keeps the timed hot loop free of the 5-6 cross-thread Mutex<Vec> pushes
+        // per query that serialized workers at high parallelism (matching the main
+        // search() path). Dispatch counters use Relaxed (only their own
+        // monotonicity matters) and the progress bar is advanced in batches.
+        let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut recs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut u_times: Vec<f64> = Vec::new();
+
         std::thread::scope(|s| {
+            let mut handles = Vec::with_capacity(parallel);
             for _ in 0..parallel {
                 let uri = uri.clone();
                 let db_name = db_name.clone();
@@ -1318,20 +1330,23 @@ impl Engine for MongoDBEngine {
                 let upd_vectors = &upd_vectors;
                 let upd_metadata = &upd_metadata;
                 let update_seq = &update_seq;
-                let search_times = Arc::clone(&search_times);
-                let update_times = Arc::clone(&update_times);
-                let precisions = Arc::clone(&precisions);
-                let recalls = Arc::clone(&recalls);
-                let mrrs = Arc::clone(&mrrs);
-                let ndcgs = Arc::clone(&ndcgs);
                 let search_idx = Arc::clone(&search_idx);
                 let update_idx = Arc::clone(&update_idx);
                 let pb = &pb;
 
-                s.spawn(move || {
+                handles.push(s.spawn(move || {
+                    // Thread-local sample buffers — no cross-thread lock per query.
+                    let mut t: Vec<f64> = Vec::new();
+                    let mut p: Vec<f64> = Vec::new();
+                    let mut r: Vec<f64> = Vec::new();
+                    let mut mr: Vec<f64> = Vec::new();
+                    let mut nd: Vec<f64> = Vec::new();
+                    let mut ut: Vec<f64> = Vec::new();
+                    let mut pb_pending: u64 = 0;
+
                     let client = match Client::with_uri_str(&uri) {
                         Ok(c) => c,
-                        Err(_) => return,
+                        Err(_) => return (t, p, r, mr, nd, ut),
                     };
                     let coll = client
                         .database(&db_name)
@@ -1340,7 +1355,7 @@ impl Engine for MongoDBEngine {
                     'outer: loop {
                         // Search phase: do S searches
                         for _ in 0..ratio_searches {
-                            let idx = search_idx.fetch_add(1, Ordering::SeqCst);
+                            let idx = search_idx.fetch_add(1, Ordering::Relaxed);
                             if idx >= num_to_run {
                                 break 'outer;
                             }
@@ -1369,7 +1384,6 @@ impl Engine for MongoDBEngine {
 
                             match results {
                                 Ok(result_ids) => {
-                                    search_times.lock().unwrap().push(query_time);
                                     let ordered_ids: Vec<i64> =
                                         result_ids.iter().map(|(id, _)| *id).collect();
                                     let m = crate::metrics::compute_metrics(
@@ -1377,21 +1391,26 @@ impl Engine for MongoDBEngine {
                                         &neighbors[idx],
                                         top,
                                     );
-                                    precisions.lock().unwrap().push(m.precision);
-                                    recalls.lock().unwrap().push(m.recall);
-                                    mrrs.lock().unwrap().push(m.mrr);
-                                    ndcgs.lock().unwrap().push(m.ndcg);
+                                    t.push(query_time);
+                                    p.push(m.precision);
+                                    r.push(m.recall);
+                                    mr.push(m.mrr);
+                                    nd.push(m.ndcg);
                                 }
                                 Err(e) => {
                                     eprintln!("Search query {} failed: {}", idx, e);
                                 }
                             }
-                            pb.inc(1);
+                            pb_pending += 1;
+                            if pb_pending >= 256 {
+                                pb.inc(pb_pending);
+                                pb_pending = 0;
+                            }
                         }
 
                         // Update phase: do U updates
                         for _ in 0..ratio_updates {
-                            let uidx = update_idx.fetch_add(1, Ordering::SeqCst);
+                            let uidx = update_idx.fetch_add(1, Ordering::Relaxed);
                             let data_idx = update_seq[uidx % update_seq_len];
 
                             let update_start = Instant::now();
@@ -1403,121 +1422,69 @@ impl Engine for MongoDBEngine {
                                 schema_types,
                             );
                             let update_time = update_start.elapsed().as_secs_f64();
-                            update_times.lock().unwrap().push(update_time);
+                            ut.push(update_time);
                         }
                     }
-                });
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
+                    }
+                    (t, p, r, mr, nd, ut)
+                }));
+            }
+
+            for h in handles {
+                let (t, p, r, mr, nd, ut) = h.join().unwrap();
+                times.extend(t);
+                precs.extend(p);
+                recs.extend(r);
+                mrr_vals.extend(mr);
+                ndcg_vals.extend(nd);
+                u_times.extend(ut);
             }
         });
 
         pb.finish_and_clear();
         let total_time = start_time.elapsed().as_secs_f64();
 
-        let times = search_times.lock().unwrap();
-        let precs = precisions.lock().unwrap();
-        let recs = recalls.lock().unwrap();
-        let mrr_vals = mrrs.lock().unwrap();
-        let ndcg_vals = ndcgs.lock().unwrap();
-        let u_times = update_times.lock().unwrap();
-
         if times.is_empty() {
             return Err("No searches completed".to_string());
         }
 
-        let rps = times.len() as f64 / total_time;
-        let mean_precision = precs.iter().sum::<f64>() / precs.len() as f64;
-        let mean_recall = recs.iter().sum::<f64>() / recs.len() as f64;
-        let mean_mrr = mrr_vals.iter().sum::<f64>() / mrr_vals.len() as f64;
-        let mean_ndcg = ndcg_vals.iter().sum::<f64>() / ndcg_vals.len() as f64;
-        let mean_time = times.iter().sum::<f64>() / times.len() as f64;
-        let std_time = (times.iter().map(|t| (t - mean_time).powi(2)).sum::<f64>()
-            / times.len() as f64)
-            .sqrt();
-        let min_time = times.iter().copied().fold(f64::INFINITY, f64::min);
-        let max_time = times.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-
-        let mut sorted_times: Vec<f64> = times.clone();
-        sorted_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
-
-        let p50_idx = (sorted_times.len() as f64 * 0.50) as usize;
-        let p95_idx = (sorted_times.len() as f64 * 0.95) as usize;
-        let p99_idx = (sorted_times.len() as f64 * 0.99) as usize;
-
-        let p50_time = sorted_times.get(p50_idx).copied().unwrap_or(0.0);
-        let p95_time = sorted_times
-            .get(p95_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-        let p99_time = sorted_times
-            .get(p99_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-
-        // Update latency stats
+        // Update latency stats (linear-interpolation percentiles, matching the
+        // shared search-stats path).
         let (update_count, update_rps, update_mean_time, update_p50, update_p95, update_p99) =
             if !u_times.is_empty() {
                 let u_rps = u_times.len() as f64 / total_time;
                 let u_mean = u_times.iter().sum::<f64>() / u_times.len() as f64;
                 let mut u_sorted: Vec<f64> = u_times.clone();
                 u_sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                let u_p50 = u_sorted
-                    .get((u_sorted.len() as f64 * 0.50) as usize)
-                    .copied()
-                    .unwrap_or(0.0);
-                let u_p95 = u_sorted
-                    .get(((u_sorted.len() as f64 * 0.95) as usize).min(u_sorted.len() - 1))
-                    .copied()
-                    .unwrap_or(0.0);
-                let u_p99 = u_sorted
-                    .get(((u_sorted.len() as f64 * 0.99) as usize).min(u_sorted.len() - 1))
-                    .copied()
-                    .unwrap_or(0.0);
                 (
                     Some(u_times.len()),
                     Some(u_rps),
                     Some(u_mean),
-                    Some(u_p50),
-                    Some(u_p95),
-                    Some(u_p99),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.50)),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.95)),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.99)),
                 )
             } else {
                 (None, None, None, None, None, None)
             };
 
-        Ok(SearchResults {
-            total_time,
-            mean_time,
-            mean_precision,
-            mean_recall,
-            mean_mrr,
-            mean_ndcg,
-            std_time,
-            min_time,
-            max_time,
-            rps,
-            p50_time,
-            p95_time,
-            p99_time,
-            precisions: precs.to_vec(),
-            recalls: recs.to_vec(),
-            mrrs: mrr_vals.to_vec(),
-            ndcgs: ndcg_vals.to_vec(),
-            latencies: times.to_vec(),
-            top: explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10)),
-            num_queries: times.len(),
-            requested_queries: num_to_run,
-            failed_queries: num_to_run.saturating_sub(times.len()),
-            parallel,
-            update_count,
-            update_rps,
-            update_mean_time,
-            update_p50_time: update_p50,
-            update_p95_time: update_p95,
-            update_p99_time: update_p99,
-            update_latencies: Some(u_times.to_vec()),
-            update_search_ratio: Some(format!("{}:{}", ratio.updates, ratio.searches)),
-            ..Default::default()
-        })
+        // Search latency + quality stats through the shared percentile path so the
+        // mixed harness matches the main search() footing.
+        let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
+        let mut results = crate::engine::compute_search_stats(
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
+        )?;
+        results.update_count = update_count;
+        results.update_rps = update_rps;
+        results.update_mean_time = update_mean_time;
+        results.update_p50_time = update_p50;
+        results.update_p95_time = update_p95;
+        results.update_p99_time = update_p99;
+        results.update_latencies = Some(u_times);
+        results.update_search_ratio = Some(format!("{}:{}", ratio.updates, ratio.searches));
+        Ok(results)
     }
 
     fn delete(&mut self) -> Result<(), String> {

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -227,13 +227,19 @@ impl MongoDBEngine {
                         let result = filter_only_find(&coll, filter, top);
                         let query_time = query_start.elapsed().as_secs_f64();
 
-                        if let Err(e) = result {
-                            if local_errs.len() < 3 {
-                                local_errs.push(e);
+                        // Record a latency sample only for successful queries, so a
+                        // failed $vectorSearch/find is counted as a failure (num_to_run
+                        // minus successes) rather than folded into RPS/percentiles.
+                        // MongoDB has no check_commandstats backstop, so this is the
+                        // only place failures are surfaced.
+                        match result {
+                            Ok(_) => t.push(query_time),
+                            Err(e) => {
+                                if local_errs.len() < 3 {
+                                    local_errs.push(e);
+                                }
                             }
                         }
-
-                        t.push(query_time);
                         pb_pending += 1;
                         if pb_pending >= 256 {
                             pb.inc(pb_pending);
@@ -1165,6 +1171,7 @@ impl Engine for MongoDBEngine {
                     let mut r = Vec::new();
                     let mut mr = Vec::new();
                     let mut nd = Vec::new();
+                    let mut pb_pending: u64 = 0;
 
                     let client = match Client::with_uri_str(&uri) {
                         Ok(c) => c,
@@ -1221,7 +1228,16 @@ impl Engine for MongoDBEngine {
                                 eprintln!("Search query {} failed: {}", idx, e);
                             }
                         }
-                        pb.inc(1);
+                        // Batch progress updates so the highest-QPS runs don't pay a
+                        // contended atomic per query.
+                        pb_pending += 1;
+                        if pb_pending >= 256 {
+                            pb.inc(pb_pending);
+                            pb_pending = 0;
+                        }
+                    }
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd)
                 }));

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -475,37 +475,48 @@ impl RedisEngine {
             runnable_indices.len()
         };
 
-        let search_times: Arc<Mutex<Vec<f64>>> =
-            Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
+        // Each worker accumulates latencies into a thread-local buffer and returns
+        // it on join; the main thread concatenates. This keeps the timed hot loop
+        // free of the per-query cross-thread Mutex<Vec> push that serialized
+        // workers at high parallelism (matching the main search() path). The work
+        // counter uses Relaxed (only its own monotonicity matters). Progress is
+        // advanced in batches so the atomic isn't contended once per query.
         let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
         let start_time = Instant::now();
 
+        let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
+
         std::thread::scope(|s| {
+            let mut handles = Vec::with_capacity(parallel);
             for _ in 0..parallel {
                 let redis_url = self.redis_url.clone();
                 let parsed_filters = &parsed_filters;
                 let runnable_indices = &runnable_indices;
                 let neighbors = &neighbors;
-                let search_times = Arc::clone(&search_times);
                 let errors = Arc::clone(&errors);
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
 
-                s.spawn(move || {
+                handles.push(s.spawn(move || {
+                    // Thread-local sample buffer — no cross-thread lock per query.
+                    let mut t: Vec<f64> = Vec::new();
+                    let mut local_errs: Vec<String> = Vec::new();
+                    let mut pb_pending: u64 = 0;
+
                     let client = match redis::Client::open(redis_url.as_str()) {
                         Ok(c) => c,
-                        Err(_) => return,
+                        Err(_) => return t,
                     };
                     let mut conn = match client.get_connection() {
                         Ok(c) => c,
-                        Err(_) => return,
+                        Err(_) => return t,
                     };
 
                     loop {
-                        let seq = query_idx.fetch_add(1, Ordering::SeqCst);
+                        let seq = query_idx.fetch_add(1, Ordering::Relaxed);
                         if seq >= num_to_run {
                             break;
                         }
@@ -531,58 +542,53 @@ impl RedisEngine {
                         let query_time = query_start.elapsed().as_secs_f64();
 
                         if let Err(e) = result {
-                            let mut errs = errors.lock().unwrap();
+                            if local_errs.len() < 3 {
+                                local_errs.push(e);
+                            }
+                        }
+
+                        t.push(query_time);
+                        pb_pending += 1;
+                        if pb_pending >= 256 {
+                            pb.inc(pb_pending);
+                            pb_pending = 0;
+                        }
+                    }
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
+                    }
+                    if !local_errs.is_empty() {
+                        let mut errs = errors.lock().unwrap();
+                        for e in local_errs {
                             if errs.len() < 3 {
                                 errs.push(e);
                             }
                         }
-
-                        search_times.lock().unwrap().push(query_time);
-                        pb.inc(1);
                     }
-                });
+                    t
+                }));
+            }
+
+            for h in handles {
+                times.extend(h.join().unwrap());
             }
         });
 
-        let logged_errors = errors.lock().unwrap();
-        if !logged_errors.is_empty() {
-            for e in logged_errors.iter() {
-                eprintln!("\tFilter-only search error: {}", e);
+        {
+            let logged_errors = errors.lock().unwrap();
+            if !logged_errors.is_empty() {
+                for e in logged_errors.iter() {
+                    eprintln!("\tFilter-only search error: {}", e);
+                }
             }
         }
 
         pb.finish_and_clear();
         let total_time = start_time.elapsed().as_secs_f64();
 
-        let times = search_times.lock().unwrap();
         if times.is_empty() {
             return Err("No filter-only searches completed".to_string());
         }
-
-        let rps = times.len() as f64 / total_time;
-        let mean_time = times.iter().sum::<f64>() / times.len() as f64;
-        let std_time = (times.iter().map(|t| (t - mean_time).powi(2)).sum::<f64>()
-            / times.len() as f64)
-            .sqrt();
-        let min_time = times.iter().copied().fold(f64::INFINITY, f64::min);
-        let max_time = times.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-
-        let mut sorted_times: Vec<f64> = times.clone();
-        sorted_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
-
-        let p50_idx = (sorted_times.len() as f64 * 0.50) as usize;
-        let p95_idx = (sorted_times.len() as f64 * 0.95) as usize;
-        let p99_idx = (sorted_times.len() as f64 * 0.99) as usize;
-
-        let p50_time = sorted_times.get(p50_idx).copied().unwrap_or(0.0);
-        let p95_time = sorted_times
-            .get(p95_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-        let p99_time = sorted_times
-            .get(p99_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
 
         // Verify no FT.SEARCH failures occurred
         let mut check_conn = self.get_connection()?;
@@ -593,24 +599,23 @@ impl RedisEngine {
             self.commandstats_baseline.as_ref(),
         )?;
 
-        Ok(SearchResults {
+        // Route latency stats through the shared percentile path (linear
+        // interpolation) so filter-only is measured on the same footing as the
+        // main search(). Filter-only has no precision/recall: signal that with the
+        // mean_precision == -1 sentinel, an empty precisions vec, and top == 0.
+        let mut results = crate::engine::compute_search_stats(
+            &times,
+            &[],
+            &[],
+            &[],
+            &[],
             total_time,
-            mean_time,
-            mean_precision: -1.0, // Not applicable for filter-only
-            std_time,
-            min_time,
-            max_time,
-            rps,
-            p50_time,
-            p95_time,
-            p99_time,
-            precisions: vec![], // No precision for filter-only
-            latencies: times.to_vec(),
-            top: 0,
-            num_queries: times.len(),
+            0,
             parallel,
-            ..Default::default()
-        })
+            num_to_run,
+        )?;
+        results.mean_precision = -1.0;
+        Ok(results)
     }
 
     fn create_progress_bar(&self, total: usize) -> ProgressBar {
@@ -1793,13 +1798,6 @@ impl Engine for RedisEngine {
             queries.len()
         };
 
-        let search_times: Arc<Mutex<Vec<f64>>> =
-            Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let update_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
-        let precisions: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let recalls: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let mrrs: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let ndcgs: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
         let search_idx = Arc::new(AtomicUsize::new(0));
         let update_idx = Arc::new(AtomicUsize::new(0));
 
@@ -1810,7 +1808,21 @@ impl Engine for RedisEngine {
         let pb = self.create_progress_bar(num_to_run);
         let start_time = Instant::now();
 
+        // Each worker accumulates search + update samples into thread-local
+        // buffers and returns them on join; the main thread concatenates. This
+        // keeps the timed hot loop free of the 5-6 cross-thread Mutex<Vec> pushes
+        // per query that serialized workers at high parallelism (matching the main
+        // search() path). Dispatch counters use Relaxed (only their own
+        // monotonicity matters) and the progress bar is advanced in batches.
+        let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut recs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut mrs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut nds: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut u_times: Vec<f64> = Vec::new();
+
         std::thread::scope(|s| {
+            let mut handles = Vec::with_capacity(parallel);
             for _ in 0..parallel {
                 let redis_url = self.redis_url.clone();
                 let config = self.config.clone();
@@ -1824,30 +1836,33 @@ impl Engine for RedisEngine {
                 let upd_vectors = &upd_vectors;
                 let upd_metadata = &upd_metadata;
                 let update_seq = &update_seq;
-                let search_times = Arc::clone(&search_times);
-                let update_times = Arc::clone(&update_times);
-                let precisions = Arc::clone(&precisions);
-                let recalls = Arc::clone(&recalls);
-                let mrrs = Arc::clone(&mrrs);
-                let ndcgs = Arc::clone(&ndcgs);
                 let search_idx = Arc::clone(&search_idx);
                 let update_idx = Arc::clone(&update_idx);
                 let pb = &pb;
 
-                s.spawn(move || {
+                handles.push(s.spawn(move || {
+                    // Thread-local sample buffers — no cross-thread lock per query.
+                    let mut t: Vec<f64> = Vec::new();
+                    let mut p: Vec<f64> = Vec::new();
+                    let mut r: Vec<f64> = Vec::new();
+                    let mut mr: Vec<f64> = Vec::new();
+                    let mut nd: Vec<f64> = Vec::new();
+                    let mut ut: Vec<f64> = Vec::new();
+                    let mut pb_pending: u64 = 0;
+
                     let client = match redis::Client::open(redis_url.as_str()) {
                         Ok(c) => c,
-                        Err(_) => return,
+                        Err(_) => return (t, p, r, mr, nd, ut),
                     };
                     let mut conn = match client.get_connection() {
                         Ok(c) => c,
-                        Err(_) => return,
+                        Err(_) => return (t, p, r, mr, nd, ut),
                     };
 
                     'outer: loop {
                         // Search phase: do S searches
                         for _ in 0..ratio_searches {
-                            let idx = search_idx.fetch_add(1, Ordering::SeqCst);
+                            let idx = search_idx.fetch_add(1, Ordering::Relaxed);
                             if idx >= num_to_run {
                                 break 'outer;
                             }
@@ -1879,25 +1894,29 @@ impl Engine for RedisEngine {
                             // failures are surfaced, never scored as 0-recall.
                             match results {
                                 Ok(result_ids) => {
-                                    search_times.lock().unwrap().push(query_time);
                                     let ordered_ids: Vec<i64> =
                                         result_ids.iter().map(|(id, _)| *id).collect();
                                     let m = compute_metrics(&ordered_ids, &neighbors[idx], top);
-                                    precisions.lock().unwrap().push(m.precision);
-                                    recalls.lock().unwrap().push(m.recall);
-                                    mrrs.lock().unwrap().push(m.mrr);
-                                    ndcgs.lock().unwrap().push(m.ndcg);
+                                    t.push(query_time);
+                                    p.push(m.precision);
+                                    r.push(m.recall);
+                                    mr.push(m.mrr);
+                                    nd.push(m.ndcg);
                                 }
                                 Err(e) => {
                                     eprintln!("Search query {} failed: {}", idx, e);
                                 }
                             }
-                            pb.inc(1);
+                            pb_pending += 1;
+                            if pb_pending >= 256 {
+                                pb.inc(pb_pending);
+                                pb_pending = 0;
+                            }
                         }
 
                         // Update phase: do U updates
                         for _ in 0..ratio_updates {
-                            let uidx = update_idx.fetch_add(1, Ordering::SeqCst);
+                            let uidx = update_idx.fetch_add(1, Ordering::Relaxed);
                             let data_idx = update_seq[uidx % update_seq_len];
 
                             let update_start = Instant::now();
@@ -1909,82 +1928,49 @@ impl Engine for RedisEngine {
                                 upd_metadata[data_idx].as_ref(),
                             );
                             let update_time = update_start.elapsed().as_secs_f64();
-                            update_times.lock().unwrap().push(update_time);
+                            ut.push(update_time);
                         }
                     }
-                });
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
+                    }
+                    (t, p, r, mr, nd, ut)
+                }));
+            }
+
+            for h in handles {
+                let (t, p, r, mr, nd, ut) = h.join().unwrap();
+                times.extend(t);
+                precs.extend(p);
+                recs.extend(r);
+                mrs.extend(mr);
+                nds.extend(nd);
+                u_times.extend(ut);
             }
         });
 
         pb.finish_and_clear();
         let total_time = start_time.elapsed().as_secs_f64();
 
-        let times = search_times.lock().unwrap();
-        let precs = precisions.lock().unwrap();
-        let recs = recalls.lock().unwrap();
-        let mrs = mrrs.lock().unwrap();
-        let nds = ndcgs.lock().unwrap();
-        let u_times = update_times.lock().unwrap();
-
         if times.is_empty() {
             return Err("No searches completed".to_string());
         }
 
-        let rps = times.len() as f64 / total_time;
-        let mean_precision = precs.iter().sum::<f64>() / precs.len() as f64;
-        let mean_recall = recs.iter().sum::<f64>() / recs.len() as f64;
-        let mean_mrr = mrs.iter().sum::<f64>() / mrs.len() as f64;
-        let mean_ndcg = nds.iter().sum::<f64>() / nds.len() as f64;
-        let mean_time = times.iter().sum::<f64>() / times.len() as f64;
-        let std_time = (times.iter().map(|t| (t - mean_time).powi(2)).sum::<f64>()
-            / times.len() as f64)
-            .sqrt();
-        let min_time = times.iter().copied().fold(f64::INFINITY, f64::min);
-        let max_time = times.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-
-        let mut sorted_times: Vec<f64> = times.clone();
-        sorted_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
-
-        let p50_idx = (sorted_times.len() as f64 * 0.50) as usize;
-        let p95_idx = (sorted_times.len() as f64 * 0.95) as usize;
-        let p99_idx = (sorted_times.len() as f64 * 0.99) as usize;
-
-        let p50_time = sorted_times.get(p50_idx).copied().unwrap_or(0.0);
-        let p95_time = sorted_times
-            .get(p95_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-        let p99_time = sorted_times
-            .get(p99_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-
-        // Update latency stats
+        // Update latency stats (linear-interpolation percentiles, matching the
+        // shared search-stats path).
         let (update_count, update_rps, update_mean_time, update_p50, update_p95, update_p99) =
             if !u_times.is_empty() {
                 let u_rps = u_times.len() as f64 / total_time;
                 let u_mean = u_times.iter().sum::<f64>() / u_times.len() as f64;
                 let mut u_sorted: Vec<f64> = u_times.clone();
                 u_sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                let u_p50 = u_sorted
-                    .get((u_sorted.len() as f64 * 0.50) as usize)
-                    .copied()
-                    .unwrap_or(0.0);
-                let u_p95 = u_sorted
-                    .get(((u_sorted.len() as f64 * 0.95) as usize).min(u_sorted.len() - 1))
-                    .copied()
-                    .unwrap_or(0.0);
-                let u_p99 = u_sorted
-                    .get(((u_sorted.len() as f64 * 0.99) as usize).min(u_sorted.len() - 1))
-                    .copied()
-                    .unwrap_or(0.0);
                 (
                     Some(u_times.len()),
                     Some(u_rps),
                     Some(u_mean),
-                    Some(u_p50),
-                    Some(u_p95),
-                    Some(u_p99),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.50)),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.95)),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.99)),
                 )
             } else {
                 (None, None, None, None, None, None)
@@ -1999,40 +1985,21 @@ impl Engine for RedisEngine {
             self.commandstats_baseline.as_ref(),
         )?;
 
-        Ok(SearchResults {
-            total_time,
-            mean_time,
-            mean_precision,
-            mean_recall,
-            mean_mrr,
-            mean_ndcg,
-            std_time,
-            min_time,
-            max_time,
-            rps,
-            p50_time,
-            p95_time,
-            p99_time,
-            precisions: precs.to_vec(),
-            recalls: recs.to_vec(),
-            mrrs: mrs.to_vec(),
-            ndcgs: nds.to_vec(),
-            latencies: times.to_vec(),
-            top: explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10)),
-            num_queries: times.len(),
-            requested_queries: num_to_run,
-            failed_queries: num_to_run.saturating_sub(times.len()),
-            parallel,
-            update_count,
-            update_rps,
-            update_mean_time,
-            update_p50_time: update_p50,
-            update_p95_time: update_p95,
-            update_p99_time: update_p99,
-            update_latencies: Some(u_times.to_vec()),
-            update_search_ratio: Some(format!("{}:{}", ratio.updates, ratio.searches)),
-            ..Default::default()
-        })
+        // Search latency + quality stats through the shared percentile path so the
+        // mixed harness matches the main search() footing.
+        let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
+        let mut results = crate::engine::compute_search_stats(
+            &times, &precs, &recs, &mrs, &nds, total_time, top, parallel, num_to_run,
+        )?;
+        results.update_count = update_count;
+        results.update_rps = update_rps;
+        results.update_mean_time = update_mean_time;
+        results.update_p50_time = update_p50;
+        results.update_p95_time = update_p95;
+        results.update_p99_time = update_p99;
+        results.update_latencies = Some(u_times);
+        results.update_search_ratio = Some(format!("{}:{}", ratio.updates, ratio.searches));
+        Ok(results)
     }
 
     fn delete(&mut self) -> Result<(), String> {

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -541,13 +541,18 @@ impl RedisEngine {
                         );
                         let query_time = query_start.elapsed().as_secs_f64();
 
-                        if let Err(e) = result {
-                            if local_errs.len() < 3 {
-                                local_errs.push(e);
+                        // Record a latency sample only for successful queries, so a
+                        // failed FT.SEARCH is counted as a failure (num_to_run minus
+                        // successes) rather than folded into RPS/percentiles — parity
+                        // with the main search() path.
+                        match result {
+                            Ok(_) => t.push(query_time),
+                            Err(e) => {
+                                if local_errs.len() < 3 {
+                                    local_errs.push(e);
+                                }
                             }
                         }
-
-                        t.push(query_time);
                         pb_pending += 1;
                         if pb_pending >= 256 {
                             pb.inc(pb_pending);
@@ -1654,6 +1659,7 @@ impl Engine for RedisEngine {
                     let mut r = Vec::new();
                     let mut mr = Vec::new();
                     let mut nd = Vec::new();
+                    let mut pb_pending: u64 = 0;
 
                     let client = match redis::Client::open(redis_url.as_str()) {
                         Ok(c) => c,
@@ -1714,7 +1720,16 @@ impl Engine for RedisEngine {
                                 eprintln!("Search query {} failed: {}", idx, e);
                             }
                         }
-                        pb.inc(1);
+                        // Batch progress updates so the highest-QPS runs don't pay a
+                        // contended atomic per query.
+                        pb_pending += 1;
+                        if pb_pending >= 256 {
+                            pb.inc(pb_pending);
+                            pb_pending = 0;
+                        }
+                    }
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd)
                 }));

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -595,13 +595,18 @@ impl ValkeyEngine {
                         );
                         let query_time = query_start.elapsed().as_secs_f64();
 
-                        if let Err(e) = result {
-                            if local_errs.len() < 3 {
-                                local_errs.push(e);
+                        // Record a latency sample only for successful queries, so a
+                        // failed FT.SEARCH is counted as a failure (num_to_run minus
+                        // successes) rather than folded into RPS/percentiles — parity
+                        // with the main search() path.
+                        match result {
+                            Ok(_) => t.push(query_time),
+                            Err(e) => {
+                                if local_errs.len() < 3 {
+                                    local_errs.push(e);
+                                }
                             }
                         }
-
-                        t.push(query_time);
                         pb_pending += 1;
                         if pb_pending >= 256 {
                             pb.inc(pb_pending);
@@ -1715,6 +1720,7 @@ impl Engine for ValkeyEngine {
                     let mut r = Vec::new();
                     let mut mr = Vec::new();
                     let mut nd = Vec::new();
+                    let mut pb_pending: u64 = 0;
 
                     let auth = std::env::var("VALKEY_AUTH").ok();
                     let user = std::env::var("VALKEY_USER").ok();
@@ -1786,7 +1792,16 @@ impl Engine for ValkeyEngine {
                                 eprintln!("Search query {} failed: {}", idx, e);
                             }
                         }
-                        pb.inc(1);
+                        // Batch progress updates so the highest-QPS runs don't pay a
+                        // contended atomic per query.
+                        pb_pending += 1;
+                        if pb_pending >= 256 {
+                            pb.inc(pb_pending);
+                            pb_pending = 0;
+                        }
+                    }
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd)
                 }));

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -515,27 +515,38 @@ impl ValkeyEngine {
             runnable_indices.len()
         };
 
-        let search_times: Arc<Mutex<Vec<f64>>> =
-            Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
+        // Each worker accumulates latencies into a thread-local buffer and returns
+        // it on join; the main thread concatenates. This keeps the timed hot loop
+        // free of the per-query cross-thread Mutex<Vec> push that serialized
+        // workers at high parallelism (matching the main search() path). The work
+        // counter uses Relaxed (only its own monotonicity matters). Progress is
+        // advanced in batches so the atomic isn't contended once per query.
         let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
         let start_time = Instant::now();
 
+        let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
+
         std::thread::scope(|s| {
+            let mut handles = Vec::with_capacity(parallel);
             for _ in 0..parallel {
                 let host = self.host.clone();
                 let port = self.port;
                 let parsed_filters = &parsed_filters;
                 let runnable_indices = &runnable_indices;
                 let neighbors = &neighbors;
-                let search_times = Arc::clone(&search_times);
                 let errors = Arc::clone(&errors);
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
 
-                s.spawn(move || {
+                handles.push(s.spawn(move || {
+                    // Thread-local sample buffer — no cross-thread lock per query.
+                    let mut t: Vec<f64> = Vec::new();
+                    let mut local_errs: Vec<String> = Vec::new();
+                    let mut pb_pending: u64 = 0;
+
                     let auth = std::env::var("VALKEY_AUTH").ok();
                     let user = std::env::var("VALKEY_USER").ok();
                     let auth_part = match (&user, &auth) {
@@ -552,15 +563,15 @@ impl ValkeyEngine {
                     );
                     let client = match redis::Client::open(url.as_str()) {
                         Ok(c) => c,
-                        Err(_) => return,
+                        Err(_) => return t,
                     };
                     let mut conn = match client.get_connection() {
                         Ok(c) => c,
-                        Err(_) => return,
+                        Err(_) => return t,
                     };
 
                     loop {
-                        let seq = query_idx.fetch_add(1, Ordering::SeqCst);
+                        let seq = query_idx.fetch_add(1, Ordering::Relaxed);
                         if seq >= num_to_run {
                             break;
                         }
@@ -585,58 +596,53 @@ impl ValkeyEngine {
                         let query_time = query_start.elapsed().as_secs_f64();
 
                         if let Err(e) = result {
-                            let mut errs = errors.lock().unwrap();
+                            if local_errs.len() < 3 {
+                                local_errs.push(e);
+                            }
+                        }
+
+                        t.push(query_time);
+                        pb_pending += 1;
+                        if pb_pending >= 256 {
+                            pb.inc(pb_pending);
+                            pb_pending = 0;
+                        }
+                    }
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
+                    }
+                    if !local_errs.is_empty() {
+                        let mut errs = errors.lock().unwrap();
+                        for e in local_errs {
                             if errs.len() < 3 {
                                 errs.push(e);
                             }
                         }
-
-                        search_times.lock().unwrap().push(query_time);
-                        pb.inc(1);
                     }
-                });
+                    t
+                }));
+            }
+
+            for h in handles {
+                times.extend(h.join().unwrap());
             }
         });
 
-        let logged_errors = errors.lock().unwrap();
-        if !logged_errors.is_empty() {
-            for e in logged_errors.iter() {
-                eprintln!("\tFilter-only search error: {}", e);
+        {
+            let logged_errors = errors.lock().unwrap();
+            if !logged_errors.is_empty() {
+                for e in logged_errors.iter() {
+                    eprintln!("\tFilter-only search error: {}", e);
+                }
             }
         }
 
         pb.finish_and_clear();
         let total_time = start_time.elapsed().as_secs_f64();
 
-        let times = search_times.lock().unwrap();
         if times.is_empty() {
             return Err("No filter-only searches completed".to_string());
         }
-
-        let rps = times.len() as f64 / total_time;
-        let mean_time = times.iter().sum::<f64>() / times.len() as f64;
-        let std_time = (times.iter().map(|t| (t - mean_time).powi(2)).sum::<f64>()
-            / times.len() as f64)
-            .sqrt();
-        let min_time = times.iter().copied().fold(f64::INFINITY, f64::min);
-        let max_time = times.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-
-        let mut sorted_times: Vec<f64> = times.clone();
-        sorted_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
-
-        let p50_idx = (sorted_times.len() as f64 * 0.50) as usize;
-        let p95_idx = (sorted_times.len() as f64 * 0.95) as usize;
-        let p99_idx = (sorted_times.len() as f64 * 0.99) as usize;
-
-        let p50_time = sorted_times.get(p50_idx).copied().unwrap_or(0.0);
-        let p95_time = sorted_times
-            .get(p95_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-        let p99_time = sorted_times
-            .get(p99_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
 
         let mut check_conn = self.get_connection()?;
         redis_utils::check_commandstats(
@@ -646,24 +652,23 @@ impl ValkeyEngine {
             self.commandstats_baseline.as_ref(),
         )?;
 
-        Ok(SearchResults {
+        // Route latency stats through the shared percentile path (linear
+        // interpolation) so filter-only is measured on the same footing as the
+        // main search(). Filter-only has no precision/recall: signal that with the
+        // mean_precision == -1 sentinel, an empty precisions vec, and top == 0.
+        let mut results = crate::engine::compute_search_stats(
+            &times,
+            &[],
+            &[],
+            &[],
+            &[],
             total_time,
-            mean_time,
-            mean_precision: -1.0,
-            std_time,
-            min_time,
-            max_time,
-            rps,
-            p50_time,
-            p95_time,
-            p99_time,
-            precisions: vec![],
-            latencies: times.to_vec(),
-            top: 0,
-            num_queries: times.len(),
+            0,
             parallel,
-            ..Default::default()
-        })
+            num_to_run,
+        )?;
+        results.mean_precision = -1.0;
+        Ok(results)
     }
 
     fn create_progress_bar(&self, total: usize) -> ProgressBar {
@@ -1865,13 +1870,6 @@ impl Engine for ValkeyEngine {
             queries.len()
         };
 
-        let search_times: Arc<Mutex<Vec<f64>>> =
-            Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let update_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
-        let precisions: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let recalls: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let mrrs: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let ndcgs: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
         let search_idx = Arc::new(AtomicUsize::new(0));
         let update_idx = Arc::new(AtomicUsize::new(0));
 
@@ -1882,7 +1880,21 @@ impl Engine for ValkeyEngine {
         let pb = self.create_progress_bar(num_to_run);
         let start_time = Instant::now();
 
+        // Each worker accumulates search + update samples into thread-local
+        // buffers and returns them on join; the main thread concatenates. This
+        // keeps the timed hot loop free of the 5-6 cross-thread Mutex<Vec> pushes
+        // per query that serialized workers at high parallelism (matching the main
+        // search() path). Dispatch counters use Relaxed (only their own
+        // monotonicity matters) and the progress bar is advanced in batches.
+        let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut recs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut u_times: Vec<f64> = Vec::new();
+
         std::thread::scope(|s| {
+            let mut handles = Vec::with_capacity(parallel);
             for _ in 0..parallel {
                 let host = self.host.clone();
                 let port = self.port;
@@ -1896,26 +1908,29 @@ impl Engine for ValkeyEngine {
                 let upd_vectors = &upd_vectors;
                 let upd_metadata = &upd_metadata;
                 let update_seq = &update_seq;
-                let search_times = Arc::clone(&search_times);
-                let update_times = Arc::clone(&update_times);
-                let precisions = Arc::clone(&precisions);
-                let recalls = Arc::clone(&recalls);
-                let mrrs = Arc::clone(&mrrs);
-                let ndcgs = Arc::clone(&ndcgs);
                 let search_idx = Arc::clone(&search_idx);
                 let update_idx = Arc::clone(&update_idx);
                 let pb = &pb;
 
-                s.spawn(move || {
+                handles.push(s.spawn(move || {
+                    // Thread-local sample buffers — no cross-thread lock per query.
+                    let mut t: Vec<f64> = Vec::new();
+                    let mut p: Vec<f64> = Vec::new();
+                    let mut r: Vec<f64> = Vec::new();
+                    let mut mr: Vec<f64> = Vec::new();
+                    let mut nd: Vec<f64> = Vec::new();
+                    let mut ut: Vec<f64> = Vec::new();
+                    let mut pb_pending: u64 = 0;
+
                     let mut conn = match ValkeyEngine::connect(&host, port) {
                         Ok(c) => c,
-                        Err(_) => return,
+                        Err(_) => return (t, p, r, mr, nd, ut),
                     };
 
                     'outer: loop {
                         // Search phase: do S searches
                         for _ in 0..ratio_searches {
-                            let idx = search_idx.fetch_add(1, Ordering::SeqCst);
+                            let idx = search_idx.fetch_add(1, Ordering::Relaxed);
                             if idx >= num_to_run {
                                 break 'outer;
                             }
@@ -1944,7 +1959,6 @@ impl Engine for ValkeyEngine {
 
                             match &results {
                                 Ok(result_ids) => {
-                                    search_times.lock().unwrap().push(query_time);
                                     let ordered_ids: Vec<i64> =
                                         result_ids.iter().map(|(id, _)| *id).collect();
                                     let m = crate::metrics::compute_metrics(
@@ -1952,21 +1966,26 @@ impl Engine for ValkeyEngine {
                                         &neighbors[idx],
                                         top,
                                     );
-                                    precisions.lock().unwrap().push(m.precision);
-                                    recalls.lock().unwrap().push(m.recall);
-                                    mrrs.lock().unwrap().push(m.mrr);
-                                    ndcgs.lock().unwrap().push(m.ndcg);
+                                    t.push(query_time);
+                                    p.push(m.precision);
+                                    r.push(m.recall);
+                                    mr.push(m.mrr);
+                                    nd.push(m.ndcg);
                                 }
                                 Err(e) => {
                                     eprintln!("Search query {} failed: {}", idx, e);
                                 }
                             }
-                            pb.inc(1);
+                            pb_pending += 1;
+                            if pb_pending >= 256 {
+                                pb.inc(pb_pending);
+                                pb_pending = 0;
+                            }
                         }
 
                         // Update phase: do U updates
                         for _ in 0..ratio_updates {
-                            let uidx = update_idx.fetch_add(1, Ordering::SeqCst);
+                            let uidx = update_idx.fetch_add(1, Ordering::Relaxed);
                             let data_idx = update_seq[uidx % update_seq_len];
 
                             let update_start = Instant::now();
@@ -1978,82 +1997,49 @@ impl Engine for ValkeyEngine {
                                 upd_metadata[data_idx].as_ref(),
                             );
                             let update_time = update_start.elapsed().as_secs_f64();
-                            update_times.lock().unwrap().push(update_time);
+                            ut.push(update_time);
                         }
                     }
-                });
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
+                    }
+                    (t, p, r, mr, nd, ut)
+                }));
+            }
+
+            for h in handles {
+                let (t, p, r, mr, nd, ut) = h.join().unwrap();
+                times.extend(t);
+                precs.extend(p);
+                recs.extend(r);
+                mrr_vals.extend(mr);
+                ndcg_vals.extend(nd);
+                u_times.extend(ut);
             }
         });
 
         pb.finish_and_clear();
         let total_time = start_time.elapsed().as_secs_f64();
 
-        let times = search_times.lock().unwrap();
-        let precs = precisions.lock().unwrap();
-        let recs = recalls.lock().unwrap();
-        let mrr_vals = mrrs.lock().unwrap();
-        let ndcg_vals = ndcgs.lock().unwrap();
-        let u_times = update_times.lock().unwrap();
-
         if times.is_empty() {
             return Err("No searches completed".to_string());
         }
 
-        let rps = times.len() as f64 / total_time;
-        let mean_precision = precs.iter().sum::<f64>() / precs.len() as f64;
-        let mean_recall = recs.iter().sum::<f64>() / recs.len() as f64;
-        let mean_mrr = mrr_vals.iter().sum::<f64>() / mrr_vals.len() as f64;
-        let mean_ndcg = ndcg_vals.iter().sum::<f64>() / ndcg_vals.len() as f64;
-        let mean_time = times.iter().sum::<f64>() / times.len() as f64;
-        let std_time = (times.iter().map(|t| (t - mean_time).powi(2)).sum::<f64>()
-            / times.len() as f64)
-            .sqrt();
-        let min_time = times.iter().copied().fold(f64::INFINITY, f64::min);
-        let max_time = times.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-
-        let mut sorted_times: Vec<f64> = times.clone();
-        sorted_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
-
-        let p50_idx = (sorted_times.len() as f64 * 0.50) as usize;
-        let p95_idx = (sorted_times.len() as f64 * 0.95) as usize;
-        let p99_idx = (sorted_times.len() as f64 * 0.99) as usize;
-
-        let p50_time = sorted_times.get(p50_idx).copied().unwrap_or(0.0);
-        let p95_time = sorted_times
-            .get(p95_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-        let p99_time = sorted_times
-            .get(p99_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-
-        // Update latency stats
+        // Update latency stats (linear-interpolation percentiles, matching the
+        // shared search-stats path).
         let (update_count, update_rps, update_mean_time, update_p50, update_p95, update_p99) =
             if !u_times.is_empty() {
                 let u_rps = u_times.len() as f64 / total_time;
                 let u_mean = u_times.iter().sum::<f64>() / u_times.len() as f64;
                 let mut u_sorted: Vec<f64> = u_times.clone();
                 u_sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                let u_p50 = u_sorted
-                    .get((u_sorted.len() as f64 * 0.50) as usize)
-                    .copied()
-                    .unwrap_or(0.0);
-                let u_p95 = u_sorted
-                    .get(((u_sorted.len() as f64 * 0.95) as usize).min(u_sorted.len() - 1))
-                    .copied()
-                    .unwrap_or(0.0);
-                let u_p99 = u_sorted
-                    .get(((u_sorted.len() as f64 * 0.99) as usize).min(u_sorted.len() - 1))
-                    .copied()
-                    .unwrap_or(0.0);
                 (
                     Some(u_times.len()),
                     Some(u_rps),
                     Some(u_mean),
-                    Some(u_p50),
-                    Some(u_p95),
-                    Some(u_p99),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.50)),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.95)),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.99)),
                 )
             } else {
                 (None, None, None, None, None, None)
@@ -2068,40 +2054,21 @@ impl Engine for ValkeyEngine {
             self.commandstats_baseline.as_ref(),
         )?;
 
-        Ok(SearchResults {
-            total_time,
-            mean_time,
-            mean_precision,
-            mean_recall,
-            mean_mrr,
-            mean_ndcg,
-            recalls: recs.to_vec(),
-            mrrs: mrr_vals.to_vec(),
-            ndcgs: ndcg_vals.to_vec(),
-            std_time,
-            min_time,
-            max_time,
-            rps,
-            p50_time,
-            p95_time,
-            p99_time,
-            precisions: precs.to_vec(),
-            latencies: times.to_vec(),
-            top: explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10)),
-            num_queries: times.len(),
-            requested_queries: num_to_run,
-            failed_queries: num_to_run.saturating_sub(times.len()),
-            parallel,
-            update_count,
-            update_rps,
-            update_mean_time,
-            update_p50_time: update_p50,
-            update_p95_time: update_p95,
-            update_p99_time: update_p99,
-            update_latencies: Some(u_times.to_vec()),
-            update_search_ratio: Some(format!("{}:{}", ratio.updates, ratio.searches)),
-            ..Default::default()
-        })
+        // Search latency + quality stats through the shared percentile path so the
+        // mixed harness matches the main search() footing.
+        let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
+        let mut results = crate::engine::compute_search_stats(
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
+        )?;
+        results.update_count = update_count;
+        results.update_rps = update_rps;
+        results.update_mean_time = update_mean_time;
+        results.update_p50_time = update_p50;
+        results.update_p95_time = update_p95;
+        results.update_p99_time = update_p99;
+        results.update_latencies = Some(u_times);
+        results.update_search_ratio = Some(format!("{}:{}", ratio.updates, ratio.searches));
+        Ok(results)
     }
 
     fn delete(&mut self) -> Result<(), String> {

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -703,13 +703,6 @@ impl Engine for VectorSetsEngine {
             queries.len()
         };
 
-        let search_times: Arc<Mutex<Vec<f64>>> =
-            Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let update_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
-        let precisions: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let recalls: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let mrrs: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
-        let ndcgs: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::with_capacity(num_to_run)));
         let search_idx = Arc::new(AtomicUsize::new(0));
         let update_idx = Arc::new(AtomicUsize::new(0));
 
@@ -720,7 +713,21 @@ impl Engine for VectorSetsEngine {
         let pb = self.create_progress_bar(num_to_run);
         let start_time = Instant::now();
 
+        // Each worker accumulates search + update samples into thread-local
+        // buffers and returns them on join; the main thread concatenates. This
+        // keeps the timed hot loop free of the 5-6 cross-thread Mutex<Vec> pushes
+        // per query that serialized workers at high parallelism (matching the main
+        // search() path). Dispatch counters use Relaxed (only their own
+        // monotonicity matters) and the progress bar is advanced in batches.
+        let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut recs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut u_times: Vec<f64> = Vec::new();
+
         std::thread::scope(|s| {
+            let mut handles = Vec::with_capacity(parallel);
             for _ in 0..parallel {
                 let redis_url = self.redis_url.clone();
                 let config = self.config.clone();
@@ -731,30 +738,33 @@ impl Engine for VectorSetsEngine {
                 let upd_vectors = &upd_vectors;
                 let upd_metadata = &upd_metadata;
                 let update_seq = &update_seq;
-                let search_times = Arc::clone(&search_times);
-                let update_times = Arc::clone(&update_times);
-                let precisions = Arc::clone(&precisions);
-                let recalls = Arc::clone(&recalls);
-                let mrrs = Arc::clone(&mrrs);
-                let ndcgs = Arc::clone(&ndcgs);
                 let search_idx = Arc::clone(&search_idx);
                 let update_idx = Arc::clone(&update_idx);
                 let pb = &pb;
 
-                s.spawn(move || {
+                handles.push(s.spawn(move || {
+                    // Thread-local sample buffers — no cross-thread lock per query.
+                    let mut t: Vec<f64> = Vec::new();
+                    let mut p: Vec<f64> = Vec::new();
+                    let mut r: Vec<f64> = Vec::new();
+                    let mut mr: Vec<f64> = Vec::new();
+                    let mut nd: Vec<f64> = Vec::new();
+                    let mut ut: Vec<f64> = Vec::new();
+                    let mut pb_pending: u64 = 0;
+
                     let client = match redis::Client::open(redis_url.as_str()) {
                         Ok(c) => c,
-                        Err(_) => return,
+                        Err(_) => return (t, p, r, mr, nd, ut),
                     };
                     let mut conn = match client.get_connection() {
                         Ok(c) => c,
-                        Err(_) => return,
+                        Err(_) => return (t, p, r, mr, nd, ut),
                     };
 
                     'outer: loop {
                         // Search phase: do S searches
                         for _ in 0..ratio_searches {
-                            let idx = search_idx.fetch_add(1, Ordering::SeqCst);
+                            let idx = search_idx.fetch_add(1, Ordering::Relaxed);
                             if idx >= num_to_run {
                                 break 'outer;
                             }
@@ -782,7 +792,6 @@ impl Engine for VectorSetsEngine {
 
                             match results {
                                 Ok(result_ids) => {
-                                    search_times.lock().unwrap().push(query_time);
                                     let ordered_ids: Vec<i64> =
                                         result_ids.iter().map(|(id, _)| *id).collect();
                                     let m = crate::metrics::compute_metrics(
@@ -790,21 +799,26 @@ impl Engine for VectorSetsEngine {
                                         &neighbors[idx],
                                         top,
                                     );
-                                    precisions.lock().unwrap().push(m.precision);
-                                    recalls.lock().unwrap().push(m.recall);
-                                    mrrs.lock().unwrap().push(m.mrr);
-                                    ndcgs.lock().unwrap().push(m.ndcg);
+                                    t.push(query_time);
+                                    p.push(m.precision);
+                                    r.push(m.recall);
+                                    mr.push(m.mrr);
+                                    nd.push(m.ndcg);
                                 }
                                 Err(e) => {
                                     eprintln!("Search query {} failed: {}", idx, e);
                                 }
                             }
-                            pb.inc(1);
+                            pb_pending += 1;
+                            if pb_pending >= 256 {
+                                pb.inc(pb_pending);
+                                pb_pending = 0;
+                            }
                         }
 
                         // Update phase: do U updates
                         for _ in 0..ratio_updates {
-                            let uidx = update_idx.fetch_add(1, Ordering::SeqCst);
+                            let uidx = update_idx.fetch_add(1, Ordering::Relaxed);
                             let data_idx = update_seq[uidx % update_seq_len];
 
                             let update_start = Instant::now();
@@ -816,82 +830,49 @@ impl Engine for VectorSetsEngine {
                                 upd_metadata[data_idx].as_ref(),
                             );
                             let update_time = update_start.elapsed().as_secs_f64();
-                            update_times.lock().unwrap().push(update_time);
+                            ut.push(update_time);
                         }
                     }
-                });
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
+                    }
+                    (t, p, r, mr, nd, ut)
+                }));
+            }
+
+            for h in handles {
+                let (t, p, r, mr, nd, ut) = h.join().unwrap();
+                times.extend(t);
+                precs.extend(p);
+                recs.extend(r);
+                mrr_vals.extend(mr);
+                ndcg_vals.extend(nd);
+                u_times.extend(ut);
             }
         });
 
         pb.finish_and_clear();
         let total_time = start_time.elapsed().as_secs_f64();
 
-        let times = search_times.lock().unwrap();
-        let precs = precisions.lock().unwrap();
-        let recs = recalls.lock().unwrap();
-        let mrr_vals = mrrs.lock().unwrap();
-        let ndcg_vals = ndcgs.lock().unwrap();
-        let u_times = update_times.lock().unwrap();
-
         if times.is_empty() {
             return Err("No searches completed".to_string());
         }
 
-        let rps = times.len() as f64 / total_time;
-        let mean_precision = precs.iter().sum::<f64>() / precs.len() as f64;
-        let mean_recall = recs.iter().sum::<f64>() / recs.len() as f64;
-        let mean_mrr = mrr_vals.iter().sum::<f64>() / mrr_vals.len() as f64;
-        let mean_ndcg = ndcg_vals.iter().sum::<f64>() / ndcg_vals.len() as f64;
-        let mean_time = times.iter().sum::<f64>() / times.len() as f64;
-        let std_time = (times.iter().map(|t| (t - mean_time).powi(2)).sum::<f64>()
-            / times.len() as f64)
-            .sqrt();
-        let min_time = times.iter().copied().fold(f64::INFINITY, f64::min);
-        let max_time = times.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-
-        let mut sorted_times: Vec<f64> = times.clone();
-        sorted_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
-
-        let p50_idx = (sorted_times.len() as f64 * 0.50) as usize;
-        let p95_idx = (sorted_times.len() as f64 * 0.95) as usize;
-        let p99_idx = (sorted_times.len() as f64 * 0.99) as usize;
-
-        let p50_time = sorted_times.get(p50_idx).copied().unwrap_or(0.0);
-        let p95_time = sorted_times
-            .get(p95_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-        let p99_time = sorted_times
-            .get(p99_idx.min(sorted_times.len() - 1))
-            .copied()
-            .unwrap_or(0.0);
-
-        // Update latency stats
+        // Update latency stats (linear-interpolation percentiles, matching the
+        // shared search-stats path).
         let (update_count, update_rps, update_mean_time, update_p50, update_p95, update_p99) =
             if !u_times.is_empty() {
                 let u_rps = u_times.len() as f64 / total_time;
                 let u_mean = u_times.iter().sum::<f64>() / u_times.len() as f64;
                 let mut u_sorted: Vec<f64> = u_times.clone();
                 u_sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                let u_p50 = u_sorted
-                    .get((u_sorted.len() as f64 * 0.50) as usize)
-                    .copied()
-                    .unwrap_or(0.0);
-                let u_p95 = u_sorted
-                    .get(((u_sorted.len() as f64 * 0.95) as usize).min(u_sorted.len() - 1))
-                    .copied()
-                    .unwrap_or(0.0);
-                let u_p99 = u_sorted
-                    .get(((u_sorted.len() as f64 * 0.99) as usize).min(u_sorted.len() - 1))
-                    .copied()
-                    .unwrap_or(0.0);
                 (
                     Some(u_times.len()),
                     Some(u_rps),
                     Some(u_mean),
-                    Some(u_p50),
-                    Some(u_p95),
-                    Some(u_p99),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.50)),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.95)),
+                    Some(crate::engine::percentile_linear(&u_sorted, 0.99)),
                 )
             } else {
                 (None, None, None, None, None, None)
@@ -906,40 +887,21 @@ impl Engine for VectorSetsEngine {
             self.commandstats_baseline.as_ref(),
         )?;
 
-        Ok(SearchResults {
-            total_time,
-            mean_time,
-            mean_precision,
-            mean_recall,
-            mean_mrr,
-            mean_ndcg,
-            std_time,
-            min_time,
-            max_time,
-            rps,
-            p50_time,
-            p95_time,
-            p99_time,
-            precisions: precs.to_vec(),
-            recalls: recs.to_vec(),
-            mrrs: mrr_vals.to_vec(),
-            ndcgs: ndcg_vals.to_vec(),
-            latencies: times.to_vec(),
-            top: explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10)),
-            num_queries: times.len(),
-            requested_queries: num_to_run,
-            failed_queries: num_to_run.saturating_sub(times.len()),
-            parallel,
-            update_count,
-            update_rps,
-            update_mean_time,
-            update_p50_time: update_p50,
-            update_p95_time: update_p95,
-            update_p99_time: update_p99,
-            update_latencies: Some(u_times.to_vec()),
-            update_search_ratio: Some(format!("{}:{}", ratio.updates, ratio.searches)),
-            ..Default::default()
-        })
+        // Search latency + quality stats through the shared percentile path so the
+        // mixed harness matches the main search() footing.
+        let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
+        let mut results = crate::engine::compute_search_stats(
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
+        )?;
+        results.update_count = update_count;
+        results.update_rps = update_rps;
+        results.update_mean_time = update_mean_time;
+        results.update_p50_time = update_p50;
+        results.update_p95_time = update_p95;
+        results.update_p99_time = update_p99;
+        results.update_latencies = Some(u_times);
+        results.update_search_ratio = Some(format!("{}:{}", ratio.updates, ratio.searches));
+        Ok(results)
     }
 
     fn delete(&mut self) -> Result<(), String> {

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -566,6 +566,7 @@ impl Engine for VectorSetsEngine {
                     let mut r = Vec::new();
                     let mut mr = Vec::new();
                     let mut nd = Vec::new();
+                    let mut pb_pending: u64 = 0;
 
                     let client = match redis::Client::open(redis_url.as_str()) {
                         Ok(c) => c,
@@ -618,7 +619,16 @@ impl Engine for VectorSetsEngine {
                                 eprintln!("Search query {} failed: {}", idx, e);
                             }
                         }
-                        pb.inc(1);
+                        // Batch progress updates so the highest-QPS runs don't pay a
+                        // contended atomic per query.
+                        pb_pending += 1;
+                        if pb_pending >= 256 {
+                            pb.inc(pb_pending);
+                            pb_pending = 0;
+                        }
+                    }
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd)
                 }));

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -104,7 +104,13 @@ pub fn write_match_any_project(
     engine_configs_json: &str,
     dim: usize,
 ) -> MatchAnyProject {
-    write_match_any_project_metric(dataset_name, engine_configs_json, dim, GtMetric::L2)
+    write_match_any_project_metric(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        GtMetric::L2,
+        N_QUERIES,
+    )
 }
 
 /// Cosine-ground-truth variant of [`write_match_any_project`] for engines that
@@ -114,7 +120,48 @@ pub fn write_match_any_cosine_project(
     engine_configs_json: &str,
     dim: usize,
 ) -> MatchAnyProject {
-    write_match_any_project_metric(dataset_name, engine_configs_json, dim, GtMetric::Cosine)
+    write_match_any_project_metric(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        GtMetric::Cosine,
+        N_QUERIES,
+    )
+}
+
+/// [`write_match_any_project`] with an explicit query count. The mixed/filter
+/// harnesses cap `num_to_run` at the number of queries in the fixture, so a
+/// larger count is needed to exercise the multi-worker join-merge (and, for
+/// mixed, to reliably drive updates) at `parallel >= 4`.
+pub fn write_match_any_project_n(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+    n_queries: usize,
+) -> MatchAnyProject {
+    write_match_any_project_metric(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        GtMetric::L2,
+        n_queries,
+    )
+}
+
+/// Cosine variant of [`write_match_any_project_n`] (VectorSets).
+pub fn write_match_any_cosine_project_n(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+    n_queries: usize,
+) -> MatchAnyProject {
+    write_match_any_project_metric(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        GtMetric::Cosine,
+        n_queries,
+    )
 }
 
 fn write_match_any_project_metric(
@@ -122,13 +169,14 @@ fn write_match_any_project_metric(
     engine_configs_json: &str,
     dim: usize,
     metric: GtMetric,
+    n_queries: usize,
 ) -> MatchAnyProject {
     // Deterministic data/queries so ground truth is reproducible across engines.
     let mut rng = StdRng::seed_from_u64(0xA11CE);
     let gen_vec =
         |rng: &mut StdRng| -> Vec<f32> { (0..dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect() };
     let vectors: Vec<Vec<f32>> = (0..N_DOCS).map(|_| gen_vec(&mut rng)).collect();
-    let queries: Vec<Vec<f32>> = (0..N_QUERIES).map(|_| gen_vec(&mut rng)).collect();
+    let queries: Vec<Vec<f32>> = (0..n_queries).map(|_| gen_vec(&mut rng)).collect();
 
     // Nearest neighbours computed over the FILTERED corpus only.
     let filtered_gt = |q: &[f32]| -> Vec<i64> {
@@ -1083,4 +1131,63 @@ pub fn read_recalls(root: &Path, engine: &str) -> Vec<f64> {
         .iter()
         .map(|x| x.as_f64().unwrap())
         .collect()
+}
+
+/// Like [`run_binary`] but appends `extra` CLI args (e.g. `--skip-vector-index`
+/// for the filter-only harness, or `--update-search-ratio 1:5` for mixed).
+pub fn run_binary_extra(
+    root: &Path,
+    engine: &str,
+    dataset: &str,
+    host: &str,
+    envs: &[(&str, &str)],
+    extra: &[&str],
+) -> bool {
+    let mut cmd = std::process::Command::new(binary_path());
+    cmd.args([
+        "--engines",
+        engine,
+        "--datasets",
+        dataset,
+        "--host",
+        host,
+        "--skip-if-exists",
+        "false",
+    ]);
+    cmd.args(extra);
+    cmd.current_dir(root);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("run vector-db-benchmark");
+    if !out.status.success() {
+        eprintln!(
+            "stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    out.status.success()
+}
+
+/// Read the whole `results` object from an engine's search result JSON, so a
+/// test can assert on any field (percentiles, requested/failed_queries,
+/// update_* metrics, the mean_precisions sentinel, …). `engine` is the result
+/// filename prefix — note `--skip-vector-index` renames the engine to
+/// `<engine_type>-no-vector`, so pass that prefix for filter-only runs.
+pub fn read_results_obj(root: &Path, engine: &str) -> serde_json::Value {
+    let pattern = format!("{}-*-search-*.json", engine);
+    let dir = root.join("results");
+    let path = fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            glob::Pattern::new(&pattern)
+                .unwrap()
+                .matches(&p.file_name().unwrap().to_string_lossy())
+        })
+        .unwrap_or_else(|| panic!("no search result for {}", engine));
+    let v: serde_json::Value = serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
+    v["results"].clone()
 }

--- a/tests/integration_mongodb.rs
+++ b/tests/integration_mongodb.rs
@@ -894,6 +894,10 @@ fn test_binary_mongodb_mixed_benchmark() {
         "engine": "mongodb",
         "connection_params": {},
         "collection_params": {},
+        // parallel: 1 — this test asserts an EXACT update_count (2), which only
+        // holds single-threaded (the mixed loop's `break 'outer` makes the update
+        // count interleaving-dependent at parallel > 1). The multi-worker
+        // join-merge is covered by test_binary_mongodb_mixed_parallel.
         "search_params": [{
             "parallel": 1,
             "num_candidates": 20,
@@ -995,6 +999,144 @@ fn test_binary_mongodb_mixed_benchmark() {
 
     drop_test_collection();
     fs::remove_dir_all(&project_root).ok();
+}
+
+/// End-to-end MIXED harness at `parallel: 4` over a 2000-query fixture, so many
+/// full search phases (and updates) run and the per-worker thread-local sample
+/// buffers are merged across threads (the join-merge path — the actual rewrite).
+/// Complements `test_binary_mongodb_mixed_benchmark` (parallel: 1, exact
+/// update_count): here we assert recall/precision are intact, updates ran
+/// (`update_count > 0`, `update_rps > 0`), and search percentiles are monotone.
+#[test]
+fn test_binary_mongodb_mixed_parallel() {
+    wait_for_mongodb();
+    drop_test_collection();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "mongo-mx", "engine": "mongodb",
+        "connection_params": {}, "collection_params": {},
+        "search_params": [{"parallel": 4, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project_n(
+        "mongo-mx-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+        2000,
+    );
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = std::env::var("MONGODB_PORT").unwrap_or_else(|_| MONGODB_PORT.to_string());
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "mongo-mx",
+            "mongo-mx-test",
+            MONGODB_HOST,
+            &[
+                ("MONGODB_PORT", port.as_str()),
+                ("MONGODB_DB", TEST_DB),
+                ("MONGODB_COLLECTION", TEST_COLLECTION),
+                ("MONGODB_INDEX_NAME", TEST_INDEX),
+            ],
+            &["--update-search-ratio", "1:5", "--repetitions", "1"],
+        ),
+        "mongodb mixed (parallel) run failed"
+    );
+
+    let r = common::read_results_obj(&proj.root, "mongo-mx");
+    let recall = r["mean_recall"].as_f64().unwrap();
+    let precision = r["mean_precisions"].as_f64().unwrap();
+    let update_count = r["update_count"].as_u64().unwrap();
+    let update_rps = r["update_rps"].as_f64().unwrap();
+    let p50 = r["p50_time"].as_f64().unwrap();
+    let p95 = r["p95_time"].as_f64().unwrap();
+    let p99 = r["p99_time"].as_f64().unwrap();
+    println!(
+        "mongodb mixed (parallel=4): recall={recall:.3} precision={precision:.3} \
+         update_count={update_count} update_rps={update_rps:.1} p50={p50} p95={p95} p99={p99}"
+    );
+    assert!(precision >= 0.8, "mixed precision {precision} < 0.8");
+    assert!(recall >= 0.9, "mixed recall {recall} < 0.9");
+    assert!(update_count > 0, "mixed run performed no updates");
+    assert!(update_rps > 0.0, "update_rps should be positive");
+    assert!(
+        p50 <= p95 && p95 <= p99,
+        "percentiles must be monotone: p50={p50} p95={p95} p99={p99}"
+    );
+    drop_test_collection();
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+/// End-to-end FILTER-ONLY harness (`--skip-vector-index`) at `parallel: 4` with
+/// `--queries 1000`: MongoDB has no `check_commandstats` backstop, so this is the
+/// primary guard that failed `$vectorSearch`/`find` calls are counted (not folded
+/// into RPS/percentiles). Asserts the filter-only sentinel (`mean_precisions ==
+/// -1`), full query accounting (requested == succeeded, failed == 0) on a healthy
+/// run, positive RPS, and monotone linear percentiles, with the per-worker sample
+/// buffers merged across threads.
+#[test]
+fn test_binary_mongodb_filter_only() {
+    wait_for_mongodb();
+    drop_test_collection();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "mongo-fo", "engine": "mongodb",
+        "connection_params": {}, "collection_params": {},
+        "search_params": [{"parallel": 4, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "mongo-fo-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = std::env::var("MONGODB_PORT").unwrap_or_else(|_| MONGODB_PORT.to_string());
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "mongo-fo",
+            "mongo-fo-test",
+            MONGODB_HOST,
+            &[
+                ("MONGODB_PORT", port.as_str()),
+                ("MONGODB_DB", TEST_DB),
+                ("MONGODB_COLLECTION", TEST_COLLECTION),
+                ("MONGODB_INDEX_NAME", TEST_INDEX),
+            ],
+            &["--skip-vector-index", "--queries", "1000"],
+        ),
+        "mongodb filter-only run failed"
+    );
+
+    let r = common::read_results_obj(&proj.root, "mongodb-no-vector");
+    let mp = r["mean_precisions"].as_f64().unwrap();
+    let rps = r["rps"].as_f64().unwrap();
+    let p50 = r["p50_time"].as_f64().unwrap();
+    let p95 = r["p95_time"].as_f64().unwrap();
+    let p99 = r["p99_time"].as_f64().unwrap();
+    let requested = r["requested_queries"].as_u64().unwrap();
+    let succeeded = r["succeeded_queries"].as_u64().unwrap();
+    let failed = r["failed_queries"].as_u64().unwrap();
+    println!(
+        "mongodb filter-only: mean_precisions={mp} rps={rps:.1} p50={p50} p95={p95} p99={p99} \
+         requested={requested} succeeded={succeeded} failed={failed}"
+    );
+    assert_eq!(mp, -1.0, "filter-only sentinel lost");
+    assert_eq!(requested, 1000, "requested_queries");
+    assert_eq!(failed, 0, "healthy run must have no failed queries");
+    assert_eq!(succeeded, 1000, "all queries should succeed");
+    assert!(rps > 0.0, "rps should be positive");
+    assert!(
+        p50 <= p95 && p95 <= p99,
+        "percentiles must be monotone: p50={p50} p95={p95} p99={p99}"
+    );
+    drop_test_collection();
+    fs::remove_dir_all(&proj.root).ok();
 }
 
 /// End-to-end `match_any`: filter a keyword field to an OR-set and assert the

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -1676,6 +1676,11 @@ fn test_binary_redis_mixed_benchmark() {
         "collection_params": {
             "hnsw_config": { "M": 16, "EF_CONSTRUCTION": 128 }
         },
+        // parallel: 1 — this test asserts EXACT FT.SEARCH/HSET call counts, which
+        // only hold single-threaded (the mixed loop's `break 'outer` skips the
+        // update phase for whichever worker draws the out-of-range search index,
+        // so the update count is interleaving-dependent at parallel > 1). The
+        // multi-worker join-merge is covered by test_binary_redis_mixed_parallel.
         "search_params": [{
             "parallel": 1,
             "search_params": { "ef": 256 },
@@ -1797,6 +1802,132 @@ fn test_binary_redis_mixed_benchmark() {
     );
 
     fs::remove_dir_all(&project_root).ok();
+}
+
+/// End-to-end FILTER-ONLY harness (`--skip-vector-index`): uploads vectors
+/// without indexing and runs pure metadata-filter queries through
+/// `search_filter_only`, driven at `parallel: 4` with `--queries 1000` so the
+/// thread-local per-worker latency buffers are genuinely merged across threads
+/// (the join-merge path — the actual rewrite). Asserts the filter-only sentinel
+/// (`mean_precisions == -1`), that every dispatched query is accounted for
+/// (`requested == succeeded`, `failed == 0`) on a healthy run, positive RPS, and
+/// monotone linear percentiles (p50 <= p95 <= p99).
+#[test]
+fn test_binary_redis_filter_only() {
+    wait_for_redis();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "redis-fo", "engine": "redis",
+        "search_params": [{"parallel": 4, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "redis-fo-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = TEST_PORT.to_string();
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "redis-fo",
+            "redis-fo-test",
+            "localhost",
+            &[("REDIS_PORT", port.as_str())],
+            &["--skip-vector-index", "--queries", "1000"],
+        ),
+        "redis filter-only run failed"
+    );
+
+    // --skip-vector-index renames the engine to "<type>-no-vector".
+    let r = common::read_results_obj(&proj.root, "redis-no-vector");
+    let mp = r["mean_precisions"].as_f64().unwrap();
+    let rps = r["rps"].as_f64().unwrap();
+    let p50 = r["p50_time"].as_f64().unwrap();
+    let p95 = r["p95_time"].as_f64().unwrap();
+    let p99 = r["p99_time"].as_f64().unwrap();
+    let requested = r["requested_queries"].as_u64().unwrap();
+    let succeeded = r["succeeded_queries"].as_u64().unwrap();
+    let failed = r["failed_queries"].as_u64().unwrap();
+    println!(
+        "redis filter-only: mean_precisions={mp} rps={rps:.1} p50={p50} p95={p95} p99={p99} \
+         requested={requested} succeeded={succeeded} failed={failed}"
+    );
+    assert_eq!(mp, -1.0, "filter-only sentinel lost");
+    assert_eq!(requested, 1000, "requested_queries");
+    assert_eq!(failed, 0, "healthy run must have no failed queries");
+    assert_eq!(succeeded, 1000, "all queries should succeed");
+    assert!(rps > 0.0, "rps should be positive");
+    assert!(
+        p50 <= p95 && p95 <= p99,
+        "percentiles must be monotone: p50={p50} p95={p95} p99={p99}"
+    );
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+/// End-to-end MIXED harness at `parallel: 4` over a 2000-query fixture, so many
+/// full search phases (and updates) run and the per-worker thread-local sample
+/// buffers are merged across threads (the join-merge path — the actual rewrite).
+/// Complements `test_binary_redis_mixed_benchmark` (parallel: 1, exact counts):
+/// here we assert the search recall/precision are intact, updates ran
+/// (`update_count > 0`, `update_rps > 0`), and search percentiles are monotone.
+#[test]
+fn test_binary_redis_mixed_parallel() {
+    wait_for_redis();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "redis-mx", "engine": "redis",
+        "search_params": [{"parallel": 4, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project_n(
+        "redis-mx-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+        2000,
+    );
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = TEST_PORT.to_string();
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "redis-mx",
+            "redis-mx-test",
+            "localhost",
+            &[("REDIS_PORT", port.as_str())],
+            &["--update-search-ratio", "1:5", "--repetitions", "1"],
+        ),
+        "redis mixed (parallel) run failed"
+    );
+
+    let r = common::read_results_obj(&proj.root, "redis-mx");
+    let recall = r["mean_recall"].as_f64().unwrap();
+    let precision = r["mean_precisions"].as_f64().unwrap();
+    let update_count = r["update_count"].as_u64().unwrap();
+    let update_rps = r["update_rps"].as_f64().unwrap();
+    let p50 = r["p50_time"].as_f64().unwrap();
+    let p95 = r["p95_time"].as_f64().unwrap();
+    let p99 = r["p99_time"].as_f64().unwrap();
+    let succeeded = r["succeeded_queries"].as_u64().unwrap();
+    println!(
+        "redis mixed (parallel=4): recall={recall:.3} precision={precision:.3} \
+         succeeded={succeeded} update_count={update_count} update_rps={update_rps:.1} \
+         p50={p50} p95={p95} p99={p99}"
+    );
+    assert!(precision >= 0.8, "mixed precision {precision} < 0.8");
+    assert!(recall >= 0.9, "mixed recall {recall} < 0.9");
+    assert!(update_count > 0, "mixed run performed no updates");
+    assert!(update_rps > 0.0, "update_rps should be positive");
+    assert!(
+        p50 <= p95 && p95 <= p99,
+        "percentiles must be monotone: p50={p50} p95={p95} p99={p99}"
+    );
+    fs::remove_dir_all(&proj.root).ok();
 }
 
 /// End-to-end `match_any`: filter a keyword (TAG) field to an OR-set and assert

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -1194,6 +1194,128 @@ fn test_binary_valkey_match_any_resp3() {
     );
 }
 
+/// End-to-end FILTER-ONLY harness (`--skip-vector-index`) at `parallel: 4` with
+/// `--queries 1000`, so the per-worker thread-local latency buffers are merged
+/// across threads (the join-merge path). Asserts the filter-only sentinel
+/// (`mean_precisions == -1`), full query accounting (requested == succeeded,
+/// failed == 0) on a healthy run, positive RPS, and monotone linear percentiles.
+#[test]
+fn test_binary_valkey_filter_only() {
+    wait_for_valkey();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "valkey-fo", "engine": "valkey",
+        "search_params": [{"parallel": 4, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "valkey-fo-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = test_port().to_string();
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "valkey-fo",
+            "valkey-fo-test",
+            "127.0.0.1",
+            &[("VALKEY_PORT", port.as_str())],
+            &["--skip-vector-index", "--queries", "1000"],
+        ),
+        "valkey filter-only run failed"
+    );
+
+    let r = common::read_results_obj(&proj.root, "valkey-no-vector");
+    let mp = r["mean_precisions"].as_f64().unwrap();
+    let rps = r["rps"].as_f64().unwrap();
+    let p50 = r["p50_time"].as_f64().unwrap();
+    let p95 = r["p95_time"].as_f64().unwrap();
+    let p99 = r["p99_time"].as_f64().unwrap();
+    let requested = r["requested_queries"].as_u64().unwrap();
+    let succeeded = r["succeeded_queries"].as_u64().unwrap();
+    let failed = r["failed_queries"].as_u64().unwrap();
+    println!(
+        "valkey filter-only: mean_precisions={mp} rps={rps:.1} p50={p50} p95={p95} p99={p99} \
+         requested={requested} succeeded={succeeded} failed={failed}"
+    );
+    assert_eq!(mp, -1.0, "filter-only sentinel lost");
+    assert_eq!(requested, 1000, "requested_queries");
+    assert_eq!(failed, 0, "healthy run must have no failed queries");
+    assert_eq!(succeeded, 1000, "all queries should succeed");
+    assert!(rps > 0.0, "rps should be positive");
+    assert!(
+        p50 <= p95 && p95 <= p99,
+        "percentiles must be monotone: p50={p50} p95={p95} p99={p99}"
+    );
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+/// End-to-end MIXED harness (`--update-search-ratio`) at `parallel: 4`: mirrors
+/// `test_binary_redis_mixed_benchmark` but exercises the valkey mixed path with a
+/// real multi-worker join-merge. Asserts search recall/precision are intact,
+/// updates ran (`update_count > 0`, `update_rps > 0`), and the search percentiles
+/// are monotone.
+#[test]
+fn test_binary_valkey_mixed_benchmark() {
+    wait_for_valkey();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "valkey-mx", "engine": "valkey",
+        "search_params": [{"parallel": 4, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    // 2000 queries so that at parallel: 4 the mixed loop reliably completes many
+    // full search phases (and thus updates), and merges a large per-worker sample
+    // set across threads.
+    let proj = common::write_match_any_project_n(
+        "valkey-mx-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+        2000,
+    );
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = test_port().to_string();
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "valkey-mx",
+            "valkey-mx-test",
+            "127.0.0.1",
+            &[("VALKEY_PORT", port.as_str())],
+            &["--update-search-ratio", "1:5", "--repetitions", "1"],
+        ),
+        "valkey mixed run failed"
+    );
+
+    let r = common::read_results_obj(&proj.root, "valkey-mx");
+    let recall = r["mean_recall"].as_f64().unwrap();
+    let precision = r["mean_precisions"].as_f64().unwrap();
+    let update_count = r["update_count"].as_u64().unwrap();
+    let update_rps = r["update_rps"].as_f64().unwrap();
+    let p50 = r["p50_time"].as_f64().unwrap();
+    let p95 = r["p95_time"].as_f64().unwrap();
+    let p99 = r["p99_time"].as_f64().unwrap();
+    println!(
+        "valkey mixed: recall={recall:.3} precision={precision:.3} update_count={update_count} \
+         update_rps={update_rps:.1} p50={p50} p95={p95} p99={p99}"
+    );
+    assert!(precision >= 0.8, "mixed precision {precision} < 0.8");
+    assert!(recall >= 0.9, "mixed recall {recall} < 0.9");
+    assert!(update_count > 0, "mixed run performed no updates");
+    assert!(update_rps > 0.0, "update_rps should be positive");
+    assert!(
+        p50 <= p95 && p95 <= p99,
+        "percentiles must be monotone: p50={p50} p95={p95} p99={p99}"
+    );
+    fs::remove_dir_all(&proj.root).ok();
+}
+
 // ── New filter datatypes: bool / uuid / full-text / datetime ────────────────
 //
 // Each drives the real binary against a compound dataset whose queries carry a

--- a/tests/integration_vectorsets.rs
+++ b/tests/integration_vectorsets.rs
@@ -186,3 +186,71 @@ fn test_binary_vectorsets_bool_filter() {
         recall
     );
 }
+
+/// End-to-end MIXED harness (`--update-search-ratio`) at `parallel: 4`: drives
+/// the VectorSets mixed path (VSIM search + VADD update) with a real multi-worker
+/// join-merge of the thread-local sample buffers. Cosine ground truth (VectorSets
+/// ranks by cosine). Asserts search recall/precision are intact, updates ran
+/// (`update_count > 0`, `update_rps > 0`), and search percentiles are monotone.
+#[test]
+fn test_binary_vectorsets_mixed_benchmark() {
+    wait_for_vectorsets();
+
+    let name = "vsets-mx";
+    let configs = serde_json::json!([{
+        "name": name,
+        "engine": "vectorsets",
+        "search_params": [{"parallel": 4, "search_params": {"ef": 400}}],
+        "upload_params": {
+            "hnsw_config": {"quant": "NOQUANT", "M": 16, "EF_CONSTRUCTION": 200},
+            "CAS": true,
+            "parallel": 1,
+            "batch_size": 100
+        }
+    }]);
+    // 2000 queries so that at parallel: 4 the mixed loop reliably completes many
+    // full search phases (and thus updates), and merges a large per-worker sample
+    // set across threads.
+    let proj = common::write_match_any_cosine_project_n(
+        "vs-mx",
+        &serde_json::to_string(&configs).unwrap(),
+        8,
+        2000,
+    );
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = test_port().to_string();
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            name,
+            "vs-mx",
+            TEST_HOST,
+            &[("REDIS_PORT", port.as_str())],
+            &["--update-search-ratio", "1:5", "--repetitions", "1"],
+        ),
+        "vectorsets mixed run failed"
+    );
+
+    let r = common::read_results_obj(&proj.root, name);
+    let recall = r["mean_recall"].as_f64().unwrap();
+    let precision = r["mean_precisions"].as_f64().unwrap();
+    let update_count = r["update_count"].as_u64().unwrap();
+    let update_rps = r["update_rps"].as_f64().unwrap();
+    let p50 = r["p50_time"].as_f64().unwrap();
+    let p95 = r["p95_time"].as_f64().unwrap();
+    let p99 = r["p99_time"].as_f64().unwrap();
+    println!(
+        "vectorsets mixed: recall={recall:.3} precision={precision:.3} update_count={update_count} \
+         update_rps={update_rps:.1} p50={p50} p95={p95} p99={p99}"
+    );
+    assert!(precision >= 0.8, "mixed precision {precision} < 0.8");
+    assert!(recall >= 0.9, "mixed recall {recall} < 0.9");
+    assert!(update_count > 0, "mixed run performed no updates");
+    assert!(update_rps > 0.0, "update_rps should be positive");
+    assert!(
+        p50 <= p95 && p95 <= p99,
+        "percentiles must be monotone: p50={p50} p95={p95} p99={p99}"
+    );
+    std::fs::remove_dir_all(&proj.root).ok();
+}


### PR DESCRIPTION
## Redis-family measurement-overhead rewrite (coverage+overhead loop, PR-B)

The 15-agent audit found the **filter-only** and **mixed** search harnesses of the Redis-family engines added client overhead and used a *biased percentile* that the main `search()` path does not — so those modes were measured on a worse, unfair footing than search-only for the *same* engine. This makes them match the reference `search()`.

### Fixes (redis, valkey, vectorsets, mongodb)
- **Removed the per-query global `Arc<Mutex<Vec>>`** in every filter-only/mixed timed loop → thread-local buffers merged after join (the pattern `search()` already uses). No cross-thread lock per query. *Reviewer-verified: no dropped or double-counted samples.*
- **Unified percentile math** on `compute_search_stats`/`percentile_linear` — dropped the hand-rolled nearest-rank `(len*q) as usize` that pinned p99==max for N≤100. Filter-only sentinel (`mean_precisions=-1`) and mixed update stats preserved.
- **Relaxed** dispatch counter (was `SeqCst`) to match `search()`.
- **Batched `pb.inc(256)`** in the harnesses *and* the reference `search()` paths, so the highest-QPS engines don't pay a contended atomic + clock read per query.
- **Filter-only failure accounting**: latency is now pushed only on `Ok`, so `failed_queries` reflects real failures (true parity with `search()`; MongoDB filter-only previously had no failure signal).

### New coverage (the rewritten hot paths are now actually exercised)
Committed integration tests at **parallel≥4** (the multi-worker merge was previously never run by any test):
- `test_binary_{redis,valkey,mongodb}_filter_only` — assert `mean_precisions=-1`, `requested==succeeded`, `failed==0`, `rps>0`, monotone p50≤p95≤p99.
- `test_binary_{valkey,vectorsets}_mixed_benchmark` + `test_binary_{redis,mongodb}_mixed_parallel` — recall/precision + `update_count>0` over a 2000-query fixture merged across 4 workers.

### Intended metric changes (correctness, not regressions)
- filter-only/mixed **and** update percentiles now use linear interpolation (was nearest-rank) — p50/p95/p99 differ slightly for identical raw latencies.
- filter-only now reports `requested_queries=num_to_run` (was 0) and real `failed_queries`.

### Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean
- 180 unit tests; all new tests pass live at parallel=4 (redis filter-only rps~9k failed=0; redis/valkey/vectorsets/mongodb mixed recall 1.0 update_count~400)
- Full suites green: redis 23, valkey 18, vectorsets 4, mongodb 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)