### PR TITLE
perf(mongodb): consistent timed-window boundary + overhead-invariant guard tests

### DIFF
--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -846,15 +846,23 @@ fn filter_only_find(
     Ok(count)
 }
 
-/// Execute a vector search using $vectorSearch aggregation pipeline.
-fn vector_search(
-    coll: &mongodb::sync::Collection<Document>,
+/// Build the `$vectorSearch` aggregation pipeline for one query.
+///
+/// Done OUTSIDE the per-query timed window (see the search() precompute): turning
+/// the query vector into a full `Vec<Bson::Double>` and assembling the two
+/// pipeline docs (`$vectorSearch` + `$project`) is client-side CPU work, not
+/// server latency. Precomputing it means the timed window wraps only the
+/// aggregate RPC round-trip + cursor decode, matching the reference engines
+/// (pgvector/qdrant/redis) and the ES/OS/Milvus/Weaviate boundary from #113.
+///
+/// The returned pipeline is identical to what the previous inline build produced.
+fn build_search_pipeline(
     index_name: &str,
     query_vector: &[f32],
     top: usize,
     num_candidates: i64,
     filter: Option<&Document>,
-) -> Result<Vec<(i64, f64)>, String> {
+) -> Vec<Document> {
     let bson_vec: Vec<mongodb::bson::Bson> = query_vector
         .iter()
         .map(|&f| mongodb::bson::Bson::Double(f as f64))
@@ -872,7 +880,7 @@ fn vector_search(
         vs_stage.insert("filter", f.clone());
     }
 
-    let pipeline = vec![
+    vec![
         doc! { "$vectorSearch": vs_stage },
         doc! {
             "$project": {
@@ -880,22 +888,66 @@ fn vector_search(
                 "score": { "$meta": "vectorSearchScore" },
             }
         },
-    ];
+    ]
+}
 
+/// Send a precomputed aggregation pipeline and return the DECODED documents.
+///
+/// The consistent timed boundary (see qdrant/pgvector/redis and #113) is:
+/// pipeline built OUTSIDE the window; aggregate RPC send + cursor read +
+/// decode-to-`Document` INSIDE the window (this fn); id/score extraction OUTSIDE
+/// (`extract_search_hits`). So the BSON cursor decode is billed as latency
+/// exactly like qdrant's protobuf decode and pgvector's row decode.
+fn send_search(
+    coll: &mongodb::sync::Collection<Document>,
+    pipeline: &[Document],
+) -> Result<Vec<Document>, String> {
     let cursor = coll
-        .aggregate(pipeline)
+        .aggregate(pipeline.to_vec())
         .run()
         .map_err(|e| format!("Vector search failed: {}", e))?;
 
-    let mut results = Vec::with_capacity(top);
+    let mut docs = Vec::new();
     for result in cursor {
         let doc = result.map_err(|e| format!("Failed to read result: {}", e))?;
-        let id = doc.get_i64("_id").unwrap_or(0);
-        let score = doc.get_f64("score").unwrap_or(0.0);
-        results.push((id, score));
+        docs.push(doc);
     }
+    Ok(docs)
+}
 
-    Ok(results)
+/// Extract the id/score list from already-decoded documents.
+///
+/// Done AFTER the timed window (`elapsed`), mirroring pgvector/qdrant pulling the
+/// final ids out of the decoded response for recall. This is pure struct field
+/// access — no I/O — so it must not be billed as query latency.
+fn extract_search_hits(docs: &[Document]) -> Vec<(i64, f64)> {
+    docs.iter()
+        .map(|doc| {
+            let id = doc.get_i64("_id").unwrap_or(0);
+            let score = doc.get_f64("score").unwrap_or(0.0);
+            (id, score)
+        })
+        .collect()
+}
+
+/// Execute a vector search end-to-end (build + send + extract).
+///
+/// Convenience wrapper used by the untimed index-catchup probe
+/// (`wait_for_index_catchup`), where the split boundary is irrelevant. The timed
+/// search()/search_mixed() paths deliberately do NOT use this: they precompute
+/// pipelines out of the window and call `send_search`/`extract_search_hits`
+/// directly so only the RPC + decode is timed.
+fn vector_search(
+    coll: &mongodb::sync::Collection<Document>,
+    index_name: &str,
+    query_vector: &[f32],
+    top: usize,
+    num_candidates: i64,
+    filter: Option<&Document>,
+) -> Result<Vec<(i64, f64)>, String> {
+    let pipeline = build_search_pipeline(index_name, query_vector, top, num_candidates, filter);
+    let docs = send_search(coll, &pipeline)?;
+    Ok(extract_search_hits(&docs))
 }
 
 /// Parse filter conditions into MongoDB query document.
@@ -1177,6 +1229,36 @@ impl Engine for MongoDBEngine {
             queries.len()
         };
 
+        // Precompute per-query `top` and the fully built `$vectorSearch`
+        // aggregation pipelines BEFORE the parallel region so the timed window
+        // wraps only the aggregate RPC round-trip + cursor decode (see
+        // build_search_pipeline / send_search). `tops[idx]` reproduces the same k
+        // the pipeline embeds, so recall is computed against an identical result
+        // set — this is measurement-only, unchanged recall/precision.
+        let tops: Vec<usize> = (0..num_to_run)
+            .map(|idx| {
+                explicit_top.unwrap_or_else(|| {
+                    let n = neighbors[idx].len();
+                    if n > 0 {
+                        n
+                    } else {
+                        10
+                    }
+                })
+            })
+            .collect();
+        let pipelines: Vec<Vec<Document>> = (0..num_to_run)
+            .map(|idx| {
+                build_search_pipeline(
+                    &self.index_name,
+                    &queries[idx],
+                    tops[idx],
+                    (tops[idx] as i64) * num_candidates_factor,
+                    parsed_filters[idx].as_ref(),
+                )
+            })
+            .collect();
+
         // Per-thread sample buffers merged on join — no per-query Mutex<Vec>
         // contention in the timed loop (see redis.rs::search). Metrics are
         // order-independent so results are unchanged; work counter uses Relaxed.
@@ -1188,7 +1270,6 @@ impl Engine for MongoDBEngine {
         let uri = self.uri.clone();
         let db_name = self.db_name.clone();
         let collection_name = self.collection_name.clone();
-        let index_name = self.index_name.clone();
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -1202,10 +1283,9 @@ impl Engine for MongoDBEngine {
                 let uri = uri.clone();
                 let db_name = db_name.clone();
                 let collection_name = collection_name.clone();
-                let index_name = index_name.clone();
-                let queries = &queries;
                 let neighbors = &neighbors;
-                let parsed_filters = &parsed_filters;
+                let tops = &tops;
+                let pipelines = &pipelines;
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
 
@@ -1231,30 +1311,18 @@ impl Engine for MongoDBEngine {
                             break;
                         }
 
-                        let top = explicit_top.unwrap_or_else(|| {
-                            let n = neighbors[idx].len();
-                            if n > 0 {
-                                n
-                            } else {
-                                10
-                            }
-                        });
+                        let top = tops[idx];
 
-                        let num_candidates = (top as i64) * num_candidates_factor;
-
+                        // Timed window: aggregate RPC send + cursor read + decode
+                        // to Documents. Pipeline is prebuilt (out); id/score
+                        // extraction runs after `elapsed` (out).
                         let query_start = Instant::now();
-                        let results = vector_search(
-                            &coll,
-                            &index_name,
-                            &queries[idx],
-                            top,
-                            num_candidates,
-                            parsed_filters[idx].as_ref(),
-                        );
+                        let response = send_search(&coll, &pipelines[idx]);
                         let query_time = query_start.elapsed().as_secs_f64();
 
-                        match results {
-                            Ok(result_ids) => {
+                        match response {
+                            Ok(docs) => {
+                                let result_ids = extract_search_hits(&docs);
                                 let ordered_ids: Vec<i64> =
                                     result_ids.iter().map(|(id, _)| *id).collect();
                                 let m = crate::metrics::compute_metrics(
@@ -1347,6 +1415,34 @@ impl Engine for MongoDBEngine {
             queries.len()
         };
 
+        // Precompute per-query `top` and `$vectorSearch` pipelines BEFORE the
+        // parallel region so the timed search window wraps only the aggregate RPC
+        // + cursor decode (matching the main search() path). Measurement-only:
+        // recall/precision unchanged.
+        let tops: Vec<usize> = (0..num_to_run)
+            .map(|idx| {
+                explicit_top.unwrap_or_else(|| {
+                    let n = neighbors[idx].len();
+                    if n > 0 {
+                        n
+                    } else {
+                        10
+                    }
+                })
+            })
+            .collect();
+        let pipelines: Vec<Vec<Document>> = (0..num_to_run)
+            .map(|idx| {
+                build_search_pipeline(
+                    &self.index_name,
+                    &queries[idx],
+                    tops[idx],
+                    (tops[idx] as i64) * num_candidates_factor,
+                    parsed_filters[idx].as_ref(),
+                )
+            })
+            .collect();
+
         let search_idx = Arc::new(AtomicUsize::new(0));
         let update_idx = Arc::new(AtomicUsize::new(0));
 
@@ -1360,7 +1456,6 @@ impl Engine for MongoDBEngine {
         let uri = self.uri.clone();
         let db_name = self.db_name.clone();
         let collection_name = self.collection_name.clone();
-        let index_name = self.index_name.clone();
         let schema_types = &self.schema_types;
 
         // Each worker accumulates search + update samples into thread-local
@@ -1382,10 +1477,9 @@ impl Engine for MongoDBEngine {
                 let uri = uri.clone();
                 let db_name = db_name.clone();
                 let collection_name = collection_name.clone();
-                let index_name = index_name.clone();
-                let queries = &queries;
                 let neighbors = &neighbors;
-                let parsed_filters = &parsed_filters;
+                let tops = &tops;
+                let pipelines = &pipelines;
                 let upd_ids = &upd_ids;
                 let upd_vectors = &upd_vectors;
                 let upd_metadata = &upd_metadata;
@@ -1420,30 +1514,17 @@ impl Engine for MongoDBEngine {
                                 break 'outer;
                             }
 
-                            let top = explicit_top.unwrap_or_else(|| {
-                                let n = neighbors[idx].len();
-                                if n > 0 {
-                                    n
-                                } else {
-                                    10
-                                }
-                            });
+                            let top = tops[idx];
 
-                            let num_candidates = (top as i64) * num_candidates_factor;
-
+                            // Timed window: aggregate RPC + cursor decode only.
+                            // Pipeline prebuilt (out); id extraction after elapsed.
                             let query_start = Instant::now();
-                            let results = vector_search(
-                                &coll,
-                                &index_name,
-                                &queries[idx],
-                                top,
-                                num_candidates,
-                                parsed_filters[idx].as_ref(),
-                            );
+                            let response = send_search(&coll, &pipelines[idx]);
                             let query_time = query_start.elapsed().as_secs_f64();
 
-                            match results {
-                                Ok(result_ids) => {
+                            match response {
+                                Ok(docs) => {
+                                    let result_ids = extract_search_hits(&docs);
                                     let ordered_ids: Vec<i64> =
                                         result_ids.iter().map(|(id, _)| *id).collect();
                                     let m = crate::metrics::compute_metrics(
@@ -1556,6 +1637,70 @@ impl Engine for MongoDBEngine {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // Load-bearing: the hoisted (out-of-timed-window) pipeline builder must
+    // produce a pipeline byte-identical to the one the previous inline build
+    // embedded in the aggregate request. If this drifts, the timed window would
+    // send a different request than the recall computation assumes.
+    #[test]
+    fn build_search_pipeline_matches_inline_build() {
+        let query: Vec<f32> = vec![0.1, -0.2, 0.3];
+        let top = 2usize;
+        let num_candidates = 20i64;
+        let filter = doc! { "color": { "$in": ["red", "blue"] } };
+
+        // Reconstruct the exact vector-to-BSON conversion + doc order the old
+        // inline path used (f32 -> f64 Double, insertion order preserved).
+        let bson_vec: Vec<mongodb::bson::Bson> = query
+            .iter()
+            .map(|&f| mongodb::bson::Bson::Double(f as f64))
+            .collect();
+        let expected = vec![
+            doc! { "$vectorSearch": {
+                "index": "vidx",
+                "path": "vector",
+                "queryVector": bson_vec.clone(),
+                "numCandidates": num_candidates,
+                "limit": top as i64,
+                "filter": filter.clone(),
+            } },
+            doc! { "$project": {
+                "_id": 1,
+                "score": { "$meta": "vectorSearchScore" },
+            } },
+        ];
+
+        let got = build_search_pipeline("vidx", &query, top, num_candidates, Some(&filter));
+        assert_eq!(got, expected, "filtered pipeline must be byte-identical");
+
+        // Unfiltered variant: no `filter` key at all (not an empty/null filter).
+        let expected_nf = vec![
+            doc! { "$vectorSearch": {
+                "index": "vidx",
+                "path": "vector",
+                "queryVector": bson_vec,
+                "numCandidates": num_candidates,
+                "limit": top as i64,
+            } },
+            doc! { "$project": {
+                "_id": 1,
+                "score": { "$meta": "vectorSearchScore" },
+            } },
+        ];
+        let got_nf = build_search_pipeline("vidx", &query, top, num_candidates, None);
+        assert_eq!(got_nf, expected_nf, "unfiltered pipeline must omit filter");
+    }
+
+    // extract_search_hits pulls (id, score) pairs out of decoded docs, in order.
+    #[test]
+    fn extract_search_hits_reads_id_and_score() {
+        let docs = vec![
+            doc! { "_id": 7i64, "score": 0.9f64 },
+            doc! { "_id": 3i64, "score": 0.5f64 },
+        ];
+        let hits = extract_search_hits(&docs);
+        assert_eq!(hits, vec![(7i64, 0.9f64), (3i64, 0.5f64)]);
+    }
 
     // A single AND clause is returned unwrapped: {"color": {"$in": [...]}}.
     #[test]

--- a/tests/overhead_invariants.rs
+++ b/tests/overhead_invariants.rs
@@ -1,0 +1,183 @@
+//! Overhead-invariant guard tests (regression tripwire).
+//!
+//! These are pure source-scanning tests: they read the engine `.rs` files as
+//! TEXT and assert that the measurement-overhead fixes from PRs #108 / #110 /
+//! #111 / #113 stay in place. They do NOT need a database — they run in the
+//! normal `cargo test` set and fail CI the moment someone reintroduces one of
+//! the anti-patterns those PRs removed.
+//!
+//! Two invariants are locked in:
+//!
+//!   INV-2  No per-query cross-thread `Mutex<Vec>` push inside a timed worker
+//!          loop. Every per-query latency/quality sample must land in a
+//!          thread-local buffer that is merged on join — NOT pushed through a
+//!          single `Arc<Mutex<Vec<f64>>>` that serializes workers at high
+//!          parallelism. (#108 for the Redis-family filter-only/mixed paths,
+//!          #110 for turbopuffer.)
+//!
+//!   INV-3  One stats path. Every search / filter-only / mixed path computes
+//!          its latency percentiles through the shared `compute_search_stats`
+//!          (linear-interpolation) helper, NOT a hand-rolled nearest-rank
+//!          `(len as f64 * q) as usize` index — the biased method that made
+//!          `p99 == max` for `N <= 100`. (#108.)
+//!
+//! Keep the assertions on DISTINCTIVE substrings that will not false-positive on
+//! unrelated code (e.g. the legitimate `errors.lock().unwrap().push(e)` in the
+//! UPLOAD paths must stay allowed). The percentile-parity behaviour itself is
+//! covered by the unit test `engine::tests::filter_mixed_stats_use_linear_percentiles`
+//! (p99 == 99.01 on 1..=100); this file guards the SOURCE shape that keeps that
+//! true across all engines.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Engine source files that own a timed per-query worker loop whose sample
+/// buffers were converted from `Arc<Mutex<Vec>>` to thread-local (#108/#110/#111)
+/// and whose percentiles route through `compute_search_stats` (#108).
+const ENGINE_FILES: &[&str] = &[
+    "redis.rs",
+    "valkey.rs",
+    "vectorsets.rs",
+    "mongodb_engine.rs",
+    "turbopuffer.rs",
+];
+
+fn engine_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/bin/vector_db_benchmark/engine")
+}
+
+fn read_engine(file: &str) -> String {
+    let path = engine_dir().join(file);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {}", path.display(), e))
+}
+
+/// INV-2 — no per-query metric buffer is pushed through a cross-thread mutex in
+/// a timed loop. We ban the EXACT sample-buffer lock-push idioms that #108/#110
+/// removed. Each pattern below named a per-query metric buffer
+/// (`search_times`/`precisions`/`recalls`/`mrrs`/`ndcgs`/`update_times`) that
+/// used to be an `Arc<Mutex<Vec<f64>>>`; if any reappears, a timed worker loop
+/// is once again serializing on a shared lock per query.
+///
+/// NOTE: this deliberately does NOT ban `.lock().unwrap().push(` in general —
+/// the upload/error paths legitimately collect errors under a mutex
+/// (`errors.lock().unwrap().push(e)`), which is off the timed hot path.
+#[test]
+fn inv2_no_per_query_mutex_push_in_timed_loops() {
+    // (banned substring, what it used to guard)
+    let banned: &[(&str, &str)] = &[
+        (
+            "search_times.lock().unwrap().push",
+            "per-query search latency pushed through a shared Mutex<Vec> (was #108 FIX1)",
+        ),
+        (
+            "update_times.lock().unwrap().push",
+            "per-op update latency pushed through a shared Mutex<Vec> (mixed path, #108 FIX1)",
+        ),
+        (
+            "precisions.lock().unwrap().push",
+            "per-query precision pushed through a shared Mutex<Vec> (mixed path, #108 FIX1)",
+        ),
+        (
+            "recalls.lock().unwrap().push",
+            "per-query recall pushed through a shared Mutex<Vec> (mixed path, #108 FIX1)",
+        ),
+        (
+            "mrrs.lock().unwrap().push",
+            "per-query MRR pushed through a shared Mutex<Vec> (mixed path, #108 FIX1)",
+        ),
+        (
+            "ndcgs.lock().unwrap().push",
+            "per-query NDCG pushed through a shared Mutex<Vec> (mixed path, #108 FIX1)",
+        ),
+        (
+            "times.lock().unwrap().push",
+            "per-query latency pushed through a shared Mutex<Vec> in a timed loop",
+        ),
+    ];
+
+    let mut violations = Vec::new();
+    for &file in ENGINE_FILES {
+        let src = read_engine(file);
+        for &(pat, why) in banned {
+            let count = src.matches(pat).count();
+            if count != 0 {
+                violations.push(format!(
+                    "  {} contains `{}` ({}x) — {}",
+                    file, pat, count, why
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "INV-2 VIOLATED: a per-query metric buffer is pushed through a cross-thread \
+         Mutex<Vec> inside a timed worker loop. Accumulate into a THREAD-LOCAL Vec \
+         and merge on join instead (see redis.rs::search). Offenders:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// INV-3a — every timed engine still routes its stats through the single shared
+/// `compute_search_stats` helper. If an engine stops referencing it, it has
+/// almost certainly grown a private (likely nearest-rank) percentile path again.
+#[test]
+fn inv3_all_engines_use_shared_compute_search_stats() {
+    let mut missing = Vec::new();
+    for &file in ENGINE_FILES {
+        let src = read_engine(file);
+        if !src.contains("compute_search_stats") {
+            missing.push(file);
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "INV-3 VIOLATED: these engines no longer reference `compute_search_stats`, so \
+         their search/filter-only/mixed stats are no longer on the shared \
+         linear-percentile footing: {:?}",
+        missing
+    );
+}
+
+/// INV-3b — the hand-rolled nearest-rank percentile idiom `(len as f64 * q) as
+/// usize` (which made `p99 == max` for `N <= 100`) must not reappear in any
+/// engine file. The three multiplier substrings below are distinctive of that
+/// specific indexing pattern and do not occur in correct code (which calls
+/// `percentile_linear` / `compute_search_stats`).
+#[test]
+fn inv3_no_nearest_rank_percentile_indexing() {
+    let banned: &[&str] = &[
+        "as f64 * 0.50) as usize",
+        "as f64 * 0.95) as usize",
+        "as f64 * 0.99) as usize",
+    ];
+
+    let mut violations = Vec::new();
+    // Scan every engine source, not just the five — the biased idiom is wrong
+    // anywhere it appears.
+    for entry in fs::read_dir(engine_dir()).expect("read engine dir") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let src = fs::read_to_string(&path).expect("read engine source");
+        for &pat in banned {
+            if src.contains(pat) {
+                violations.push(format!(
+                    "  {} contains `{}`",
+                    path.file_name().unwrap().to_string_lossy(),
+                    pat
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "INV-3 VIOLATED: a hand-rolled nearest-rank percentile index reappeared \
+         (`(len as f64 * q) as usize`). This biases p99 upward and makes p99 == max \
+         for N <= 100 — route through `percentile_linear` / `compute_search_stats` \
+         instead. Offenders:\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
## MongoDB timed-window + overhead invariant guards (coverage+overhead loop, PR-H)

Completes the timed-window boundary work (mongodb was the last engine) and adds regression tripwires that lock in the overhead fixes from #108/#111/#113.

### MongoDB timed-window
Split `vector_search` into `build_search_pipeline` (out of window) / `send_search` (RPC + cursor decode, in window) / `extract_search_hits` (ids/scores, after `elapsed`) — the same consistent boundary as #113 (request-serialize out, RPC+decode in, id-extract out). Both `search()` and `search_mixed()` precompute pipelines before the parallel region. The `wait_for_index_catchup` readiness poll from #112 is untouched (it uses `vector_search` as an untimed composer). Measurement-only — recall/precision identical (mongodb live 11/11, recall 1.0). Byte-identity unit test on the pipeline.

### Overhead-invariant guard tests (`tests/overhead_invariants.rs`)
Source-scanning tripwires so a future edit can't silently reintroduce the overhead:
- **INV-2**: the per-query metric-buffer `.lock().unwrap().push` idioms removed in #108/#110 appear 0× in redis/valkey/vectorsets/mongodb/turbopuffer timed loops (the legitimate upload-path `errors.lock()` is allowed).
- **INV-3a**: every Redis-family + mongodb + turbopuffer path references the shared `compute_search_stats`.
- **INV-3b**: the biased nearest-rank percentile idiom `(len as f64 * q) as usize` appears 0× anywhere.

**Teeth proven**: reintroducing a `search_times.lock().unwrap().push` in redis.rs turns `inv2_no_per_query_mutex_push_in_timed_loops` red; reverting restores green. (Percentile parity — p99==99.01 on 1..=100 — is already unit-tested from #108.)

### Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean
- 213 unit tests + 3 guard tests; mongodb integration 11/11 recall unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)