### PR TITLE
perf(es,os,milvus,weaviate): consistent timed-window boundary (request-serialize out, RPC+decode in)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ half = "2.4"
 indicatif = "0.18.4"
 hdf5 = "0.8.1"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["raw_value"] }
 ndarray = "0.16"
 ndarray-npy = "0.9"
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -636,16 +636,20 @@ fn upload_bulk_batch(
     Ok(())
 }
 
-/// Execute a KNN search using the official client.
-fn knn_search(
-    rt: &tokio::runtime::Runtime,
-    client: &Elasticsearch,
-    index_name: &str,
+/// Build the KNN search request body for one query and pre-serialize it to a
+/// `RawValue`. This is deliberately done OUTSIDE the per-query timed window (the
+/// vector-to-JSON serialization — ryu float formatting over every dimension — is
+/// client CPU work, not server latency). Pre-serializing to a `RawValue` means
+/// the timed send only copies the already-formatted bytes onto the socket, so
+/// the measured latency reflects the RPC round-trip like the reference engines
+/// (pgvector/qdrant). The produced bytes are byte-identical to what the client
+/// would otherwise serialize inline.
+fn build_knn_body(
     query_vector: &[f32],
     top: usize,
     num_candidates: i64,
     filter: Option<&serde_json::Value>,
-) -> Result<Vec<(i64, f64)>, String> {
+) -> Box<serde_json::value::RawValue> {
     let mut knn = serde_json::json!({
         "field": "vector",
         "query_vector": query_vector,
@@ -668,11 +672,24 @@ fn knn_search(
         "_source": false,
     });
 
+    serde_json::value::to_raw_value(&body).expect("serialize KNN search body")
+}
+
+/// Send a pre-built KNN search request and return the raw response text. Only
+/// the network send + wire read live here (the caller wraps this in the timed
+/// window); the JSON body is already serialized (`raw_body`) and the response is
+/// parsed by `parse_knn_response` AFTER the window closes.
+fn knn_send(
+    rt: &tokio::runtime::Runtime,
+    client: &Elasticsearch,
+    index_name: &str,
+    raw_body: &serde_json::value::RawValue,
+) -> Result<String, String> {
     let resp = rt
         .block_on(
             client
                 .search(SearchParts::Index(&[index_name]))
-                .body(body)
+                .body(raw_body)
                 .send(),
         )
         .map_err(|e| format!("KNN search failed: {}", e))?;
@@ -682,8 +699,15 @@ fn knn_search(
         return Err(format!("KNN search error: {}", text));
     }
 
-    let resp_body: serde_json::Value = rt
-        .block_on(resp.json())
+    rt.block_on(resp.text())
+        .map_err(|e| format!("Failed to read search response: {}", e))
+}
+
+/// Parse a KNN search response body (done AFTER the timed window — DOM
+/// deserialization is client work, mirroring how pgvector/qdrant extract ids
+/// after `elapsed`).
+fn parse_knn_response(text: &str) -> Result<Vec<(i64, f64)>, String> {
+    let resp_body: serde_json::Value = serde_json::from_str(text)
         .map_err(|e| format!("Failed to parse search response: {}", e))?;
 
     let hits = resp_body
@@ -814,6 +838,33 @@ impl Engine for ElasticsearchEngine {
             queries.len()
         };
 
+        // Precompute per-query `top` and the fully serialized request bodies
+        // BEFORE the parallel region so the timed window wraps only the RPC
+        // round-trip (see build_knn_body). `tops[idx]` reproduces the same k the
+        // request embeds, so recall is computed against an identical result set.
+        let tops: Vec<usize> = (0..num_to_run)
+            .map(|idx| {
+                explicit_top.unwrap_or_else(|| {
+                    let n = neighbors[idx].len();
+                    if n > 0 {
+                        n
+                    } else {
+                        10
+                    }
+                })
+            })
+            .collect();
+        let raw_bodies: Vec<Box<serde_json::value::RawValue>> = (0..num_to_run)
+            .map(|idx| {
+                build_knn_body(
+                    &queries[idx],
+                    tops[idx],
+                    num_candidates,
+                    parsed_filters[idx].as_ref(),
+                )
+            })
+            .collect();
+
         // Per-thread sample buffers merged on join — no per-query Mutex<Vec>
         // contention in the timed loop (see redis.rs::search). Metrics are
         // order-independent so results are unchanged; work counter uses Relaxed.
@@ -836,9 +887,9 @@ impl Engine for ElasticsearchEngine {
             for _ in 0..parallel {
                 let base_url = base_url.clone();
                 let index_name = index_name.clone();
-                let queries = &queries;
                 let neighbors = &neighbors;
-                let parsed_filters = &parsed_filters;
+                let tops = &tops;
+                let raw_bodies = &raw_bodies;
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
 
@@ -867,28 +918,16 @@ impl Engine for ElasticsearchEngine {
                             break;
                         }
 
-                        let top = explicit_top.unwrap_or_else(|| {
-                            let n = neighbors[idx].len();
-                            if n > 0 {
-                                n
-                            } else {
-                                10
-                            }
-                        });
+                        let top = tops[idx];
 
+                        // Timed window: only the network send + wire read of the
+                        // raw response. Body is pre-serialized; response is parsed
+                        // after `elapsed`.
                         let query_start = Instant::now();
-                        let results = knn_search(
-                            &rt,
-                            &client,
-                            &index_name,
-                            &queries[idx],
-                            top,
-                            num_candidates,
-                            parsed_filters[idx].as_ref(),
-                        );
+                        let response = knn_send(&rt, &client, &index_name, &raw_bodies[idx]);
                         let query_time = query_start.elapsed().as_secs_f64();
 
-                        match results {
+                        match response.and_then(|text| parse_knn_response(&text)) {
                             Ok(result_ids) => {
                                 let ordered_ids: Vec<i64> =
                                     result_ids.iter().map(|(id, _)| *id).collect();

--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -675,16 +675,20 @@ fn build_knn_body(
     serde_json::value::to_raw_value(&body).expect("serialize KNN search body")
 }
 
-/// Send a pre-built KNN search request and return the raw response text. Only
-/// the network send + wire read live here (the caller wraps this in the timed
-/// window); the JSON body is already serialized (`raw_body`) and the response is
-/// parsed by `parse_knn_response` AFTER the window closes.
+/// Send a pre-built KNN search request and return the DECODED response. The
+/// consistent timed boundary (see qdrant/pgvector/redis) is: request-serialize
+/// OUT of the window (`raw_body` is already serialized), RPC send + receive +
+/// decode-to-structured-response IN the window (this fn: send + status check +
+/// wire read + `from_str` into a `serde_json::Value`), and id/score extraction
+/// OUT of the window (`extract_knn_hits`). So this whole fn runs inside the
+/// timed region; the JSON decode is billed as latency exactly as qdrant's
+/// protobuf decode and pgvector's row decode are.
 fn knn_send(
     rt: &tokio::runtime::Runtime,
     client: &Elasticsearch,
     index_name: &str,
     raw_body: &serde_json::value::RawValue,
-) -> Result<String, String> {
+) -> Result<serde_json::Value, String> {
     let resp = rt
         .block_on(
             client
@@ -699,17 +703,16 @@ fn knn_send(
         return Err(format!("KNN search error: {}", text));
     }
 
-    rt.block_on(resp.text())
-        .map_err(|e| format!("Failed to read search response: {}", e))
+    let text = rt
+        .block_on(resp.text())
+        .map_err(|e| format!("Failed to read search response: {}", e))?;
+    serde_json::from_str(&text).map_err(|e| format!("Failed to parse search response: {}", e))
 }
 
-/// Parse a KNN search response body (done AFTER the timed window — DOM
-/// deserialization is client work, mirroring how pgvector/qdrant extract ids
-/// after `elapsed`).
-fn parse_knn_response(text: &str) -> Result<Vec<(i64, f64)>, String> {
-    let resp_body: serde_json::Value = serde_json::from_str(text)
-        .map_err(|e| format!("Failed to parse search response: {}", e))?;
-
+/// Extract the id/score list from an already-decoded response (done AFTER the
+/// timed window — only pulling the final ids out of the decoded struct for
+/// recall, mirroring how pgvector/qdrant extract ids after `elapsed`).
+fn extract_knn_hits(resp_body: &serde_json::Value) -> Result<Vec<(i64, f64)>, String> {
     let hits = resp_body
         .get("hits")
         .and_then(|h| h.get("hits"))
@@ -920,14 +923,14 @@ impl Engine for ElasticsearchEngine {
 
                         let top = tops[idx];
 
-                        // Timed window: only the network send + wire read of the
-                        // raw response. Body is pre-serialized; response is parsed
-                        // after `elapsed`.
+                        // Timed window: network send + receive + decode of the
+                        // response into a structured value. Body is pre-serialized
+                        // (out); id/score extraction runs after `elapsed` (out).
                         let query_start = Instant::now();
                         let response = knn_send(&rt, &client, &index_name, &raw_bodies[idx]);
                         let query_time = query_start.elapsed().as_secs_f64();
 
-                        match response.and_then(|text| parse_knn_response(&text)) {
+                        match response.and_then(|resp_body| extract_knn_hits(&resp_body)) {
                             Ok(result_ids) => {
                                 let ordered_ids: Vec<i64> =
                                     result_ids.iter().map(|(id, _)| *id).collect();
@@ -979,6 +982,49 @@ impl Engine for ElasticsearchEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Load-bearing: the hoisted request body (pre-serialized to a RawValue) must
+    /// be byte-identical to what the old inline `.body(value)` path put on the
+    /// wire — otherwise this measurement-only change would alter the request.
+    #[test]
+    fn build_knn_body_bytes_match_old_wire_bytes() {
+        let vec = vec![0.1f32, -0.2, 0.3];
+        let top = 2usize;
+        let num_candidates = 10i64;
+        let filter = serde_json::json!({"term": {"color": "red"}});
+
+        // Reconstruct exactly the Value the old inline path serialized via JsonBody.
+        let mut knn = serde_json::json!({
+            "field": "vector",
+            "query_vector": vec,
+            "k": top,
+            "num_candidates": num_candidates,
+        });
+        knn.as_object_mut()
+            .unwrap()
+            .insert("filter".to_string(), filter.clone());
+        let expected = serde_json::json!({"knn": knn, "size": top, "_source": false});
+        let expected_bytes = serde_json::to_vec(&expected).unwrap();
+
+        let raw = build_knn_body(&vec, top, num_candidates, Some(&filter));
+        // The wire bytes: JsonBody(raw).write emits the RawValue verbatim.
+        assert_eq!(raw.get().as_bytes(), expected_bytes.as_slice());
+        // to_raw_value round-trips to the same bytes as to_vec (guards raw_value).
+        let reparsed: serde_json::Value = serde_json::from_str(raw.get()).unwrap();
+        assert_eq!(serde_json::to_vec(&reparsed).unwrap(), expected_bytes);
+
+        // Unfiltered variant.
+        let expected_nf = serde_json::json!({
+            "knn": {"field": "vector", "query_vector": vec, "k": top, "num_candidates": num_candidates},
+            "size": top,
+            "_source": false,
+        });
+        let raw_nf = build_knn_body(&vec, top, num_candidates, None);
+        assert_eq!(
+            raw_nf.get().as_bytes(),
+            serde_json::to_vec(&expected_nf).unwrap().as_slice()
+        );
+    }
 
     #[test]
     fn test_id_to_uuid_hex_zero() {

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -474,16 +474,20 @@ fn insert_batch(
 
 /// Search Milvus via REST API.
 #[allow(clippy::too_many_arguments)]
-fn search_vectors(
-    client: &reqwest::blocking::Client,
-    base_url: &str,
+/// Build and serialize one search request body to JSON bytes. Done OUTSIDE the
+/// per-query timed window: serializing the query vector to JSON decimal text
+/// (ryu formatting over every dimension) is client CPU work, not server latency.
+/// Pre-serializing means the timed send only copies the finished bytes onto the
+/// socket, matching the reference engines (pgvector/qdrant). The bytes are
+/// identical to what `.json(&body)` would have sent inline.
+fn build_search_body(
     collection_name: &str,
     query_vector: &[f32],
     top: usize,
     metric_type: &str,
     ef: Option<i64>,
     filter: Option<&str>,
-) -> Result<Vec<(i64, f64)>, String> {
+) -> Vec<u8> {
     let mut body = serde_json::json!({
         "collectionName": collection_name,
         "data": [query_vector],
@@ -512,11 +516,22 @@ fn search_vectors(
         );
     }
 
+    serde_json::to_vec(&body).expect("serialize search body")
+}
+
+/// Send a pre-serialized search request and return the raw response text. Only
+/// the network send + wire read live here (the caller wraps this in the timed
+/// window); the response is parsed by `parse_search_response` AFTER `elapsed`.
+fn send_search(
+    client: &reqwest::blocking::Client,
+    base_url: &str,
+    body: &[u8],
+) -> Result<String, String> {
     let url = format!("{}/v2/vectordb/entities/search", base_url);
     let resp = client
         .post(&url)
         .header("Content-Type", "application/json")
-        .json(&body)
+        .body(body.to_vec())
         .send()
         .map_err(|e| format!("Search failed: {}", e))?;
 
@@ -528,8 +543,14 @@ fn search_vectors(
         ));
     }
 
-    let resp_body: serde_json::Value = resp
-        .json()
+    resp.text()
+        .map_err(|e| format!("Failed to read search response: {}", e))
+}
+
+/// Parse a search response body (done AFTER the timed window — DOM
+/// deserialization is client work, mirroring pgvector/qdrant).
+fn parse_search_response(text: &str) -> Result<Vec<(i64, f64)>, String> {
+    let resp_body: serde_json::Value = serde_json::from_str(text)
         .map_err(|e| format!("Failed to parse search response: {}", e))?;
 
     let code = resp_body.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
@@ -850,6 +871,36 @@ impl Engine for MilvusEngine {
             queries.len()
         };
 
+        // Precompute per-query `top` and the fully serialized request bodies
+        // BEFORE the parallel region so the timed window wraps only the RPC
+        // round-trip (see build_search_body). `tops[idx]` reproduces the same k
+        // the request embeds, so recall is computed against an identical result
+        // set.
+        let tops: Vec<usize> = (0..num_to_run)
+            .map(|idx| {
+                explicit_top.unwrap_or_else(|| {
+                    let n = neighbors[idx].len();
+                    if n > 0 {
+                        n
+                    } else {
+                        10
+                    }
+                })
+            })
+            .collect();
+        let bodies: Vec<Vec<u8>> = (0..num_to_run)
+            .map(|idx| {
+                build_search_body(
+                    &self.collection_name,
+                    &queries[idx],
+                    tops[idx],
+                    &self.metric_type,
+                    ef,
+                    parsed_filters[idx].as_deref(),
+                )
+            })
+            .collect();
+
         // Per-thread sample buffers merged on join — no per-query Mutex<Vec>
         // contention in the timed loop (see redis.rs::search). Metrics are
         // order-independent so results are unchanged; work counter uses Relaxed.
@@ -868,12 +919,10 @@ impl Engine for MilvusEngine {
             let mut handles = Vec::with_capacity(parallel);
             for _ in 0..parallel {
                 let base_url = self.base_url.clone();
-                let collection_name = self.collection_name.clone();
-                let metric_type = self.metric_type.clone();
                 let timeout = self.timeout;
-                let queries = &queries;
                 let neighbors = &neighbors;
-                let parsed_filters = &parsed_filters;
+                let tops = &tops;
+                let bodies = &bodies;
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
 
@@ -898,29 +947,16 @@ impl Engine for MilvusEngine {
                             break;
                         }
 
-                        let top = explicit_top.unwrap_or_else(|| {
-                            let n = neighbors[idx].len();
-                            if n > 0 {
-                                n
-                            } else {
-                                10
-                            }
-                        });
+                        let top = tops[idx];
 
+                        // Timed window: only the network send + wire read of the
+                        // raw response. Body is pre-serialized; response is parsed
+                        // after `elapsed`.
                         let query_start = Instant::now();
-                        let results = search_vectors(
-                            &client,
-                            &base_url,
-                            &collection_name,
-                            &queries[idx],
-                            top,
-                            &metric_type,
-                            ef,
-                            parsed_filters[idx].as_deref(),
-                        );
+                        let response = send_search(&client, &base_url, &bodies[idx]);
                         let query_time = query_start.elapsed().as_secs_f64();
 
-                        match results {
+                        match response.and_then(|text| parse_search_response(&text)) {
                             Ok(result_ids) => {
                                 let ordered_ids: Vec<i64> =
                                     result_ids.iter().map(|(id, _)| *id).collect();

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -519,14 +519,18 @@ fn build_search_body(
     serde_json::to_vec(&body).expect("serialize search body")
 }
 
-/// Send a pre-serialized search request and return the raw response text. Only
-/// the network send + wire read live here (the caller wraps this in the timed
-/// window); the response is parsed by `parse_search_response` AFTER `elapsed`.
+/// Send a pre-serialized search request and return the DECODED response. The
+/// consistent timed boundary (see qdrant/pgvector/redis) is: request body
+/// pre-serialized OUTSIDE the window; RPC send + receive + decode-to-structured-
+/// response INSIDE the window (this fn: post + HTTP-status check + wire read +
+/// `from_str`); app-level code check + id/score extraction OUTSIDE
+/// (`extract_search_hits`). So the JSON decode is billed as latency exactly like
+/// qdrant's protobuf decode.
 fn send_search(
     client: &reqwest::blocking::Client,
     base_url: &str,
     body: &[u8],
-) -> Result<String, String> {
+) -> Result<serde_json::Value, String> {
     let url = format!("{}/v2/vectordb/entities/search", base_url);
     let resp = client
         .post(&url)
@@ -543,16 +547,16 @@ fn send_search(
         ));
     }
 
-    resp.text()
-        .map_err(|e| format!("Failed to read search response: {}", e))
+    let text = resp
+        .text()
+        .map_err(|e| format!("Failed to read search response: {}", e))?;
+    serde_json::from_str(&text).map_err(|e| format!("Failed to parse search response: {}", e))
 }
 
-/// Parse a search response body (done AFTER the timed window — DOM
-/// deserialization is client work, mirroring pgvector/qdrant).
-fn parse_search_response(text: &str) -> Result<Vec<(i64, f64)>, String> {
-    let resp_body: serde_json::Value = serde_json::from_str(text)
-        .map_err(|e| format!("Failed to parse search response: {}", e))?;
-
+/// Extract the id/score list from an already-decoded response (done AFTER the
+/// timed window — the app-level `code` check and id extraction pull the final
+/// ids out of the decoded struct for recall, mirroring pgvector/qdrant).
+fn extract_search_hits(resp_body: &serde_json::Value) -> Result<Vec<(i64, f64)>, String> {
     let code = resp_body.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
     if code != 0 {
         let msg = resp_body
@@ -949,14 +953,14 @@ impl Engine for MilvusEngine {
 
                         let top = tops[idx];
 
-                        // Timed window: only the network send + wire read of the
-                        // raw response. Body is pre-serialized; response is parsed
-                        // after `elapsed`.
+                        // Timed window: network send + receive + decode of the
+                        // response into a structured value. Body is pre-serialized
+                        // (out); code check + id extraction run after `elapsed` (out).
                         let query_start = Instant::now();
                         let response = send_search(&client, &base_url, &bodies[idx]);
                         let query_time = query_start.elapsed().as_secs_f64();
 
-                        match response.and_then(|text| parse_search_response(&text)) {
+                        match response.and_then(|resp_body| extract_search_hits(&resp_body)) {
                             Ok(result_ids) => {
                                 let ordered_ids: Vec<i64> =
                                     result_ids.iter().map(|(id, _)| *id).collect();
@@ -1010,6 +1014,43 @@ impl Engine for MilvusEngine {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Load-bearing: the hoisted request body bytes must equal what the old inline
+    /// `.json(&body)` path put on the wire (reqwest's `.json` uses `to_vec`).
+    #[test]
+    fn build_search_body_bytes_match_json_serialization() {
+        let vec = vec![0.1f32, -0.2, 0.3];
+        let top = 2usize;
+        let filter = "color == \"red\"";
+
+        // serde_json Map is a BTreeMap (no preserve_order feature), so an
+        // equivalent literal serializes byte-identically regardless of insert order.
+        let expected = json!({
+            "collectionName": "bench",
+            "data": [vec],
+            "annsField": "vector",
+            "limit": top,
+            "outputFields": ["id"],
+            "searchParams": {"metric_type": "COSINE", "params": {"ef": 64}},
+            "filter": filter,
+        });
+        let expected_bytes = serde_json::to_vec(&expected).unwrap();
+
+        let body = build_search_body("bench", &vec, top, "COSINE", Some(64), Some(filter));
+        assert_eq!(body, expected_bytes);
+
+        // Unfiltered + no-ef variant.
+        let expected_nf = json!({
+            "collectionName": "bench",
+            "data": [vec],
+            "annsField": "vector",
+            "limit": top,
+            "outputFields": ["id"],
+            "searchParams": {"metric_type": "COSINE"},
+        });
+        let body_nf = build_search_body("bench", &vec, top, "COSINE", None, None);
+        assert_eq!(body_nf, serde_json::to_vec(&expected_nf).unwrap());
+    }
 
     #[test]
     fn match_any_string_list_emits_in() {

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -735,18 +735,19 @@ fn hit_id(hit: &serde_json::Value) -> Option<&str> {
         .or_else(|| hit.get("_id").and_then(|v| v.as_str()))
 }
 
-/// Send a pre-serialized KNN search request and return the raw response text.
-/// Only the network send + wire read live here (the caller wraps this in the
-/// timed window). The request body is pre-serialized to a `RawValue` OUTSIDE the
-/// window (the vector-to-JSON ryu formatting is client CPU work, not server
-/// latency — see the search loop) and the response is parsed by
-/// `parse_knn_response` AFTER the window closes, mirroring pgvector/qdrant.
+/// Send a pre-serialized KNN search request and return the DECODED response.
+/// The consistent timed boundary (see qdrant/pgvector/redis) is: request body
+/// pre-serialized to a `RawValue` OUTSIDE the window (the vector-to-JSON ryu
+/// formatting is client CPU work); RPC send + receive + decode-to-structured-
+/// response INSIDE the window (this fn: send + status check + wire read +
+/// `from_str`); id/score extraction OUTSIDE (`extract_knn_hits`). So the JSON
+/// decode is billed as latency exactly like qdrant's protobuf decode.
 fn knn_send(
     rt: &tokio::runtime::Runtime,
     client: &OpenSearch,
     index_name: &str,
     raw_body: &serde_json::value::RawValue,
-) -> Result<String, String> {
+) -> Result<serde_json::Value, String> {
     let resp = rt
         .block_on(
             client
@@ -761,16 +762,16 @@ fn knn_send(
         return Err(format!("KNN search error: {}", text));
     }
 
-    rt.block_on(resp.text())
-        .map_err(|e| format!("Failed to read search response: {}", e))
+    let text = rt
+        .block_on(resp.text())
+        .map_err(|e| format!("Failed to read search response: {}", e))?;
+    serde_json::from_str(&text).map_err(|e| format!("Failed to parse search response: {}", e))
 }
 
-/// Parse a KNN search response body (done AFTER the timed window — DOM
-/// deserialization is client work, mirroring pgvector/qdrant).
-fn parse_knn_response(text: &str) -> Result<Vec<(i64, f64)>, String> {
-    let resp_body: serde_json::Value = serde_json::from_str(text)
-        .map_err(|e| format!("Failed to parse search response: {}", e))?;
-
+/// Extract the id/score list from an already-decoded response (done AFTER the
+/// timed window — only pulling final ids out of the decoded struct for recall,
+/// mirroring pgvector/qdrant).
+fn extract_knn_hits(resp_body: &serde_json::Value) -> Result<Vec<(i64, f64)>, String> {
     let hits = resp_body
         .get("hits")
         .and_then(|h| h.get("hits"))
@@ -976,14 +977,14 @@ impl Engine for OpenSearchEngine {
 
                         let top = tops[idx];
 
-                        // Timed window: only the network send + wire read of the
-                        // raw response. Body is pre-serialized; response is parsed
-                        // after `elapsed`.
+                        // Timed window: network send + receive + decode of the
+                        // response into a structured value. Body is pre-serialized
+                        // (out); id/score extraction runs after `elapsed` (out).
                         let query_start = Instant::now();
                         let response = knn_send(&rt, &client, &index_name, &raw_bodies[idx]);
                         let query_time = query_start.elapsed().as_secs_f64();
 
-                        match response.and_then(|text| parse_knn_response(&text)) {
+                        match response.and_then(|resp_body| extract_knn_hits(&resp_body)) {
                             Ok(result_ids) => {
                                 let ordered_ids: Vec<i64> =
                                     result_ids.iter().map(|(id, _)| *id).collect();
@@ -1036,6 +1037,29 @@ impl Engine for OpenSearchEngine {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Load-bearing: the hoisted request body is `to_raw_value(&build_knn_body())`.
+    /// Its verbatim bytes (what JsonBody writes on the wire) must equal the bytes
+    /// the old inline `.body(build_knn_body())` path serialized via `to_vec`.
+    #[test]
+    fn build_knn_body_raw_value_roundtrips_to_wire_bytes() {
+        let vec = vec![0.1f32, -0.2, 0.3];
+        let top = 2usize;
+        let filter = json!({"term": {"color": "red"}});
+
+        let body = build_knn_body(&vec, top, Some(&filter));
+        let to_vec_bytes = serde_json::to_vec(&body).unwrap();
+        let raw = serde_json::value::to_raw_value(&body).unwrap();
+        assert_eq!(raw.get().as_bytes(), to_vec_bytes.as_slice());
+
+        // Unfiltered variant.
+        let body_nf = build_knn_body(&vec, top, None);
+        let raw_nf = serde_json::value::to_raw_value(&body_nf).unwrap();
+        assert_eq!(
+            raw_nf.get().as_bytes(),
+            serde_json::to_vec(&body_nf).unwrap().as_slice()
+        );
+    }
 
     #[test]
     fn test_match_any_string_list_emits_terms() {

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -735,21 +735,23 @@ fn hit_id(hit: &serde_json::Value) -> Option<&str> {
         .or_else(|| hit.get("_id").and_then(|v| v.as_str()))
 }
 
-fn knn_search(
+/// Send a pre-serialized KNN search request and return the raw response text.
+/// Only the network send + wire read live here (the caller wraps this in the
+/// timed window). The request body is pre-serialized to a `RawValue` OUTSIDE the
+/// window (the vector-to-JSON ryu formatting is client CPU work, not server
+/// latency — see the search loop) and the response is parsed by
+/// `parse_knn_response` AFTER the window closes, mirroring pgvector/qdrant.
+fn knn_send(
     rt: &tokio::runtime::Runtime,
     client: &OpenSearch,
     index_name: &str,
-    query_vector: &[f32],
-    top: usize,
-    filter: Option<&serde_json::Value>,
-) -> Result<Vec<(i64, f64)>, String> {
-    let body = build_knn_body(query_vector, top, filter);
-
+    raw_body: &serde_json::value::RawValue,
+) -> Result<String, String> {
     let resp = rt
         .block_on(
             client
                 .search(SearchParts::Index(&[index_name]))
-                .body(body)
+                .body(raw_body)
                 .send(),
         )
         .map_err(|e| format!("KNN search failed: {}", e))?;
@@ -759,8 +761,14 @@ fn knn_search(
         return Err(format!("KNN search error: {}", text));
     }
 
-    let resp_body: serde_json::Value = rt
-        .block_on(resp.json())
+    rt.block_on(resp.text())
+        .map_err(|e| format!("Failed to read search response: {}", e))
+}
+
+/// Parse a KNN search response body (done AFTER the timed window — DOM
+/// deserialization is client work, mirroring pgvector/qdrant).
+fn parse_knn_response(text: &str) -> Result<Vec<(i64, f64)>, String> {
+    let resp_body: serde_json::Value = serde_json::from_str(text)
         .map_err(|e| format!("Failed to parse search response: {}", e))?;
 
     let hits = resp_body
@@ -888,6 +896,31 @@ impl Engine for OpenSearchEngine {
             queries.len()
         };
 
+        // Precompute per-query `top` and the fully serialized request bodies
+        // BEFORE the parallel region so the timed window wraps only the RPC
+        // round-trip. `build_knn_body` builds the DOM and `to_raw_value`
+        // performs the vector-to-JSON ryu formatting (client CPU work) once here;
+        // the timed send only copies the already-formatted bytes. `tops[idx]`
+        // reproduces the same k the request embeds, so recall is unchanged.
+        let tops: Vec<usize> = (0..num_to_run)
+            .map(|idx| {
+                explicit_top.unwrap_or_else(|| {
+                    let n = neighbors[idx].len();
+                    if n > 0 {
+                        n
+                    } else {
+                        10
+                    }
+                })
+            })
+            .collect();
+        let raw_bodies: Vec<Box<serde_json::value::RawValue>> = (0..num_to_run)
+            .map(|idx| {
+                let body = build_knn_body(&queries[idx], tops[idx], parsed_filters[idx].as_ref());
+                serde_json::value::to_raw_value(&body).expect("serialize KNN search body")
+            })
+            .collect();
+
         // Per-thread sample buffers merged on join — no per-query Mutex<Vec>
         // contention in the timed loop (see redis.rs::search). Metrics are
         // order-independent so results are unchanged; work counter uses Relaxed.
@@ -910,9 +943,9 @@ impl Engine for OpenSearchEngine {
             for _ in 0..parallel {
                 let base_url = base_url.clone();
                 let index_name = index_name.clone();
-                let queries = &queries;
                 let neighbors = &neighbors;
-                let parsed_filters = &parsed_filters;
+                let tops = &tops;
+                let raw_bodies = &raw_bodies;
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
 
@@ -941,27 +974,16 @@ impl Engine for OpenSearchEngine {
                             break;
                         }
 
-                        let top = explicit_top.unwrap_or_else(|| {
-                            let n = neighbors[idx].len();
-                            if n > 0 {
-                                n
-                            } else {
-                                10
-                            }
-                        });
+                        let top = tops[idx];
 
+                        // Timed window: only the network send + wire read of the
+                        // raw response. Body is pre-serialized; response is parsed
+                        // after `elapsed`.
                         let query_start = Instant::now();
-                        let results = knn_search(
-                            &rt,
-                            &client,
-                            &index_name,
-                            &queries[idx],
-                            top,
-                            parsed_filters[idx].as_ref(),
-                        );
+                        let response = knn_send(&rt, &client, &index_name, &raw_bodies[idx]);
                         let query_time = query_start.elapsed().as_secs_f64();
 
-                        match results {
+                        match response.and_then(|text| parse_knn_response(&text)) {
                             Ok(result_ids) => {
                                 let ordered_ids: Vec<i64> =
                                     result_ids.iter().map(|(id, _)| *id).collect();

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -16,7 +16,7 @@ use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 use uuid::Uuid;
 
 use super::weaviate_grpc::weaviate_v1::{
-    weaviate_client::WeaviateClient, MetadataRequest, NearVector, SearchRequest,
+    weaviate_client::WeaviateClient, MetadataRequest, NearVector, SearchReply, SearchRequest,
 };
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
@@ -620,15 +620,19 @@ fn build_graphql_body(
     serde_json::to_vec(&body).expect("serialize GraphQL search body")
 }
 
-/// Send a pre-serialized GraphQL request and return the raw response text. Only
-/// the network send + wire read live here (the caller wraps this in the timed
-/// window); the response is parsed by `parse_graphql_response` AFTER `elapsed`.
+/// Send a pre-serialized GraphQL request and return the DECODED response. The
+/// consistent timed boundary (see qdrant/pgvector/redis) is: request body
+/// pre-serialized OUTSIDE the window; RPC send + receive + decode-to-structured-
+/// response INSIDE the window (this fn: post + HTTP-status check + wire read +
+/// `from_str`); GraphQL-error check + id/score extraction OUTSIDE
+/// (`extract_graphql_hits`). So the JSON decode is billed as latency exactly
+/// like qdrant's protobuf decode.
 fn send_graphql(
     client: &reqwest::blocking::Client,
     base_url: &str,
     api_key: Option<&str>,
     body: &[u8],
-) -> Result<String, String> {
+) -> Result<serde_json::Value, String> {
     let url = format!("{}/v1/graphql", base_url);
     let mut req = client
         .post(&url)
@@ -651,16 +655,19 @@ fn send_graphql(
         ));
     }
 
-    resp.text()
-        .map_err(|e| format!("Failed to read GraphQL response: {}", e))
+    let text = resp
+        .text()
+        .map_err(|e| format!("Failed to read GraphQL response: {}", e))?;
+    serde_json::from_str(&text).map_err(|e| format!("Failed to parse GraphQL response: {}", e))
 }
 
-/// Parse a GraphQL search response body (done AFTER the timed window — DOM
-/// deserialization is client work, mirroring pgvector/qdrant).
-fn parse_graphql_response(text: &str, class_name: &str) -> Result<Vec<(i64, f64)>, String> {
-    let resp_body: serde_json::Value = serde_json::from_str(text)
-        .map_err(|e| format!("Failed to parse GraphQL response: {}", e))?;
-
+/// Extract the id/score list from an already-decoded GraphQL response (done
+/// AFTER the timed window — the GraphQL-error check and id extraction pull the
+/// final ids out of the decoded struct for recall, mirroring pgvector/qdrant).
+fn extract_graphql_hits(
+    resp_body: &serde_json::Value,
+    class_name: &str,
+) -> Result<Vec<(i64, f64)>, String> {
     // Check for errors
     if let Some(errors) = resp_body.get("errors").and_then(|e| e.as_array()) {
         if !errors.is_empty() {
@@ -693,26 +700,21 @@ fn parse_graphql_response(text: &str, class_name: &str) -> Result<Vec<(i64, f64)
     Ok(hits)
 }
 
-/// Search Weaviate over gRPC (near_vector). Sends the query vector as packed
-/// little-endian f32 bytes (`vector_bytes`) and requests uuid + distance metadata.
-/// This is the high-throughput query path; the class-level `ef` set via the REST
-/// schema update still governs recall. Returns (int-id, distance) pairs, mapping
-/// the object UUID back through `uuid_to_int` (inverse of the upload id_to_uuid).
+/// Build the gRPC `SearchRequest` for one query — packs the query vector as
+/// little-endian f32 bytes (`vector_bytes`) and requests uuid + distance
+/// metadata. This is the request-build step and is hoisted OUTSIDE the timed
+/// window (precomputed before the parallel region, mirroring `graphql_bodies`
+/// and qdrant, which builds its request before `query_start`). The class-level
+/// `ef` set via the REST schema update still governs recall.
 ///
 /// `NearVector::vector_bytes` is marked deprecated in the newer weaviate protos
 /// (superseded by a multi-vector `vectors` field) but remains the accepted
 /// packed-vector input on the 1.29–1.38 servers this targets, so we allow it.
 #[allow(deprecated)]
-async fn near_vector_search_grpc(
-    client: &mut WeaviateClient<tonic::transport::Channel>,
-    class_name: &str,
-    api_key: Option<&str>,
-    query_vector: &[f32],
-    top: usize,
-) -> Result<Vec<(i64, f64)>, String> {
+fn build_grpc_request(class_name: &str, query_vector: &[f32], top: usize) -> SearchRequest {
     let vector_bytes: Vec<u8> = query_vector.iter().flat_map(|f| f.to_le_bytes()).collect();
 
-    let search = SearchRequest {
+    SearchRequest {
         collection: class_name.to_string(),
         limit: top as u32,
         near_vector: Some(NearVector {
@@ -725,8 +727,20 @@ async fn near_vector_search_grpc(
             ..Default::default()
         }),
         ..Default::default()
-    };
+    }
+}
 
+/// Issue a prebuilt gRPC search and return the DECODED reply. The consistent
+/// timed boundary (see qdrant/pgvector/redis) is: request build OUTSIDE the
+/// window (`build_grpc_request`); RPC send + receive + protobuf decode INSIDE
+/// the window (this fn: the awaited `client.search` decodes the reply);
+/// id/distance extraction OUTSIDE (`extract_grpc_hits`). So the protobuf decode
+/// is billed as latency, matching qdrant.
+async fn grpc_search(
+    client: &mut WeaviateClient<tonic::transport::Channel>,
+    search: SearchRequest,
+    api_key: Option<&str>,
+) -> Result<SearchReply, String> {
     let mut request = tonic::Request::new(search);
     if let Some(key) = api_key {
         let val = format!("Bearer {}", key)
@@ -735,15 +749,20 @@ async fn near_vector_search_grpc(
         request.metadata_mut().insert("authorization", val);
     }
 
-    let reply = client
+    Ok(client
         .search(request)
         .await
         .map_err(|e| format!("gRPC search failed: {}", e))?
-        .into_inner();
+        .into_inner())
+}
 
+/// Extract (int-id, distance) pairs from an already-decoded gRPC reply (done
+/// AFTER the timed window), mapping each object UUID back through `uuid_to_int`
+/// (inverse of the upload id_to_uuid), mirroring pgvector/qdrant.
+fn extract_grpc_hits(reply: &SearchReply) -> Result<Vec<(i64, f64)>, String> {
     let mut hits = Vec::with_capacity(reply.results.len());
-    for r in reply.results {
-        if let Some(m) = r.metadata {
+    for r in &reply.results {
+        if let Some(m) = &r.metadata {
             let id = uuid_to_int(&m.id)?;
             hits.push((id, m.distance as f64));
         }
@@ -1170,7 +1189,13 @@ impl Engine for WeaviateEngine {
                     }
                 }
             };
-        let num_filtered = parsed_filters.iter().filter(|f| f.is_some()).count();
+        // Count filters over the executed slice only (`--num-queries` may cap the
+        // run below the full query set), so the ratio printed below is never
+        // impossible.
+        let num_filtered = parsed_filters[..num_to_run]
+            .iter()
+            .filter(|f| f.is_some())
+            .count();
         let use_grpc = grpc_ep.is_some() && num_filtered == 0;
 
         // Measurement-fairness note: the query transport is recorded so a reviewer
@@ -1190,11 +1215,12 @@ impl Engine for WeaviateEngine {
             println!("\tWeaviate search transport: {}", transport);
         }
 
-        // Precompute the fully serialized GraphQL request bodies BEFORE the
-        // parallel region (only needed on the GraphQL path). See build_graphql_body:
-        // the GraphQL-string build + JSON-wrap is the heaviest client step and must
-        // not be billed as server latency. The gRPC path packs the vector to
-        // little-endian bytes inline (the actual wire format, cheap — like qdrant).
+        // Precompute the per-query request payloads BEFORE the parallel region so
+        // the timed window wraps only RPC send + receive + decode (request build is
+        // client CPU work, hoisted like qdrant builds its request before
+        // `query_start`). Only the payloads for the transport actually used are
+        // built. GraphQL: the GraphQL-string build + JSON-wrap (the heaviest client
+        // step). gRPC: the LE-byte vector packing + `SearchRequest`.
         let graphql_bodies: Vec<Vec<u8>> = if use_grpc {
             Vec::new()
         } else {
@@ -1209,11 +1235,18 @@ impl Engine for WeaviateEngine {
                 })
                 .collect()
         };
+        let grpc_requests: Vec<SearchRequest> = if use_grpc {
+            (0..num_to_run)
+                .map(|idx| build_grpc_request(&self.class_name, &queries[idx], tops[idx]))
+                .collect()
+        } else {
+            Vec::new()
+        };
 
-        let queries = Arc::new(queries);
         let neighbors = Arc::new(neighbors);
         let tops = Arc::new(tops);
         let graphql_bodies = Arc::new(graphql_bodies);
+        let grpc_requests = Arc::new(grpc_requests);
 
         let start_time = Instant::now();
 
@@ -1242,9 +1275,8 @@ impl Engine for WeaviateEngine {
                 let mut tasks = Vec::with_capacity(parallel);
                 for _ in 0..parallel {
                     let endpoint = endpoint.clone();
-                    let class_name = self.class_name.clone();
                     let api_key = self.api_key.clone();
-                    let queries = Arc::clone(&queries);
+                    let grpc_requests = Arc::clone(&grpc_requests);
                     let neighbors = Arc::clone(&neighbors);
                     let tops = Arc::clone(&tops);
                     let query_idx = Arc::clone(&query_idx);
@@ -1270,17 +1302,15 @@ impl Engine for WeaviateEngine {
                                 break;
                             }
                             let top = tops[idx];
+                            // Owned request copy for the RPC, cloned OUT of the
+                            // window (memcpy of already-packed bytes, not a rebuild).
+                            let request = grpc_requests[idx].clone();
+                            // Timed window: send + receive + protobuf decode. Request
+                            // build is hoisted (out); id extraction after `elapsed` (out).
                             let query_start = Instant::now();
-                            let results = near_vector_search_grpc(
-                                &mut client,
-                                &class_name,
-                                api_key.as_deref(),
-                                &queries[idx],
-                                top,
-                            )
-                            .await;
+                            let reply = grpc_search(&mut client, request, api_key.as_deref()).await;
                             let query_time = query_start.elapsed().as_secs_f64();
-                            match results {
+                            match reply.and_then(|reply| extract_grpc_hits(&reply)) {
                                 Ok(result_ids) => {
                                     let ordered_ids: Vec<i64> =
                                         result_ids.iter().map(|(id, _)| *id).collect();
@@ -1353,9 +1383,9 @@ impl Engine for WeaviateEngine {
                                 break;
                             }
                             let top = tops[idx];
-                            // Timed window: only the network send + wire read of
-                            // the raw response. Body is pre-serialized; response is
-                            // parsed after `elapsed`.
+                            // Timed window: network send + receive + decode of the
+                            // response into a structured value. Body is pre-serialized
+                            // (out); id/score extraction runs after `elapsed` (out).
                             let query_start = Instant::now();
                             let response = send_graphql(
                                 &client,
@@ -1365,7 +1395,7 @@ impl Engine for WeaviateEngine {
                             );
                             let query_time = query_start.elapsed().as_secs_f64();
                             match response
-                                .and_then(|text| parse_graphql_response(&text, &class_name))
+                                .and_then(|resp_body| extract_graphql_hits(&resp_body, &class_name))
                             {
                                 Ok(result_ids) => {
                                     let ordered_ids: Vec<i64> =
@@ -1418,6 +1448,49 @@ impl Engine for WeaviateEngine {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Load-bearing: the hoisted GraphQL request body bytes must equal what the
+    /// old inline `.json(&{"query": graphql})` path put on the wire, and the
+    /// vector float formatting inside the pinned GraphQL string must not drift.
+    #[test]
+    fn build_graphql_body_bytes_match_json_serialization() {
+        let vec = vec![0.1f32, -0.2, 0.3];
+        let top = 2usize;
+
+        // Reconstruct the exact GraphQL string the old inline path built.
+        let vector_str = "0.1, -0.2, 0.3";
+        let where_clause = String::new();
+        let graphql = format!(
+            r#"{{
+            Get {{
+                {class_name}(
+                    nearVector: {{ vector: [{vector_str}] }},
+                    limit: {top}
+                    {where_clause}
+                ) {{
+                    _additional {{
+                        id
+                        distance
+                    }}
+                }}
+            }}
+        }}"#,
+            class_name = "Bench",
+            vector_str = vector_str,
+            top = top,
+            where_clause = where_clause,
+        );
+        let expected = serde_json::to_vec(&json!({ "query": graphql })).unwrap();
+
+        let body = build_graphql_body("Bench", &vec, top, None);
+        assert_eq!(body, expected);
+
+        // Pin the load-bearing float formatting and structure directly.
+        let decoded: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let q = decoded["query"].as_str().unwrap();
+        assert!(q.contains("vector: [0.1, -0.2, 0.3]"), "q={}", q);
+        assert!(q.contains("limit: 2"), "q={}", q);
+    }
 
     #[test]
     fn graphql_literal_uses_bare_keys_and_enum_operator() {

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -570,16 +570,19 @@ fn upload_batch_objects(
 }
 
 /// Search Weaviate using GraphQL near_vector query.
-fn near_vector_search(
-    client: &reqwest::blocking::Client,
-    base_url: &str,
+/// Build and serialize one GraphQL `nearVector` request body to JSON bytes.
+/// Done OUTSIDE the per-query timed window: this is the heaviest client-side
+/// step for Weaviate — a per-dimension `f32::to_string` + `format!` to assemble
+/// the GraphQL query string, then JSON-wrapping it. That is client CPU work, not
+/// server latency, so pre-building means the timed send only copies the finished
+/// bytes onto the socket (matching pgvector/qdrant). Bytes are identical to what
+/// `.json(&{"query": graphql})` would have sent inline.
+fn build_graphql_body(
     class_name: &str,
-    api_key: Option<&str>,
     query_vector: &[f32],
     top: usize,
     filter: Option<&serde_json::Value>,
-) -> Result<Vec<(i64, f64)>, String> {
-    // Build GraphQL query
+) -> Vec<u8> {
     let vector_str: String = query_vector
         .iter()
         .map(|v| v.to_string())
@@ -613,13 +616,24 @@ fn near_vector_search(
         where_clause = where_clause,
     );
 
-    let body = serde_json::json!({"query": graphql});
+    let body = serde_json::json!({ "query": graphql });
+    serde_json::to_vec(&body).expect("serialize GraphQL search body")
+}
 
+/// Send a pre-serialized GraphQL request and return the raw response text. Only
+/// the network send + wire read live here (the caller wraps this in the timed
+/// window); the response is parsed by `parse_graphql_response` AFTER `elapsed`.
+fn send_graphql(
+    client: &reqwest::blocking::Client,
+    base_url: &str,
+    api_key: Option<&str>,
+    body: &[u8],
+) -> Result<String, String> {
     let url = format!("{}/v1/graphql", base_url);
     let mut req = client
         .post(&url)
         .header("Content-Type", "application/json")
-        .json(&body);
+        .body(body.to_vec());
 
     if let Some(key) = api_key {
         req = req.header("Authorization", format!("Bearer {}", key));
@@ -637,8 +651,14 @@ fn near_vector_search(
         ));
     }
 
-    let resp_body: serde_json::Value = resp
-        .json()
+    resp.text()
+        .map_err(|e| format!("Failed to read GraphQL response: {}", e))
+}
+
+/// Parse a GraphQL search response body (done AFTER the timed window — DOM
+/// deserialization is client work, mirroring pgvector/qdrant).
+fn parse_graphql_response(text: &str, class_name: &str) -> Result<Vec<(i64, f64)>, String> {
+    let resp_body: serde_json::Value = serde_json::from_str(text)
         .map_err(|e| format!("Failed to parse GraphQL response: {}", e))?;
 
     // Check for errors
@@ -1104,6 +1124,22 @@ impl Engine for WeaviateEngine {
             queries.len()
         };
 
+        // Precompute per-query `top` BEFORE the parallel region. `tops[idx]`
+        // reproduces the same k each request embeds, so recall is computed
+        // against an identical result set on both transports.
+        let tops: Vec<usize> = (0..num_to_run)
+            .map(|idx| {
+                explicit_top.unwrap_or_else(|| {
+                    let n = neighbors[idx].len();
+                    if n > 0 {
+                        n
+                    } else {
+                        10
+                    }
+                })
+            })
+            .collect();
+
         // Per-thread sample buffers merged on join — no per-query Mutex<Vec>
         // contention in the timed loop (see redis.rs::search). Metrics are
         // order-independent so results are unchanged; work counter uses Relaxed.
@@ -1134,11 +1170,50 @@ impl Engine for WeaviateEngine {
                     }
                 }
             };
-        let use_grpc = grpc_ep.is_some() && parsed_filters.iter().all(|f| f.is_none());
+        let num_filtered = parsed_filters.iter().filter(|f| f.is_some()).count();
+        let use_grpc = grpc_ep.is_some() && num_filtered == 0;
+
+        // Measurement-fairness note: the query transport is recorded so a reviewer
+        // can see that filtered runs fall back to GraphQL while unfiltered runs use
+        // gRPC — i.e. filtered vs unfiltered Weaviate latencies are NOT measured on
+        // the same wire. gRPC filter translation is a documented follow-up; until
+        // then this log makes the asymmetry explicit rather than silent.
+        let transport = if use_grpc { "grpc" } else { "graphql" };
+        if grpc_ep.is_some() && num_filtered > 0 {
+            println!(
+                "\tWeaviate search transport: graphql (forced — {} of {} queries carry a \
+                 filter and gRPC filter translation is not implemented; unfiltered runs use gRPC, \
+                 so filtered vs unfiltered numbers are on different transports)",
+                num_filtered, num_to_run
+            );
+        } else {
+            println!("\tWeaviate search transport: {}", transport);
+        }
+
+        // Precompute the fully serialized GraphQL request bodies BEFORE the
+        // parallel region (only needed on the GraphQL path). See build_graphql_body:
+        // the GraphQL-string build + JSON-wrap is the heaviest client step and must
+        // not be billed as server latency. The gRPC path packs the vector to
+        // little-endian bytes inline (the actual wire format, cheap — like qdrant).
+        let graphql_bodies: Vec<Vec<u8>> = if use_grpc {
+            Vec::new()
+        } else {
+            (0..num_to_run)
+                .map(|idx| {
+                    build_graphql_body(
+                        &self.class_name,
+                        &queries[idx],
+                        tops[idx],
+                        parsed_filters[idx].as_ref(),
+                    )
+                })
+                .collect()
+        };
 
         let queries = Arc::new(queries);
         let neighbors = Arc::new(neighbors);
-        let parsed_filters = Arc::new(parsed_filters);
+        let tops = Arc::new(tops);
+        let graphql_bodies = Arc::new(graphql_bodies);
 
         let start_time = Instant::now();
 
@@ -1171,6 +1246,7 @@ impl Engine for WeaviateEngine {
                     let api_key = self.api_key.clone();
                     let queries = Arc::clone(&queries);
                     let neighbors = Arc::clone(&neighbors);
+                    let tops = Arc::clone(&tops);
                     let query_idx = Arc::clone(&query_idx);
                     let pb = pb.clone();
                     tasks.push(tokio::spawn(async move {
@@ -1193,14 +1269,7 @@ impl Engine for WeaviateEngine {
                             if idx >= num_to_run {
                                 break;
                             }
-                            let top = explicit_top.unwrap_or_else(|| {
-                                let n = neighbors[idx].len();
-                                if n > 0 {
-                                    n
-                                } else {
-                                    10
-                                }
-                            });
+                            let top = tops[idx];
                             let query_start = Instant::now();
                             let results = near_vector_search_grpc(
                                 &mut client,
@@ -1258,9 +1327,9 @@ impl Engine for WeaviateEngine {
                     let class_name = self.class_name.clone();
                     let api_key = self.api_key.clone();
                     let timeout = self.timeout;
-                    let queries = Arc::clone(&queries);
                     let neighbors = Arc::clone(&neighbors);
-                    let parsed_filters = Arc::clone(&parsed_filters);
+                    let tops = Arc::clone(&tops);
+                    let graphql_bodies = Arc::clone(&graphql_bodies);
                     let query_idx = Arc::clone(&query_idx);
                     let pb = &pb;
 
@@ -1283,26 +1352,21 @@ impl Engine for WeaviateEngine {
                             if idx >= num_to_run {
                                 break;
                             }
-                            let top = explicit_top.unwrap_or_else(|| {
-                                let n = neighbors[idx].len();
-                                if n > 0 {
-                                    n
-                                } else {
-                                    10
-                                }
-                            });
+                            let top = tops[idx];
+                            // Timed window: only the network send + wire read of
+                            // the raw response. Body is pre-serialized; response is
+                            // parsed after `elapsed`.
                             let query_start = Instant::now();
-                            let results = near_vector_search(
+                            let response = send_graphql(
                                 &client,
                                 &base_url,
-                                &class_name,
                                 api_key.as_deref(),
-                                &queries[idx],
-                                top,
-                                parsed_filters[idx].as_ref(),
+                                &graphql_bodies[idx],
                             );
                             let query_time = query_start.elapsed().as_secs_f64();
-                            match results {
+                            match response
+                                .and_then(|text| parse_graphql_response(&text, &class_name))
+                            {
                                 Ok(result_ids) => {
                                     let ordered_ids: Vec<i64> =
                                         result_ids.iter().map(|(id, _)| *id).collect();


### PR DESCRIPTION
## Competitor timed-window boundary (coverage+overhead loop, PR-D2)

Extends the fair timed-window boundary (PR-D1 did the Redis family) to elasticsearch, opensearch, milvus, weaviate. The per-query timed window now wraps the **same semantic operation on every engine**, so cross-engine latency is comparable.

### The consistent boundary (matches redis / qdrant / pgvector)
- **request serialize** (body/DOM build, vector→bytes): **outside** the window (precomputed once before the parallel region).
- **RPC send + receive + decode** (JSON `from_str` / protobuf decode): **inside** the window — because the reference engines decode in-window (qdrant's client returns a decoded protobuf response; pgvector returns decoded rows; redis parses the RESP reply in-window). *(An earlier revision wrongly excluded the JSON decode, which made the HTTP engines look artificially faster — the 7-agent review caught it; corrected here.)*
- **id/score extraction** for recall: **outside** the window.

### Per engine
- **ES/OS**: pre-serialize each request body to `serde_json::RawValue` before the loop; `knn_send` sends + reads + decodes to `Value`; `extract_knn_hits` pulls ids after `elapsed`.
- **milvus**: `build_search_body → Vec<u8>` hoisted; `send_search` sends+decodes; `extract_search_hits` (app-level `code` check + ids) after.
- **weaviate**: GraphQL body hoisted; **and** the default gRPC `SearchRequest` (LE-byte packing) now precomputed too (was built in-window — the "like qdrant" claim was wrong); decode stays in-window, extraction after.

### Fairness disclosure + honesty
- Weaviate records the **transport used** (`grpc` vs `graphql`) in a log line, with a warning that a filter forces the slower GraphQL path — so filtered-vs-unfiltered numbers are not silently compared across transports. (Full gRPC-filter support is a documented follow-up.)

### Correctness (measurement-only; results identical)
- **4 new byte-identity unit tests** pin each hoisted request body == `serde_json::to_vec(&body)` (the load-bearing property).
- 7-agent review verified: no byte mismatch, correct `idx` mapping, error paths preserved.
- Live through `search()`: ES/OS/milvus + weaviate **both** transports (gRPC and `WEAVIATE_USE_GRAPHQL=1`) → recall/precision 1.0, transport logged.

### Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean; 211 unit tests
- Cargo.toml: enabled serde_json `raw_value` feature (additive, no new deps, lockfile unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)