### PR TITLE
test: P0 pure-logic coverage (saturation detector, ratio parser, command-stats guard)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/redis_utils.rs
+++ b/src/bin/vector_db_benchmark/engine/redis_utils.rs
@@ -72,6 +72,23 @@ pub fn check_commandstats(
     };
 
     let current = parse_failed_calls(&info);
+    evaluate(&current, commands, context, baseline)
+}
+
+/// Pure decision logic behind [`check_commandstats`]: given the parsed
+/// `current` failed_calls map, decide whether any of `commands` accrued NEW
+/// failures since `baseline` (or any failures at all when `baseline` is `None`).
+///
+/// Returns `Err` listing each offending command and its NEW failure count, or
+/// `Ok(())` when every command is clean. Command names are matched
+/// case-insensitively (the map is keyed by uppercase); the error text preserves
+/// the caller's original spelling.
+fn evaluate(
+    current: &HashMap<String, u64>,
+    commands: &[&str],
+    context: &str,
+    baseline: Option<&CommandStatsBaseline>,
+) -> Result<(), String> {
     let mut failures = Vec::new();
 
     for cmd in commands {
@@ -100,7 +117,64 @@ pub fn check_commandstats(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_failed_calls;
+    use super::{evaluate, parse_failed_calls, CommandStatsBaseline};
+    use std::collections::HashMap;
+
+    fn map(pairs: &[(&str, u64)]) -> HashMap<String, u64> {
+        pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+    }
+
+    #[test]
+    fn evaluate_flags_failures_when_no_baseline() {
+        // failed_calls > 0 with no baseline → Err listing the command + count.
+        let current = map(&[("VADD", 3)]);
+        let err = evaluate(&current, &["VADD"], "upload", None).unwrap_err();
+        assert!(err.contains("VADD: 3 failed_calls"), "got {err}");
+        assert!(
+            err.contains("Command failures detected after upload"),
+            "got {err}"
+        );
+    }
+
+    #[test]
+    fn evaluate_ok_when_current_equals_baseline() {
+        // No NEW failures since the baseline snapshot → clean run.
+        let current = map(&[("VADD", 5)]);
+        let baseline: CommandStatsBaseline = map(&[("VADD", 5)]);
+        assert_eq!(
+            evaluate(&current, &["VADD"], "upload", Some(&baseline)),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn evaluate_reports_delta_over_baseline() {
+        // 7 current vs 5 baseline → only the 2 NEW failures are reported.
+        let current = map(&[("VADD", 7)]);
+        let baseline: CommandStatsBaseline = map(&[("VADD", 5)]);
+        let err = evaluate(&current, &["VADD"], "search", Some(&baseline)).unwrap_err();
+        assert!(err.contains("VADD: 2 failed_calls"), "got {err}");
+    }
+
+    #[test]
+    fn evaluate_matches_command_case_insensitively() {
+        // Map is keyed by uppercase (from parse_failed_calls); a lowercase
+        // command spelling still matches, and the error preserves that spelling.
+        let current = map(&[("VADD", 4)]);
+        let err = evaluate(&current, &["vadd"], "upload", None).unwrap_err();
+        assert!(err.contains("vadd: 4 failed_calls"), "got {err}");
+    }
+
+    #[test]
+    fn evaluate_ok_when_command_absent_or_zero() {
+        // A command with no entry (or zero failures) is clean; unrelated
+        // failing commands are ignored when not in the checked list.
+        let current = map(&[("FT.SEARCH", 9)]);
+        assert_eq!(
+            evaluate(&current, &["VADD", "VSIM"], "search", None),
+            Ok(())
+        );
+    }
 
     #[test]
     fn parses_failed_calls_and_uppercases_command() {

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -804,3 +804,60 @@ fn save_upload_results(
     println!("Results saved to: {:?}", path);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::parse_update_search_ratio;
+    use crate::engine::UpdateSearchRatio;
+
+    #[test]
+    fn parses_valid_ratio() {
+        assert_eq!(
+            parse_update_search_ratio("1:10"),
+            Ok(UpdateSearchRatio {
+                updates: 1,
+                searches: 10,
+            })
+        );
+    }
+
+    #[test]
+    fn allows_zero_updates() {
+        // Zero updates is valid (search-heavy phase); only searches must be > 0.
+        assert_eq!(
+            parse_update_search_ratio("0:5"),
+            Ok(UpdateSearchRatio {
+                updates: 0,
+                searches: 5,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_arity() {
+        let err = parse_update_search_ratio("1:2:3").unwrap_err();
+        assert_eq!(
+            err,
+            "Invalid update-search-ratio format: '1:2:3'. Expected 'U:S' (e.g., '1:10')"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_update_count() {
+        let err = parse_update_search_ratio("x:2").unwrap_err();
+        assert_eq!(err, "Invalid update count: 'x'");
+    }
+
+    #[test]
+    fn rejects_invalid_search_count() {
+        let err = parse_update_search_ratio("1:y").unwrap_err();
+        assert_eq!(err, "Invalid search count: 'y'");
+    }
+
+    #[test]
+    fn rejects_zero_searches() {
+        // searches == 0 would divide-by-zero later, so it is rejected up front.
+        let err = parse_update_search_ratio("1:0").unwrap_err();
+        assert_eq!(err, "Search count must be > 0");
+    }
+}

--- a/src/bin/vector_db_benchmark/summary.rs
+++ b/src/bin/vector_db_benchmark/summary.rs
@@ -497,6 +497,97 @@ mod tests {
         assert_eq!(format_precision_key(0.98), "0.9800");
     }
 
+    /// Build a `SearchEntry` for saturation tests. `sat_reason` empty means the
+    /// run was not flagged client-saturated.
+    fn entry(ef: &str, parallel: i64, rps: f64, p95: f64, sat_reason: &str) -> SearchEntry {
+        SearchEntry {
+            search_id: 0,
+            ef: ef.to_string(),
+            parallel,
+            results: SearchResults {
+                rps,
+                p95_time: p95,
+                client_saturated: !sat_reason.is_empty(),
+                saturation_reason: sat_reason.to_string(),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn saturation_warns_when_throughput_stops_scaling() {
+        // Same ef, parallel 8→16: QPS rises only ~5% (< 10%) while p95 rises →
+        // higher concurrency is not paying off, so a throughput warning fires.
+        let entries = vec![
+            entry("64", 8, 1000.0, 0.02, ""),
+            entry("64", 16, 1050.0, 0.03, ""),
+        ];
+        let w = saturation_warnings(&entries);
+        assert_eq!(w.len(), 1, "got {w:?}");
+        assert!(
+            w[0].starts_with("throughput saturated: ef=64 parallel 8→16"),
+            "got {}",
+            w[0]
+        );
+        // gain 50/1000 = 5%; p95 rose (0.03/0.02 - 1) = 50%.
+        assert!(w[0].contains("gained only 5% QPS"), "got {}", w[0]);
+        assert!(w[0].contains("p95 rose 50%"), "got {}", w[0]);
+        assert!(
+            w[0].ends_with("higher concurrency is not paying off"),
+            "got {}",
+            w[0]
+        );
+    }
+
+    #[test]
+    fn saturation_silent_when_throughput_scales_well() {
+        // QPS doubles (1000→2000, gain 100% ≥ 10%) → clean scaling, no warning
+        // even though p95 rose.
+        let entries = vec![
+            entry("64", 8, 1000.0, 0.02, ""),
+            entry("64", 16, 2000.0, 0.03, ""),
+        ];
+        assert!(saturation_warnings(&entries).is_empty());
+    }
+
+    #[test]
+    fn saturation_no_warn_when_p95_falls() {
+        // Gain < 10% but p95 FALLS (0.03→0.02): the `p95_cur > p95_prev` guard is
+        // not met, so no throughput warning is emitted.
+        let entries = vec![
+            entry("64", 8, 1000.0, 0.03, ""),
+            entry("64", 16, 1050.0, 0.02, ""),
+        ];
+        assert!(saturation_warnings(&entries).is_empty());
+    }
+
+    #[test]
+    fn saturation_warns_on_client_saturated_flag() {
+        // A single client-saturated run emits a client-saturation warning
+        // (and the throughput loop is skipped with < 2 points).
+        let entries = vec![entry("128", 32, 5000.0, 0.05, "client CPU >90%")];
+        let w = saturation_warnings(&entries);
+        assert_eq!(w.len(), 1, "got {w:?}");
+        assert_eq!(
+            w[0],
+            "client-saturated: ef=128 parallel=32 (client CPU >90%) — QPS/latency reflect the client, not the DB"
+        );
+    }
+
+    #[test]
+    fn saturation_client_warnings_ordered_by_parallel() {
+        // Two client-saturated points at parallel 16 and 8 → sorted ascending by
+        // parallel, so the parallel=8 warning is emitted first.
+        let entries = vec![
+            entry("64", 16, 4000.0, 0.04, "oversubscribed"),
+            entry("64", 8, 3000.0, 0.03, "cpu"),
+        ];
+        let w = saturation_warnings(&entries);
+        assert_eq!(w.len(), 2, "got {w:?}");
+        assert!(w[0].contains("parallel=8"), "first: {}", w[0]);
+        assert!(w[1].contains("parallel=16"), "second: {}", w[1]);
+    }
+
     #[test]
     fn test_analyze_precision_performance_picks_best_qps() {
         let entries = vec![


### PR DESCRIPTION
## P0 pure-logic coverage (coverage+overhead loop, PR-E)

The 15-agent audit flagged three zero-coverage pure functions as top priorities. All are now unit-tested, pinned to the code's actual messages/thresholds.

- **`summary::saturation_warnings`** (the CPU/throughput-saturation detector) — 5 tests: throughput-stops-scaling warning, scales-well silence, p95-falls guard, client-saturated flag, ordering by parallel.
- **`experiment::parse_update_search_ratio`** — 6 tests (valid, arity error, non-numeric update/search, `>0` guard). experiment.rs previously had no test module.
- **`redis_utils::check_commandstats`** — extracted the decision into a pure `evaluate(current, commands, context, baseline)` (I/O wrapper delegates to it), + 5 tests: no-baseline failure, no-new-failures, delta-over-baseline, case-insensitive match, clean/unrelated.

### Coverage delta (`cargo llvm-cov --lib --bins`)
- redis_utils.rs 46% → **81%**, summary.rs 20% → **43%**, experiment.rs 0% → **7.5%**

### Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean
- 196 unit tests (+16), all new tests confirmed registered and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)