### PR TITLE
test: filter-builder breadth coverage (OR/range/geo/distance/exact) + fix vectorsets null-bound bug

### DIFF
--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -152,16 +152,9 @@ impl ElasticsearchEngine {
             ));
         }
 
-        let similarity = match dist_lower.as_str() {
-            "l2" | "euclidean" => "l2_norm",
-            "cosine" | "angular" => "cosine",
-            other => {
-                return Err(format!(
-                    "Unsupported distance metric for Elasticsearch: {}",
-                    other
-                ))
-            }
-        };
+        // dot/ip already rejected above; es_similarity is only reached for the
+        // supported/unknown arms here (its dot arm exists for direct unit-testing).
+        let similarity = es_similarity(&dist_lower)?;
 
         let mut properties = serde_json::json!({
             "vector": {
@@ -431,6 +424,24 @@ fn id_to_uuid_hex(id: i64) -> String {
 fn uuid_hex_to_int(hex: &str) -> Result<i64, String> {
     let uuid = Uuid::parse_str(hex).map_err(|e| format!("Invalid UUID hex '{}': {}", hex, e))?;
     Ok(uuid.as_u128() as i64)
+}
+
+/// Map a dataset distance name to the Elasticsearch `dense_vector` similarity.
+/// `dot`/`ip` is unsupported (ES has no raw dot-product similarity) and unknown
+/// metrics error. A wrong arm here would silently change ranking, so every arm
+/// is unit-tested.
+fn es_similarity(distance: &str) -> Result<&'static str, String> {
+    match distance.to_lowercase().as_str() {
+        "l2" | "euclidean" => Ok("l2_norm"),
+        "cosine" | "angular" => Ok("cosine"),
+        "dot" | "ip" => {
+            Err("Elasticsearch does not support DOT product distance for benchmarking".to_string())
+        }
+        other => Err(format!(
+            "Unsupported distance metric for Elasticsearch: {}",
+            other
+        )),
+    }
 }
 
 // ── Elasticsearch condition parser ─────────────────────────────────────
@@ -1199,5 +1210,128 @@ mod tests {
         assert!(parse_es_conditions(&serde_json::json!({})).is_none());
         // Present-but-empty sub-arrays should not produce a filter either.
         assert!(parse_es_conditions(&serde_json::json!({"and": [], "or": []})).is_none());
+    }
+
+    // ── Range operators ────────────────────────────────────────────────────
+
+    #[test]
+    fn range_lt_lte_gt_gte_map_to_es_range() {
+        assert_eq!(
+            build_filter("n", "range", &serde_json::json!({"lt":5})).unwrap(),
+            serde_json::json!({"range":{"n":{"lt":5}}})
+        );
+        assert_eq!(
+            build_filter("n", "range", &serde_json::json!({"lte":5})).unwrap(),
+            serde_json::json!({"range":{"n":{"lte":5}}})
+        );
+        assert_eq!(
+            build_filter("n", "range", &serde_json::json!({"gt":5})).unwrap(),
+            serde_json::json!({"range":{"n":{"gt":5}}})
+        );
+        assert_eq!(
+            build_filter("n", "range", &serde_json::json!({"gte":5})).unwrap(),
+            serde_json::json!({"range":{"n":{"gte":5}}})
+        );
+    }
+
+    #[test]
+    fn range_two_sided_keeps_both_bounds() {
+        assert_eq!(
+            build_filter("n", "range", &serde_json::json!({"gte":10,"lt":20})).unwrap(),
+            serde_json::json!({"range":{"n":{"gte":10,"lt":20}}})
+        );
+    }
+
+    #[test]
+    fn range_unknown_op_yields_empty_range_object() {
+        assert_eq!(
+            build_filter("n", "range", &serde_json::json!({"foo":5})).unwrap(),
+            serde_json::json!({"range":{"n":{}}})
+        );
+    }
+
+    #[test]
+    fn range_null_bound_is_skipped() {
+        assert_eq!(
+            build_filter(
+                "n",
+                "range",
+                &serde_json::json!({"gte":serde_json::Value::Null})
+            )
+            .unwrap(),
+            serde_json::json!({"range":{"n":{}}})
+        );
+    }
+
+    // ── Geo filter ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn geo_with_radius_emits_geo_distance() {
+        assert_eq!(
+            build_filter(
+                "loc",
+                "geo",
+                &serde_json::json!({"lat":20.0,"lon":10.0,"radius":500})
+            )
+            .unwrap(),
+            serde_json::json!({"geo_distance":{"distance":"500m","loc":{"lat":20.0,"lon":10.0}}})
+        );
+    }
+
+    #[test]
+    fn geo_without_radius_uses_default_1000m() {
+        assert_eq!(
+            build_filter("loc", "geo", &serde_json::json!({"lat":20.0,"lon":10.0})).unwrap(),
+            serde_json::json!({"geo_distance":{"distance":"1000m","loc":{"lat":20.0,"lon":10.0}}})
+        );
+    }
+
+    #[test]
+    fn geo_missing_lat_or_lon_is_none() {
+        assert!(build_filter("loc", "geo", &serde_json::json!({"lon":10.0,"radius":5})).is_none());
+        assert!(build_filter("loc", "geo", &serde_json::json!({"lat":20.0,"radius":5})).is_none());
+    }
+
+    // ── Distance-metric mapping ────────────────────────────────────────────
+
+    #[test]
+    fn es_similarity_covers_all_arms() {
+        assert_eq!(es_similarity("l2").unwrap(), "l2_norm");
+        assert_eq!(es_similarity("euclidean").unwrap(), "l2_norm");
+        assert_eq!(es_similarity("cosine").unwrap(), "cosine");
+        assert_eq!(es_similarity("angular").unwrap(), "cosine");
+        assert_eq!(es_similarity("COSINE").unwrap(), "cosine");
+        // dot/ip unsupported by ES; unknown errors too.
+        assert!(es_similarity("dot").is_err());
+        assert!(es_similarity("ip").is_err());
+        assert!(es_similarity("nope").is_err());
+    }
+
+    // ── Exact-match numeric / bool / non-scalar arms ───────────────────────
+
+    #[test]
+    fn exact_match_int_float_bool_pass_through_match() {
+        assert_eq!(
+            build_filter("n", "match", &serde_json::json!({"value":5})).unwrap(),
+            serde_json::json!({"match":{"n":5}})
+        );
+        assert_eq!(
+            build_filter("n", "match", &serde_json::json!({"value":1.5})).unwrap(),
+            serde_json::json!({"match":{"n":1.5}})
+        );
+        assert_eq!(
+            build_filter("flag", "match", &serde_json::json!({"value":true})).unwrap(),
+            serde_json::json!({"match":{"flag":true}})
+        );
+    }
+
+    #[test]
+    fn exact_match_array_value_passes_through_unguarded() {
+        // ES build_filter has no scalar guard: a non-scalar value is forwarded as
+        // the match value (documents behavior; differs from qdrant's None).
+        assert_eq!(
+            build_filter("n", "match", &serde_json::json!({"value":[1,2]})).unwrap(),
+            serde_json::json!({"match":{"n":[1,2]}})
+        );
     }
 }

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -585,6 +585,19 @@ fn extract_search_hits(resp_body: &serde_json::Value) -> Result<Vec<(i64, f64)>,
 }
 
 /// Parse conditions into Milvus filter expression.
+/// Map a dataset distance name to the Milvus `metric_type`. Cosine deliberately
+/// maps to `IP` (Milvus scores cosine via inner-product over normalized vectors).
+/// Unknown metrics error. A wrong arm here would silently change ranking, so
+/// every arm is unit-tested.
+fn map_milvus_metric_type(distance: &str) -> Result<&'static str, String> {
+    match distance.to_lowercase().as_str() {
+        "l2" | "euclidean" => Ok("L2"),
+        "dot" | "ip" => Ok("IP"),
+        "cosine" | "angular" => Ok("IP"), // Milvus uses IP for cosine (normalized vectors)
+        other => Err(format!("Unsupported distance metric for Milvus: {}", other)),
+    }
+}
+
 /// Milvus uses string-based filter expressions like "field == value && field > 10"
 fn parse_milvus_conditions(conditions: &serde_json::Value) -> Option<String> {
     let obj = conditions.as_object()?;
@@ -758,12 +771,7 @@ impl Engine for MilvusEngine {
         let dist_lower = distance.to_lowercase();
 
         // Map distance metric
-        self.metric_type = match dist_lower.as_str() {
-            "l2" | "euclidean" => "L2".to_string(),
-            "dot" | "ip" => "IP".to_string(),
-            "cosine" | "angular" => "IP".to_string(), // Milvus uses IP for cosine (normalized vectors)
-            other => return Err(format!("Unsupported distance metric for Milvus: {}", other)),
-        };
+        self.metric_type = map_milvus_metric_type(&dist_lower)?.to_string();
 
         let client = self.create_client()?;
 
@@ -1105,5 +1113,117 @@ mod tests {
         let e = json!({"and": [{"color": {"match": {"any": [r#"a"b\c"#]}}}]});
         let expr = parse_milvus_conditions(&e).unwrap();
         assert_eq!(expr, r#"(color in ["a\"b\\c"])"#, "expr={}", expr);
+    }
+
+    // ── OR-branch of the condition parser ──────────────────────────────────
+
+    #[test]
+    fn or_only_emits_double_pipe_group() {
+        let cond = json!({"or":[
+            {"a":{"match":{"value":"x"}}},
+            {"b":{"match":{"value":"y"}}},
+        ]});
+        assert_eq!(
+            parse_milvus_conditions(&cond).unwrap(),
+            r#"(a == "x" || b == "y")"#
+        );
+    }
+
+    #[test]
+    fn and_plus_or_keeps_both_groups() {
+        let cond = json!({
+            "and":[{"a":{"match":{"value":"x"}}}],
+            "or":[{"b":{"match":{"value":"y"}}}],
+        });
+        assert_eq!(
+            parse_milvus_conditions(&cond).unwrap(),
+            r#"(a == "x") && (b == "y")"#
+        );
+    }
+
+    // ── Range operators ────────────────────────────────────────────────────
+
+    fn range_expr(criteria: serde_json::Value) -> Option<String> {
+        build_milvus_filter("age", "range", &criteria)
+    }
+
+    #[test]
+    fn range_lt_lte_gt_gte() {
+        assert_eq!(range_expr(json!({"lt":5})).unwrap(), "(age < 5)");
+        assert_eq!(range_expr(json!({"lte":5})).unwrap(), "(age <= 5)");
+        assert_eq!(range_expr(json!({"gt":5})).unwrap(), "(age > 5)");
+        assert_eq!(range_expr(json!({"gte":5})).unwrap(), "(age >= 5)");
+    }
+
+    #[test]
+    fn range_two_sided_gte_lt() {
+        // Fixed order lt, gt, lte, gte joined by &&.
+        assert_eq!(
+            range_expr(json!({"gte":10,"lt":20})).unwrap(),
+            "(age < 20 && age >= 10)"
+        );
+    }
+
+    #[test]
+    fn range_unknown_op_is_none() {
+        assert!(range_expr(json!({"foo":5})).is_none());
+    }
+
+    #[test]
+    fn range_null_bound_is_none() {
+        assert!(range_expr(json!({"gte":serde_json::Value::Null})).is_none());
+    }
+
+    // ── Geo filter (unsupported → None) ────────────────────────────────────
+
+    #[test]
+    fn geo_is_unsupported_returns_none() {
+        // Milvus has no native geo filter; the builder must return None so a
+        // future accidental change is caught.
+        assert!(
+            build_milvus_filter("loc", "geo", &json!({"lat":20.0,"lon":10.0,"radius":5})).is_none()
+        );
+    }
+
+    // ── Distance-metric mapping ────────────────────────────────────────────
+
+    #[test]
+    fn metric_type_mapping_covers_all_arms() {
+        assert_eq!(map_milvus_metric_type("l2").unwrap(), "L2");
+        assert_eq!(map_milvus_metric_type("euclidean").unwrap(), "L2");
+        assert_eq!(map_milvus_metric_type("dot").unwrap(), "IP");
+        assert_eq!(map_milvus_metric_type("ip").unwrap(), "IP");
+        // Cosine deliberately maps to IP (inner-product over normalized vectors).
+        assert_eq!(map_milvus_metric_type("cosine").unwrap(), "IP");
+        assert_eq!(map_milvus_metric_type("angular").unwrap(), "IP");
+        assert!(map_milvus_metric_type("nope").is_err());
+    }
+
+    // ── Exact-match numeric / bool / non-scalar arms ───────────────────────
+
+    #[test]
+    fn exact_match_int_float_bool() {
+        assert_eq!(
+            build_milvus_filter("n", "match", &json!({"value":5})).unwrap(),
+            "n == 5"
+        );
+        assert_eq!(
+            build_milvus_filter("n", "match", &json!({"value":1.5})).unwrap(),
+            "n == 1.5"
+        );
+        assert_eq!(
+            build_milvus_filter("flag", "match", &json!({"value":true})).unwrap(),
+            "flag == true"
+        );
+    }
+
+    #[test]
+    fn exact_match_array_value_inlines_json_array() {
+        // No scalar guard: a non-scalar value is Display-formatted verbatim
+        // (documents behavior).
+        assert_eq!(
+            build_milvus_filter("n", "match", &json!({"value":[1,2]})).unwrap(),
+            "n == [1,2]"
+        );
     }
 }

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -148,17 +148,10 @@ impl OpenSearchEngine {
             ));
         }
 
-        // Map distance metric (OpenSearch uses different names than ES)
-        let space_type = match dist_lower.as_str() {
-            "l2" | "euclidean" => "l2",
-            "cosine" | "angular" => "cosinesimil",
-            other => {
-                return Err(format!(
-                    "Unsupported distance metric for OpenSearch: {}",
-                    other
-                ))
-            }
-        };
+        // Map distance metric (OpenSearch uses different names than ES).
+        // dot/ip already rejected above; os_space_type is only reached for the
+        // supported/unknown arms here (its dot arm exists for direct unit-testing).
+        let space_type = os_space_type(&dist_lower)?;
 
         // Build properties with knn_vector type
         let mut properties = serde_json::json!({
@@ -488,6 +481,21 @@ fn id_to_uuid_hex(id: i64) -> String {
 fn uuid_hex_to_int(hex: &str) -> Result<i64, String> {
     let uuid = Uuid::parse_str(hex).map_err(|e| format!("Invalid UUID hex '{}': {}", hex, e))?;
     Ok(uuid.as_u128() as i64)
+}
+
+/// Map a dataset distance name to the OpenSearch knn `space_type`. `dot`/`ip`
+/// is unsupported and unknown metrics error. A wrong arm here would silently
+/// change ranking, so every arm is unit-tested.
+fn os_space_type(distance: &str) -> Result<&'static str, String> {
+    match distance.to_lowercase().as_str() {
+        "l2" | "euclidean" => Ok("l2"),
+        "cosine" | "angular" => Ok("cosinesimil"),
+        "dot" | "ip" => Err("OpenSearch does not support DOT product distance".to_string()),
+        other => Err(format!(
+            "Unsupported distance metric for OpenSearch: {}",
+            other
+        )),
+    }
 }
 
 /// Parse conditions into OpenSearch bool query (same DSL as Elasticsearch).
@@ -1161,5 +1169,128 @@ mod tests {
         assert!(parse_os_conditions(&json!({})).is_none());
         // Present-but-empty sub-arrays should not produce a filter either.
         assert!(parse_os_conditions(&json!({"and": [], "or": []})).is_none());
+    }
+
+    #[test]
+    fn and_or_combined_keeps_both_and_min_should() {
+        let conditions = json!({
+            "and": [{"a": {"match": {"value": 1}}}],
+            "or": [{"b": {"match": {"value": 2}}}],
+        });
+        let parsed = parse_os_conditions(&conditions).expect("should parse");
+        let bool_query = &parsed["bool"];
+        assert_eq!(bool_query["must"].as_array().unwrap().len(), 1);
+        assert_eq!(bool_query["should"].as_array().unwrap().len(), 1);
+        assert_eq!(bool_query["minimum_should_match"], 1);
+    }
+
+    // ── Range operators ────────────────────────────────────────────────────
+
+    #[test]
+    fn range_lt_lte_gt_gte_map_to_os_range() {
+        assert_eq!(
+            build_filter("n", "range", &json!({"lt":5})).unwrap(),
+            json!({"range":{"n":{"lt":5}}})
+        );
+        assert_eq!(
+            build_filter("n", "range", &json!({"lte":5})).unwrap(),
+            json!({"range":{"n":{"lte":5}}})
+        );
+        assert_eq!(
+            build_filter("n", "range", &json!({"gt":5})).unwrap(),
+            json!({"range":{"n":{"gt":5}}})
+        );
+        assert_eq!(
+            build_filter("n", "range", &json!({"gte":5})).unwrap(),
+            json!({"range":{"n":{"gte":5}}})
+        );
+    }
+
+    #[test]
+    fn range_two_sided_keeps_both_bounds() {
+        assert_eq!(
+            build_filter("n", "range", &json!({"gte":10,"lt":20})).unwrap(),
+            json!({"range":{"n":{"gte":10,"lt":20}}})
+        );
+    }
+
+    #[test]
+    fn range_unknown_op_yields_empty_range_object() {
+        assert_eq!(
+            build_filter("n", "range", &json!({"foo":5})).unwrap(),
+            json!({"range":{"n":{}}})
+        );
+    }
+
+    #[test]
+    fn range_null_bound_is_skipped() {
+        assert_eq!(
+            build_filter("n", "range", &json!({"gte":serde_json::Value::Null})).unwrap(),
+            json!({"range":{"n":{}}})
+        );
+    }
+
+    // ── Geo filter ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn geo_with_radius_emits_geo_distance() {
+        assert_eq!(
+            build_filter("loc", "geo", &json!({"lat":20.0,"lon":10.0,"radius":500})).unwrap(),
+            json!({"geo_distance":{"distance":"500m","loc":{"lat":20.0,"lon":10.0}}})
+        );
+    }
+
+    #[test]
+    fn geo_without_radius_uses_default_1000m() {
+        assert_eq!(
+            build_filter("loc", "geo", &json!({"lat":20.0,"lon":10.0})).unwrap(),
+            json!({"geo_distance":{"distance":"1000m","loc":{"lat":20.0,"lon":10.0}}})
+        );
+    }
+
+    #[test]
+    fn geo_missing_lat_or_lon_is_none() {
+        assert!(build_filter("loc", "geo", &json!({"lon":10.0,"radius":5})).is_none());
+        assert!(build_filter("loc", "geo", &json!({"lat":20.0,"radius":5})).is_none());
+    }
+
+    // ── Distance-metric mapping ────────────────────────────────────────────
+
+    #[test]
+    fn os_space_type_covers_all_arms() {
+        assert_eq!(os_space_type("l2").unwrap(), "l2");
+        assert_eq!(os_space_type("euclidean").unwrap(), "l2");
+        assert_eq!(os_space_type("cosine").unwrap(), "cosinesimil");
+        assert_eq!(os_space_type("angular").unwrap(), "cosinesimil");
+        assert_eq!(os_space_type("COSINE").unwrap(), "cosinesimil");
+        assert!(os_space_type("dot").is_err());
+        assert!(os_space_type("ip").is_err());
+        assert!(os_space_type("nope").is_err());
+    }
+
+    // ── Exact-match numeric / bool / non-scalar arms ───────────────────────
+
+    #[test]
+    fn exact_match_int_float_bool_pass_through_match() {
+        assert_eq!(
+            build_filter("n", "match", &json!({"value":5})).unwrap(),
+            json!({"match":{"n":5}})
+        );
+        assert_eq!(
+            build_filter("n", "match", &json!({"value":1.5})).unwrap(),
+            json!({"match":{"n":1.5}})
+        );
+        assert_eq!(
+            build_filter("flag", "match", &json!({"value":true})).unwrap(),
+            json!({"match":{"flag":true}})
+        );
+    }
+
+    #[test]
+    fn exact_match_array_value_passes_through_unguarded() {
+        assert_eq!(
+            build_filter("n", "match", &json!({"value":[1,2]})).unwrap(),
+            json!({"match":{"n":[1,2]}})
+        );
     }
 }

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -160,22 +160,9 @@ impl Engine for PgVectorEngine {
         let dist_lower = distance.to_lowercase();
 
         // Set distance operator and HNSW ops class
-        match dist_lower.as_str() {
-            "l2" | "euclidean" => {
-                self.distance_op = "<->".to_string();
-                self.hnsw_ops_class = "vector_l2_ops".to_string();
-            }
-            "cosine" | "angular" => {
-                self.distance_op = "<=>".to_string();
-                self.hnsw_ops_class = "vector_cosine_ops".to_string();
-            }
-            other => {
-                return Err(format!(
-                    "PgVector does not support distance metric: {}",
-                    other
-                ))
-            }
-        }
+        let (distance_op, hnsw_ops_class) = map_pg_distance_ops(&dist_lower)?;
+        self.distance_op = distance_op.to_string();
+        self.hnsw_ops_class = hnsw_ops_class.to_string();
 
         let mut conn = self.connect()?;
 
@@ -558,6 +545,21 @@ impl Engine for PgVectorEngine {
 
 // ── PgVector condition parser ─────────────────────────────────────
 
+/// Map a dataset distance name to the pgvector `(operator, hnsw_ops_class)` pair.
+/// `dot`/`ip` is unsupported and unknown metrics error. A wrong arm here (e.g.
+/// L2 op with a cosine ops class) would silently change ranking, so every arm is
+/// unit-tested.
+fn map_pg_distance_ops(distance: &str) -> Result<(&'static str, &'static str), String> {
+    match distance.to_lowercase().as_str() {
+        "l2" | "euclidean" => Ok(("<->", "vector_l2_ops")),
+        "cosine" | "angular" => Ok(("<=>", "vector_cosine_ops")),
+        other => Err(format!(
+            "PgVector does not support distance metric: {}",
+            other
+        )),
+    }
+}
+
 fn parse_pg_conditions(conditions: &serde_json::Value) -> Option<String> {
     let obj = conditions.as_object()?;
     if obj.is_empty() {
@@ -761,5 +763,128 @@ mod tests {
         let cond = json!({"and": [{"color": {"match": {"any": []}}}]});
         let sql = parse_pg_conditions(&cond).unwrap();
         assert!(sql.contains("false"), "sql={}", sql);
+    }
+
+    // ── OR-branch of the condition parser ──────────────────────────────────
+
+    #[test]
+    fn or_only_emits_or_joined_group() {
+        let cond = json!({"or":[
+            {"a":{"match":{"value":"x"}}},
+            {"b":{"match":{"value":"y"}}},
+        ]});
+        assert_eq!(
+            parse_pg_conditions(&cond).unwrap(),
+            "(\"a\" = 'x' OR \"b\" = 'y')"
+        );
+    }
+
+    #[test]
+    fn and_plus_or_keeps_both_groups() {
+        let cond = json!({
+            "and":[{"a":{"match":{"value":"x"}}}],
+            "or":[{"b":{"match":{"value":"y"}}}],
+        });
+        assert_eq!(
+            parse_pg_conditions(&cond).unwrap(),
+            "(\"a\" = 'x') AND (\"b\" = 'y')"
+        );
+    }
+
+    // ── Range operators ────────────────────────────────────────────────────
+
+    fn range_sql(criteria: serde_json::Value) -> Option<String> {
+        parse_pg_conditions(&json!({"and":[{"n":{"range":criteria}}]}))
+    }
+
+    #[test]
+    fn range_lt_lte_gt_gte() {
+        assert_eq!(range_sql(json!({"lt":5})).unwrap(), "(\"n\" < 5)");
+        assert_eq!(range_sql(json!({"lte":5})).unwrap(), "(\"n\" <= 5)");
+        assert_eq!(range_sql(json!({"gt":5})).unwrap(), "(\"n\" > 5)");
+        assert_eq!(range_sql(json!({"gte":5})).unwrap(), "(\"n\" >= 5)");
+    }
+
+    #[test]
+    fn range_two_sided_gte_lt() {
+        // Criteria object keys iterate in sorted order (BTreeMap): gte, then lt.
+        assert_eq!(
+            range_sql(json!({"gte":10,"lt":20})).unwrap(),
+            "(\"n\" >= 10 AND \"n\" < 20)"
+        );
+    }
+
+    #[test]
+    fn range_unknown_op_is_none() {
+        assert!(range_sql(json!({"foo":5})).is_none());
+    }
+
+    #[test]
+    fn range_null_bound_is_none() {
+        assert!(range_sql(json!({"gte":serde_json::Value::Null})).is_none());
+    }
+
+    // ── Geo filter (unsupported → None) ────────────────────────────────────
+
+    #[test]
+    fn geo_is_unsupported_returns_none() {
+        // pgvector filters on scalar columns only; geo has no clause arm, so the
+        // filter is dropped. Assert None so an accidental future change is caught.
+        let cond = json!({"and":[{"loc":{"geo":{"lat":20.0,"lon":10.0,"radius":5}}}]});
+        assert!(parse_pg_conditions(&cond).is_none());
+    }
+
+    // ── Distance-metric mapping ────────────────────────────────────────────
+
+    #[test]
+    fn distance_ops_mapping_covers_all_arms() {
+        assert_eq!(map_pg_distance_ops("l2").unwrap(), ("<->", "vector_l2_ops"));
+        assert_eq!(
+            map_pg_distance_ops("euclidean").unwrap(),
+            ("<->", "vector_l2_ops")
+        );
+        assert_eq!(
+            map_pg_distance_ops("cosine").unwrap(),
+            ("<=>", "vector_cosine_ops")
+        );
+        assert_eq!(
+            map_pg_distance_ops("angular").unwrap(),
+            ("<=>", "vector_cosine_ops")
+        );
+        assert_eq!(
+            map_pg_distance_ops("COSINE").unwrap(),
+            ("<=>", "vector_cosine_ops")
+        );
+        // dot/ip unsupported; unknown errors too.
+        assert!(map_pg_distance_ops("dot").is_err());
+        assert!(map_pg_distance_ops("ip").is_err());
+        assert!(map_pg_distance_ops("nope").is_err());
+    }
+
+    // ── Exact-match numeric / bool / non-scalar arms ───────────────────────
+
+    #[test]
+    fn exact_match_int_float_bool() {
+        assert_eq!(
+            parse_pg_conditions(&json!({"and":[{"n":{"match":{"value":5}}}]})).unwrap(),
+            "(\"n\" = 5)"
+        );
+        assert_eq!(
+            parse_pg_conditions(&json!({"and":[{"n":{"match":{"value":1.5}}}]})).unwrap(),
+            "(\"n\" = 1.5)"
+        );
+        assert_eq!(
+            parse_pg_conditions(&json!({"and":[{"flag":{"match":{"value":true}}}]})).unwrap(),
+            "(\"flag\" = true)"
+        );
+    }
+
+    #[test]
+    fn exact_match_array_value_inlines_json_array() {
+        // No scalar guard: a non-scalar value is Display-formatted verbatim.
+        assert_eq!(
+            parse_pg_conditions(&json!({"and":[{"n":{"match":{"value":[1,2]}}}]})).unwrap(),
+            "(\"n\" = [1,2])"
+        );
     }
 }

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -187,12 +187,7 @@ impl QdrantEngine {
         let distance = dataset.distance();
         let vector_size = dataset.vector_size();
 
-        let qdrant_distance = match distance.to_lowercase().as_str() {
-            "l2" | "euclidean" => Distance::Euclid,
-            "cosine" | "angular" => Distance::Cosine,
-            "dot" | "ip" => Distance::Dot,
-            other => return Err(format!("Unsupported distance metric for Qdrant: {}", other)),
-        };
+        let qdrant_distance = map_qdrant_distance(distance)?;
 
         // HNSW params come from the TYPED collection_params.hnsw_config field
         // (serde captures "m"/"ef_construct" there via aliases; the flattened
@@ -376,12 +371,7 @@ impl QdrantEngine {
     fn create_hybrid_collection(&self, dataset: &Dataset) -> Result<(), String> {
         let distance = dataset.distance();
         let vector_size = dataset.vector_size();
-        let qdrant_distance = match distance.to_lowercase().as_str() {
-            "l2" | "euclidean" => Distance::Euclid,
-            "cosine" | "angular" => Distance::Cosine,
-            "dot" | "ip" => Distance::Dot,
-            other => return Err(format!("Unsupported distance metric for Qdrant: {}", other)),
-        };
+        let qdrant_distance = map_qdrant_distance(distance)?;
 
         // Named dense vector "dense" (per-vector HNSW config if requested).
         let mut dense_params = VectorParamsBuilder::new(vector_size as u64, qdrant_distance);
@@ -741,6 +731,18 @@ impl QdrantEngine {
 }
 
 /// Parse conditions into Qdrant filter format.
+/// Map a dataset distance name to the Qdrant `Distance` enum. Unknown metrics
+/// return a clear `Err` (never silently default). A wrong arm here (e.g. IP→L2)
+/// would silently invert ranking, so every arm is unit-tested.
+fn map_qdrant_distance(distance: &str) -> Result<Distance, String> {
+    match distance.to_lowercase().as_str() {
+        "l2" | "euclidean" => Ok(Distance::Euclid),
+        "cosine" | "angular" => Ok(Distance::Cosine),
+        "dot" | "ip" => Ok(Distance::Dot),
+        other => Err(format!("Unsupported distance metric for Qdrant: {}", other)),
+    }
+}
+
 fn parse_qdrant_conditions(conditions: &serde_json::Value) -> Option<Filter> {
     let obj = conditions.as_object()?;
     if obj.is_empty() {
@@ -1507,5 +1509,147 @@ rest_responses_total{method=\"GET\"} 42
         assert!(m.get("cluster_enabled").is_none());
         // 5 curated gauges present in the sample.
         assert_eq!(m.len(), 5);
+    }
+
+    // ── OR-branch of the condition parser ──────────────────────────────────
+    use super::{map_qdrant_distance, parse_qdrant_conditions};
+    use qdrant_client::qdrant::Distance;
+
+    #[test]
+    fn or_only_populates_should_not_must() {
+        let cond = json!({"or":[
+            {"a":{"match":{"value":"x"}}},
+            {"b":{"match":{"value":"y"}}},
+        ]});
+        let filter = parse_qdrant_conditions(&cond).unwrap();
+        assert_eq!(filter.should.len(), 2, "or → 2 should entries");
+        assert!(filter.must.is_empty(), "or-only leaves must empty");
+    }
+
+    #[test]
+    fn and_plus_or_populates_both() {
+        let cond = json!({
+            "and":[{"a":{"match":{"value":"x"}}}],
+            "or":[{"b":{"match":{"value":"y"}}},{"c":{"match":{"value":"z"}}}],
+        });
+        let filter = parse_qdrant_conditions(&cond).unwrap();
+        assert_eq!(filter.must.len(), 1);
+        assert_eq!(filter.should.len(), 2);
+    }
+
+    // ── Range operators ────────────────────────────────────────────────────
+
+    fn numeric_range(criteria: serde_json::Value) -> qdrant_client::qdrant::Range {
+        let c = build_qdrant_filter("n", "range", &criteria).unwrap();
+        field_condition(&c).range.expect("numeric range")
+    }
+
+    #[test]
+    fn range_lt_sets_only_lt() {
+        let r = numeric_range(json!({"lt":5}));
+        assert_eq!(r.lt, Some(5.0));
+        assert!(r.gt.is_none() && r.lte.is_none() && r.gte.is_none());
+    }
+
+    #[test]
+    fn range_lte_sets_only_lte() {
+        let r = numeric_range(json!({"lte":5}));
+        assert_eq!(r.lte, Some(5.0));
+        assert!(r.lt.is_none() && r.gt.is_none() && r.gte.is_none());
+    }
+
+    #[test]
+    fn range_gt_sets_only_gt() {
+        let r = numeric_range(json!({"gt":5}));
+        assert_eq!(r.gt, Some(5.0));
+        assert!(r.lt.is_none() && r.lte.is_none() && r.gte.is_none());
+    }
+
+    #[test]
+    fn range_gte_sets_only_gte() {
+        let r = numeric_range(json!({"gte":5}));
+        assert_eq!(r.gte, Some(5.0));
+        assert!(r.lt.is_none() && r.gt.is_none() && r.lte.is_none());
+    }
+
+    #[test]
+    fn range_two_sided_gte_lt() {
+        let r = numeric_range(json!({"gte":10,"lt":20}));
+        assert_eq!(r.gte, Some(10.0));
+        assert_eq!(r.lt, Some(20.0));
+    }
+
+    #[test]
+    fn range_unknown_op_yields_empty_numeric_range() {
+        // Qdrant emits an (empty) numeric Range for an unrecognized key rather
+        // than None — the condition is present but constrains nothing.
+        let r = numeric_range(json!({"foo":5}));
+        assert!(r.lt.is_none() && r.gt.is_none() && r.lte.is_none() && r.gte.is_none());
+    }
+
+    #[test]
+    fn range_null_bound_yields_empty_numeric_range() {
+        let r = numeric_range(json!({"gte": serde_json::Value::Null}));
+        assert!(r.gte.is_none());
+    }
+
+    // ── Geo filter ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn geo_with_radius_sets_center_and_radius() {
+        let c = build_qdrant_filter("loc", "geo", &json!({"lat":20.0,"lon":10.0,"radius":500}))
+            .unwrap();
+        let gr = field_condition(&c).geo_radius.expect("geo_radius");
+        let center = gr.center.expect("center");
+        assert_eq!(center.lat, 20.0);
+        assert_eq!(center.lon, 10.0);
+        assert_eq!(gr.radius, 500.0);
+    }
+
+    #[test]
+    fn geo_without_radius_uses_default_1000() {
+        let c = build_qdrant_filter("loc", "geo", &json!({"lat":20.0,"lon":10.0})).unwrap();
+        let gr = field_condition(&c).geo_radius.expect("geo_radius");
+        assert_eq!(gr.radius, 1000.0);
+    }
+
+    #[test]
+    fn geo_missing_lat_or_lon_is_none() {
+        assert!(build_qdrant_filter("loc", "geo", &json!({"lon":10.0,"radius":500})).is_none());
+        assert!(build_qdrant_filter("loc", "geo", &json!({"lat":20.0,"radius":500})).is_none());
+    }
+
+    // ── Distance-metric mapping ────────────────────────────────────────────
+
+    #[test]
+    fn distance_mapping_covers_all_arms() {
+        assert_eq!(map_qdrant_distance("cosine").unwrap(), Distance::Cosine);
+        assert_eq!(map_qdrant_distance("angular").unwrap(), Distance::Cosine);
+        assert_eq!(map_qdrant_distance("l2").unwrap(), Distance::Euclid);
+        assert_eq!(map_qdrant_distance("euclidean").unwrap(), Distance::Euclid);
+        assert_eq!(map_qdrant_distance("dot").unwrap(), Distance::Dot);
+        assert_eq!(map_qdrant_distance("ip").unwrap(), Distance::Dot);
+        assert_eq!(map_qdrant_distance("COSINE").unwrap(), Distance::Cosine);
+        assert!(map_qdrant_distance("nope").is_err());
+    }
+
+    // ── Exact-match numeric / non-scalar arms ──────────────────────────────
+
+    #[test]
+    fn exact_match_int_sets_match() {
+        let c = build_qdrant_filter("n", "match", &json!({"value":5})).unwrap();
+        assert!(field_condition(&c).r#match.is_some());
+    }
+
+    #[test]
+    fn exact_match_float_is_none() {
+        // Qdrant `Match` supports keyword/integer/bool only — a float exact value
+        // matches no arm and is dropped (float filtering uses range instead).
+        assert!(build_qdrant_filter("n", "match", &json!({"value":1.5})).is_none());
+    }
+
+    #[test]
+    fn exact_match_array_value_is_none() {
+        assert!(build_qdrant_filter("n", "match", &json!({"value":[1,2]})).is_none());
     }
 }

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -120,12 +120,7 @@ impl RedisEngine {
             .query::<()>(conn);
 
         // Map distance metric
-        let distance_metric = match distance.to_lowercase().as_str() {
-            "cosine" | "angular" => "COSINE",
-            "euclidean" | "l2" => "L2",
-            "dot" | "ip" => "IP",
-            _ => "COSINE",
-        };
+        let distance_metric = map_distance_metric(distance);
 
         // Build FT.CREATE command
         let mut cmd = redis::cmd("FT.CREATE");
@@ -767,6 +762,18 @@ enum FilterParamValue {
 
 /// Parsed filter: (prefilter_query_string, param_name -> param_value).
 type ParsedFilter = (String, HashMap<String, FilterParamValue>);
+
+/// Map a dataset distance name to the RediSearch `DISTANCE_METRIC` value.
+/// Unknown metrics default to `COSINE` (matches the historical inline behavior).
+/// A typo here (e.g. IP→L2) would silently invert ranking, so it is unit-tested.
+fn map_distance_metric(distance: &str) -> &'static str {
+    match distance.to_lowercase().as_str() {
+        "cosine" | "angular" => "COSINE",
+        "euclidean" | "l2" => "L2",
+        "dot" | "ip" => "IP",
+        _ => "COSINE",
+    }
+}
 
 /// Parse meta_conditions JSON into a RediSearch prefilter string + params.
 /// Returns None when no conditions are present.
@@ -2543,5 +2550,176 @@ mod tests {
         // Non-exhaustive/other variant → non-empty JSON string, never dropped.
         let okay = redis_value_to_json(&Value::Okay);
         assert!(okay.as_str().map(|s| !s.is_empty()).unwrap_or(false));
+    }
+
+    // ── OR-branch of the condition parser ──────────────────────────────────
+    use super::{
+        build_exact_match_filter, build_geo_filter, build_range_filter, map_distance_metric,
+    };
+
+    #[test]
+    fn or_only_emits_pipe_joined_group() {
+        let cond = serde_json::json!({"or":[
+            {"a":{"match":{"value":"x"}}},
+            {"b":{"match":{"value":"y"}}},
+        ]});
+        let (q, _p) = parse_conditions(&cond).unwrap();
+        // OR clauses are pipe-joined inside a single parenthesized group; `must`
+        // (AND) is absent.
+        assert_eq!(q, "(@a:{$a_0} | @b:{$b_1})", "q={}", q);
+    }
+
+    #[test]
+    fn and_plus_or_keeps_both_groups() {
+        let cond = serde_json::json!({
+            "and":[{"a":{"match":{"value":"x"}}}],
+            "or":[{"b":{"match":{"value":"y"}}}],
+        });
+        let (q, _p) = parse_conditions(&cond).unwrap();
+        // AND group (space-joined) then OR group (pipe-joined), space-separated.
+        assert_eq!(q, "(@a:{$a_0}) (@b:{$b_1})", "q={}", q);
+    }
+
+    // ── Range operators ────────────────────────────────────────────────────
+
+    // Test the range arm directly (parse_conditions additionally wraps the whole
+    // AND group in `(...)`).
+    fn range_q(criteria: serde_json::Value) -> Option<String> {
+        let mut counter = 0;
+        build_range_filter("n", &criteria, &mut counter).map(|(q, _)| q)
+    }
+
+    #[test]
+    fn range_lt_is_exclusive() {
+        assert_eq!(
+            range_q(serde_json::json!({"lt":5})).unwrap(),
+            "@n:[-inf ($n_0_lt]"
+        );
+    }
+
+    #[test]
+    fn range_lte_is_inclusive() {
+        assert_eq!(
+            range_q(serde_json::json!({"lte":5})).unwrap(),
+            "@n:[-inf $n_0_lte]"
+        );
+    }
+
+    #[test]
+    fn range_gt_is_exclusive() {
+        assert_eq!(
+            range_q(serde_json::json!({"gt":5})).unwrap(),
+            "@n:[($n_0_gt +inf]"
+        );
+    }
+
+    #[test]
+    fn range_gte_is_inclusive() {
+        assert_eq!(
+            range_q(serde_json::json!({"gte":5})).unwrap(),
+            "@n:[$n_0_gte +inf]"
+        );
+    }
+
+    #[test]
+    fn range_two_sided_gte_lt() {
+        // Bounds are emitted in the fixed order lt, gt, lte, gte (space-joined).
+        assert_eq!(
+            range_q(serde_json::json!({"gte":10,"lt":20})).unwrap(),
+            "@n:[-inf ($n_0_lt] @n:[$n_0_gte +inf]"
+        );
+    }
+
+    #[test]
+    fn range_unknown_op_is_skipped() {
+        // No recognized bound → no clause → whole filter is None.
+        assert!(range_q(serde_json::json!({"foo":5})).is_none());
+    }
+
+    #[test]
+    fn range_null_bound_is_skipped() {
+        // A null bound never parses into a param, so no dangling clause is emitted.
+        assert!(range_q(serde_json::json!({"gte":serde_json::Value::Null})).is_none());
+    }
+
+    // ── Geo filter ─────────────────────────────────────────────────────────
+
+    fn geo_q(criteria: serde_json::Value) -> Option<(String, HashMap<String, FilterParamValue>)> {
+        let mut counter = 0;
+        build_geo_filter("loc", &criteria, &mut counter)
+    }
+
+    #[test]
+    fn geo_with_radius_emits_lon_lat_radius() {
+        let (q, params) = geo_q(serde_json::json!({"lon":10.0,"lat":20.0,"radius":500})).unwrap();
+        assert_eq!(q, "@loc:[$loc_0_lon $loc_0_lat $loc_0_radius m]", "q={}", q);
+        assert!(matches!(
+            params.get("loc_0_radius"),
+            Some(FilterParamValue::Int(500))
+        ));
+        assert!(matches!(
+            params.get("loc_0_lon"),
+            Some(FilterParamValue::Float(_))
+        ));
+        assert!(matches!(
+            params.get("loc_0_lat"),
+            Some(FilterParamValue::Float(_))
+        ));
+    }
+
+    #[test]
+    fn geo_missing_radius_is_none() {
+        // RediSearch geo has NO default radius: a missing radius drops the clause.
+        assert!(geo_q(serde_json::json!({"lon":10.0,"lat":20.0})).is_none());
+    }
+
+    #[test]
+    fn geo_missing_lat_or_lon_is_none() {
+        assert!(geo_q(serde_json::json!({"lon":10.0,"radius":500})).is_none());
+        assert!(geo_q(serde_json::json!({"lat":20.0,"radius":500})).is_none());
+    }
+
+    // ── Distance-metric mapping ────────────────────────────────────────────
+
+    #[test]
+    fn distance_metric_maps_all_arms() {
+        assert_eq!(map_distance_metric("cosine"), "COSINE");
+        assert_eq!(map_distance_metric("angular"), "COSINE");
+        assert_eq!(map_distance_metric("l2"), "L2");
+        assert_eq!(map_distance_metric("euclidean"), "L2");
+        assert_eq!(map_distance_metric("dot"), "IP");
+        assert_eq!(map_distance_metric("ip"), "IP");
+        assert_eq!(map_distance_metric("COSINE"), "COSINE"); // case-insensitive
+                                                             // Unknown → default COSINE (never silently wrong metric type).
+        assert_eq!(map_distance_metric("nope"), "COSINE");
+    }
+
+    // ── Exact-match numeric / bool / non-scalar arms ───────────────────────
+
+    fn exact_q(criteria: serde_json::Value) -> Option<(String, HashMap<String, FilterParamValue>)> {
+        let mut counter = 0;
+        build_exact_match_filter("n", &criteria, &mut counter)
+    }
+
+    #[test]
+    fn exact_match_int_emits_numeric_point() {
+        let (q, params) = exact_q(serde_json::json!({"value":5})).unwrap();
+        assert_eq!(q, "@n:[$n_0 $n_0]", "q={}", q);
+        assert!(matches!(params.get("n_0"), Some(FilterParamValue::Int(5))));
+    }
+
+    #[test]
+    fn exact_match_float_emits_numeric_point() {
+        let (q, params) = exact_q(serde_json::json!({"value":1.5})).unwrap();
+        assert_eq!(q, "@n:[$n_0 $n_0]", "q={}", q);
+        assert!(
+            matches!(params.get("n_0"), Some(FilterParamValue::Float(f)) if (*f - 1.5).abs() < 1e-9)
+        );
+    }
+
+    #[test]
+    fn exact_match_array_value_is_none() {
+        // A non-scalar (array) value matches no scalar arm → dropped → None.
+        assert!(exact_q(serde_json::json!({"value":[1,2]})).is_none());
     }
 }

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -171,12 +171,7 @@ impl ValkeyEngine {
         let _ = redis::cmd("FLUSHALL").query::<()>(conn);
 
         // Map distance metric
-        let distance_metric = match distance.to_lowercase().as_str() {
-            "cosine" | "angular" => "COSINE",
-            "euclidean" | "l2" => "L2",
-            "dot" | "ip" => "IP",
-            _ => "COSINE",
-        };
+        let distance_metric = map_distance_metric(distance);
 
         // Build FT.CREATE command
         let mut cmd = redis::cmd("FT.CREATE");
@@ -836,6 +831,18 @@ enum FilterParamValue {
 }
 
 type ParsedFilter = (String, HashMap<String, FilterParamValue>);
+
+/// Map a dataset distance name to the Valkey Search `DISTANCE_METRIC` value.
+/// Unknown metrics default to `COSINE` (matches the historical inline behavior).
+/// A typo here (e.g. IP→L2) would silently invert ranking, so it is unit-tested.
+fn map_distance_metric(distance: &str) -> &'static str {
+    match distance.to_lowercase().as_str() {
+        "cosine" | "angular" => "COSINE",
+        "euclidean" | "l2" => "L2",
+        "dot" | "ip" => "IP",
+        _ => "COSINE",
+    }
+}
 
 fn parse_conditions(conditions: &serde_json::Value) -> Option<ParsedFilter> {
     let obj = conditions.as_object()?;
@@ -2502,5 +2509,160 @@ mod tests {
             "Okay should map to a non-empty JSON string, got {:?}",
             okay
         );
+    }
+
+    // ── OR-branch of the condition parser ──────────────────────────────────
+    use super::{
+        build_exact_match_filter, build_geo_filter, build_range_filter, map_distance_metric,
+    };
+
+    fn q_of(cond: serde_json::Value) -> Option<String> {
+        parse_conditions(&cond).map(|(q, _)| q)
+    }
+
+    #[test]
+    fn or_only_emits_pipe_joined_group() {
+        let cond = serde_json::json!({"or":[
+            {"a":{"match":{"value":"x"}}},
+            {"b":{"match":{"value":"y"}}},
+        ]});
+        // Values inlined (no $param inside TAG braces on Valkey Search).
+        assert_eq!(q_of(cond).unwrap(), "(@a:{x} | @b:{y})");
+    }
+
+    #[test]
+    fn and_plus_or_keeps_both_groups() {
+        let cond = serde_json::json!({
+            "and":[{"a":{"match":{"value":"x"}}}],
+            "or":[{"b":{"match":{"value":"y"}}}],
+        });
+        assert_eq!(q_of(cond).unwrap(), "(@a:{x}) (@b:{y})");
+    }
+
+    // ── Range operators (inlined literals on Valkey Search) ────────────────
+    // Test the range arm directly (parse_conditions additionally wraps the whole
+    // AND group in `(...)`).
+
+    fn range_q(criteria: serde_json::Value) -> Option<String> {
+        let mut counter = 0;
+        build_range_filter("n", &criteria, &mut counter).map(|(q, _)| q)
+    }
+
+    #[test]
+    fn range_lt_is_exclusive() {
+        assert_eq!(
+            range_q(serde_json::json!({"lt":5})).unwrap(),
+            "@n:[-inf (5]"
+        );
+    }
+
+    #[test]
+    fn range_lte_is_inclusive() {
+        assert_eq!(
+            range_q(serde_json::json!({"lte":5})).unwrap(),
+            "@n:[-inf 5]"
+        );
+    }
+
+    #[test]
+    fn range_gt_is_exclusive() {
+        assert_eq!(
+            range_q(serde_json::json!({"gt":5})).unwrap(),
+            "@n:[(5 +inf]"
+        );
+    }
+
+    #[test]
+    fn range_gte_is_inclusive() {
+        assert_eq!(
+            range_q(serde_json::json!({"gte":5})).unwrap(),
+            "@n:[5 +inf]"
+        );
+    }
+
+    #[test]
+    fn range_two_sided_gte_lt() {
+        // Fixed order lt, gt, lte, gte (space-joined).
+        assert_eq!(
+            range_q(serde_json::json!({"gte":10,"lt":20})).unwrap(),
+            "@n:[-inf (20] @n:[10 +inf]"
+        );
+    }
+
+    #[test]
+    fn range_unknown_op_is_skipped() {
+        assert!(range_q(serde_json::json!({"foo":5})).is_none());
+    }
+
+    #[test]
+    fn range_null_bound_is_skipped() {
+        assert!(range_q(serde_json::json!({"gte":serde_json::Value::Null})).is_none());
+    }
+
+    // ── Geo filter (param-based, like redis) ───────────────────────────────
+
+    fn geo_q(criteria: serde_json::Value) -> Option<(String, HashMap<String, FilterParamValue>)> {
+        let mut counter = 0;
+        build_geo_filter("loc", &criteria, &mut counter)
+    }
+
+    #[test]
+    fn geo_with_radius_emits_lon_lat_radius() {
+        let (q, params) = geo_q(serde_json::json!({"lon":10.0,"lat":20.0,"radius":500})).unwrap();
+        assert_eq!(q, "@loc:[$loc_0_lon $loc_0_lat $loc_0_radius m]", "q={}", q);
+        assert!(matches!(
+            params.get("loc_0_radius"),
+            Some(FilterParamValue::Int(500))
+        ));
+    }
+
+    #[test]
+    fn geo_missing_radius_is_none() {
+        // Valkey Search geo has NO default radius; a missing radius drops the clause.
+        assert!(geo_q(serde_json::json!({"lon":10.0,"lat":20.0})).is_none());
+    }
+
+    #[test]
+    fn geo_missing_lat_or_lon_is_none() {
+        assert!(geo_q(serde_json::json!({"lon":10.0,"radius":500})).is_none());
+        assert!(geo_q(serde_json::json!({"lat":20.0,"radius":500})).is_none());
+    }
+
+    // ── Distance-metric mapping ────────────────────────────────────────────
+
+    #[test]
+    fn distance_metric_maps_all_arms() {
+        assert_eq!(map_distance_metric("cosine"), "COSINE");
+        assert_eq!(map_distance_metric("angular"), "COSINE");
+        assert_eq!(map_distance_metric("l2"), "L2");
+        assert_eq!(map_distance_metric("euclidean"), "L2");
+        assert_eq!(map_distance_metric("dot"), "IP");
+        assert_eq!(map_distance_metric("ip"), "IP");
+        assert_eq!(map_distance_metric("nope"), "COSINE");
+    }
+
+    // ── Exact-match numeric / non-scalar arms ──────────────────────────────
+
+    fn exact_q(criteria: serde_json::Value) -> Option<String> {
+        let mut counter = 0;
+        build_exact_match_filter("n", &criteria, &mut counter).map(|(q, _)| q)
+    }
+
+    #[test]
+    fn exact_match_int_emits_inlined_numeric_point() {
+        assert_eq!(exact_q(serde_json::json!({"value":5})).unwrap(), "@n:[5 5]");
+    }
+
+    #[test]
+    fn exact_match_float_emits_inlined_numeric_point() {
+        assert_eq!(
+            exact_q(serde_json::json!({"value":1.5})).unwrap(),
+            "@n:[1.5 1.5]"
+        );
+    }
+
+    #[test]
+    fn exact_match_array_value_is_none() {
+        assert!(exact_q(serde_json::json!({"value":[1,2]})).is_none());
     }
 }

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -1143,16 +1143,19 @@ fn never_match_clause(field_name: &str) -> String {
 fn build_range_clause(field_name: &str, criteria: &serde_json::Value) -> Option<String> {
     let mut parts = Vec::new();
 
-    if let Some(gt) = criteria.get("gt") {
+    // Only numeric bounds constrain the range; a null/non-numeric bound carries no
+    // constraint and is skipped (matching redis/valkey/qdrant/es/os/weaviate/milvus/
+    // pgvector) — otherwise `format_number` would fall back to "0" and emit `.n > 0`.
+    if let Some(gt) = criteria.get("gt").filter(|v| v.is_number()) {
         parts.push(format!(".{} > {}", field_name, format_number(gt)));
     }
-    if let Some(gte) = criteria.get("gte") {
+    if let Some(gte) = criteria.get("gte").filter(|v| v.is_number()) {
         parts.push(format!(".{} >= {}", field_name, format_number(gte)));
     }
-    if let Some(lt) = criteria.get("lt") {
+    if let Some(lt) = criteria.get("lt").filter(|v| v.is_number()) {
         parts.push(format!(".{} < {}", field_name, format_number(lt)));
     }
-    if let Some(lte) = criteria.get("lte") {
+    if let Some(lte) = criteria.get("lte").filter(|v| v.is_number()) {
         parts.push(format!(".{} <= {}", field_name, format_number(lte)));
     }
 
@@ -1469,14 +1472,10 @@ mod filter_expr_tests {
     }
 
     #[test]
-    #[ignore = "BUG: a null range bound emits `.n > 0` (format_number fallback) \
-                instead of being skipped like every other engine; remove #[ignore] to reproduce"]
-    fn range_null_bound_should_be_skipped_bug() {
-        // CORRECT behavior: a null bound carries no constraint, so the clause must
-        // be skipped (→ None), matching redis/valkey/qdrant/es/os/weaviate/milvus/
-        // pgvector. ACTUAL: build_range_clause pushes `.n > 0` because
-        // format_number(Null) falls back to "0". This test asserts the CORRECT
-        // behavior and therefore FAILS, exposing the bug.
+    fn range_null_bound_is_skipped() {
+        // A null bound carries no constraint, so the clause is skipped (→ None),
+        // matching redis/valkey/qdrant/es/os/weaviate/milvus/pgvector. (Regression
+        // guard: build_range_clause used to emit `.n > 0` via format_number(Null).)
         let got = range_expr(json!({"gt": serde_json::Value::Null}));
         assert!(got.is_none(), "null bound should be skipped, got {:?}", got);
     }

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -1411,4 +1411,91 @@ mod filter_expr_tests {
         assert!(build_filter_expression(&json!({})).is_none());
         assert!(build_filter_expression(&json!({"and": [], "or": []})).is_none());
     }
+
+    // ── OR-branch: combined AND + OR ───────────────────────────────────────
+
+    #[test]
+    fn and_plus_or_joins_and_group_with_parenthesized_or_group() {
+        let cond = json!({
+            "and":[{"a":{"match":{"value":"x"}}}],
+            "or":[{"b":{"match":{"value":"y"}}}],
+        });
+        // AND clause (no parens for a single clause) joined with the parenthesized
+        // OR group by ` and `.
+        assert_eq!(
+            build_filter_expression(&cond),
+            Some(".a == \"x\" and (.b == \"y\")".to_string())
+        );
+    }
+
+    // ── Range operators (individual arms) ──────────────────────────────────
+
+    fn range_expr(criteria: serde_json::Value) -> Option<String> {
+        build_filter_expression(&json!({"and":[{"n":{"range":criteria}}]}))
+    }
+
+    #[test]
+    fn range_lt_is_exclusive() {
+        assert_eq!(range_expr(json!({"lt":5})).unwrap(), ".n < 5");
+    }
+
+    #[test]
+    fn range_lte_is_inclusive() {
+        assert_eq!(range_expr(json!({"lte":5})).unwrap(), ".n <= 5");
+    }
+
+    #[test]
+    fn range_gt_is_exclusive() {
+        assert_eq!(range_expr(json!({"gt":5})).unwrap(), ".n > 5");
+    }
+
+    #[test]
+    fn range_gte_is_inclusive() {
+        assert_eq!(range_expr(json!({"gte":5})).unwrap(), ".n >= 5");
+    }
+
+    #[test]
+    fn range_two_sided_gte_lt() {
+        // Fixed order gt, gte, lt, lte joined by ` and `.
+        assert_eq!(
+            range_expr(json!({"gte":10,"lt":20})).unwrap(),
+            ".n >= 10 and .n < 20"
+        );
+    }
+
+    #[test]
+    fn range_unknown_op_is_none() {
+        assert!(range_expr(json!({"foo":5})).is_none());
+    }
+
+    #[test]
+    #[ignore = "BUG: a null range bound emits `.n > 0` (format_number fallback) \
+                instead of being skipped like every other engine; remove #[ignore] to reproduce"]
+    fn range_null_bound_should_be_skipped_bug() {
+        // CORRECT behavior: a null bound carries no constraint, so the clause must
+        // be skipped (→ None), matching redis/valkey/qdrant/es/os/weaviate/milvus/
+        // pgvector. ACTUAL: build_range_clause pushes `.n > 0` because
+        // format_number(Null) falls back to "0". This test asserts the CORRECT
+        // behavior and therefore FAILS, exposing the bug.
+        let got = range_expr(json!({"gt": serde_json::Value::Null}));
+        assert!(got.is_none(), "null bound should be skipped, got {:?}", got);
+    }
+
+    // ── Exact-match float / non-scalar arms ────────────────────────────────
+
+    #[test]
+    fn exact_match_float_emits_equality() {
+        assert_eq!(
+            build_filter_expression(&json!({"and":[{"score":{"match":{"value":1.5}}}]})),
+            Some(".score == 1.5".to_string())
+        );
+    }
+
+    #[test]
+    fn exact_match_array_value_is_none() {
+        // A non-scalar (array) value matches no scalar arm → clause dropped → None.
+        assert!(
+            build_filter_expression(&json!({"and":[{"n":{"match":{"value":[1,2]}}}]})).is_none()
+        );
+    }
 }

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -170,17 +170,7 @@ impl WeaviateEngine {
     ) -> Result<(), String> {
         let distance = dataset.distance();
 
-        let weaviate_distance = match distance.to_lowercase().as_str() {
-            "l2" | "euclidean" => "l2-squared",
-            "cosine" | "angular" => "cosine",
-            "dot" | "ip" => "dot",
-            other => {
-                return Err(format!(
-                    "Unsupported distance metric for Weaviate: {}",
-                    other
-                ))
-            }
-        };
+        let weaviate_distance = map_weaviate_distance(distance)?;
 
         // Build properties from schema
         let mut properties = Vec::new();
@@ -771,6 +761,21 @@ fn extract_grpc_hits(reply: &SearchReply) -> Result<Vec<(i64, f64)>, String> {
 }
 
 /// Parse conditions into Weaviate where filter format.
+/// Map a dataset distance name to the Weaviate `vectorIndexConfig.distance`
+/// value. Unknown metrics error. A wrong arm here would silently change ranking,
+/// so every arm is unit-tested.
+fn map_weaviate_distance(distance: &str) -> Result<&'static str, String> {
+    match distance.to_lowercase().as_str() {
+        "l2" | "euclidean" => Ok("l2-squared"),
+        "cosine" | "angular" => Ok("cosine"),
+        "dot" | "ip" => Ok("dot"),
+        other => Err(format!(
+            "Unsupported distance metric for Weaviate: {}",
+            other
+        )),
+    }
+}
+
 fn parse_weaviate_conditions(conditions: &serde_json::Value) -> Option<serde_json::Value> {
     let obj = conditions.as_object()?;
     if obj.is_empty() {
@@ -1607,5 +1612,144 @@ mod tests {
         assert_eq!(coerce_metadata_value(Some("keyword"), &v), json!("red"));
         // Unknown/unmapped fields pass through unchanged.
         assert_eq!(coerce_metadata_value(None, &v), json!("red"));
+    }
+
+    // ── OR-branch of the condition parser ──────────────────────────────────
+
+    #[test]
+    fn or_only_emits_or_operator_with_two_operands() {
+        let cond = json!({"or":[
+            {"a":{"match":{"value":"x"}}},
+            {"b":{"match":{"value":"y"}}},
+        ]});
+        let f = parse_weaviate_conditions(&cond).unwrap();
+        assert_eq!(f["operator"], "Or");
+        assert_eq!(f["operands"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn and_plus_or_wraps_both_groups_in_and() {
+        let cond = json!({
+            "and":[{"a":{"match":{"value":"x"}}}],
+            "or":[{"b":{"match":{"value":"y"}}},{"c":{"match":{"value":"z"}}}],
+        });
+        let f = parse_weaviate_conditions(&cond).unwrap();
+        assert_eq!(f["operator"], "And");
+        let ops = f["operands"].as_array().unwrap();
+        assert_eq!(ops.len(), 2);
+        // One operand is the collapsed AND (a bare Equal), the other the OR group.
+        assert!(ops.iter().any(|o| o["operator"] == "Or"));
+        assert!(ops.iter().any(|o| o["operator"] == "Equal"));
+    }
+
+    // ── Range operators ────────────────────────────────────────────────────
+
+    #[test]
+    fn range_single_ops_map_to_weaviate_operators() {
+        for (op, wv) in [
+            ("lt", "LessThan"),
+            ("lte", "LessThanEqual"),
+            ("gt", "GreaterThan"),
+            ("gte", "GreaterThanEqual"),
+        ] {
+            let f = build_weaviate_filter("n", "range", &json!({ op: 5 })).unwrap();
+            assert_eq!(f["operator"], wv, "op={}", op);
+            assert_eq!(f["path"], json!(["n"]));
+            assert_eq!(f["valueInt"], 5); // i64 → valueInt
+        }
+    }
+
+    #[test]
+    fn range_float_bound_uses_value_number() {
+        let f = build_weaviate_filter("n", "range", &json!({"lt":1.5})).unwrap();
+        assert_eq!(f["operator"], "LessThan");
+        assert_eq!(f["valueNumber"], 1.5);
+    }
+
+    #[test]
+    fn range_two_sided_gte_lt_wraps_in_and() {
+        let f = build_weaviate_filter("n", "range", &json!({"gte":10,"lt":20})).unwrap();
+        assert_eq!(f["operator"], "And");
+        let ops = f["operands"].as_array().unwrap();
+        assert_eq!(ops.len(), 2);
+        // Emitted in fixed order lt, gt, lte, gte.
+        assert_eq!(ops[0]["operator"], "LessThan");
+        assert_eq!(ops[0]["valueInt"], 20);
+        assert_eq!(ops[1]["operator"], "GreaterThanEqual");
+        assert_eq!(ops[1]["valueInt"], 10);
+    }
+
+    #[test]
+    fn range_unknown_op_is_none() {
+        assert!(build_weaviate_filter("n", "range", &json!({"foo":5})).is_none());
+    }
+
+    #[test]
+    fn range_null_bound_is_none() {
+        assert!(
+            build_weaviate_filter("n", "range", &json!({"gte":serde_json::Value::Null})).is_none()
+        );
+    }
+
+    // ── Geo filter ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn geo_with_radius_emits_within_geo_range() {
+        let f = build_weaviate_filter("loc", "geo", &json!({"lat":20.0,"lon":10.0,"radius":500}))
+            .unwrap();
+        assert_eq!(f["operator"], "WithinGeoRange");
+        assert_eq!(f["valueGeoRange"]["geoCoordinates"]["latitude"], 20.0);
+        assert_eq!(f["valueGeoRange"]["geoCoordinates"]["longitude"], 10.0);
+        assert_eq!(f["valueGeoRange"]["distance"]["max"], 500.0);
+    }
+
+    #[test]
+    fn geo_without_radius_uses_default_1000() {
+        let f = build_weaviate_filter("loc", "geo", &json!({"lat":20.0,"lon":10.0})).unwrap();
+        assert_eq!(f["valueGeoRange"]["distance"]["max"], 1000.0);
+    }
+
+    #[test]
+    fn geo_missing_lat_or_lon_is_none() {
+        assert!(build_weaviate_filter("loc", "geo", &json!({"lon":10.0,"radius":5})).is_none());
+        assert!(build_weaviate_filter("loc", "geo", &json!({"lat":20.0,"radius":5})).is_none());
+    }
+
+    // ── Distance-metric mapping ────────────────────────────────────────────
+
+    #[test]
+    fn distance_mapping_covers_all_arms() {
+        assert_eq!(map_weaviate_distance("l2").unwrap(), "l2-squared");
+        assert_eq!(map_weaviate_distance("euclidean").unwrap(), "l2-squared");
+        assert_eq!(map_weaviate_distance("cosine").unwrap(), "cosine");
+        assert_eq!(map_weaviate_distance("angular").unwrap(), "cosine");
+        assert_eq!(map_weaviate_distance("dot").unwrap(), "dot");
+        assert_eq!(map_weaviate_distance("ip").unwrap(), "dot");
+        assert_eq!(map_weaviate_distance("COSINE").unwrap(), "cosine");
+        assert!(map_weaviate_distance("nope").is_err());
+    }
+
+    // ── Exact-match numeric / bool / non-scalar arms ───────────────────────
+
+    #[test]
+    fn exact_match_int_float_bool_use_correct_value_key() {
+        let i = build_weaviate_filter("n", "match", &json!({"value":5})).unwrap();
+        assert_eq!(i["operator"], "Equal");
+        assert_eq!(i["valueInt"], 5);
+
+        let fl = build_weaviate_filter("n", "match", &json!({"value":1.5})).unwrap();
+        assert_eq!(fl["valueNumber"], 1.5);
+
+        let b = build_weaviate_filter("flag", "match", &json!({"value":true})).unwrap();
+        assert_eq!(b["valueBoolean"], true);
+    }
+
+    #[test]
+    fn exact_match_array_value_falls_back_to_value_text() {
+        // No scalar guard: a non-scalar value falls through value_key's default
+        // (valueText) with the array as the value (documents behavior).
+        let f = build_weaviate_filter("n", "match", &json!({"value":[1,2]})).unwrap();
+        assert_eq!(f["operator"], "Equal");
+        assert_eq!(f["valueText"], json!([1, 2]));
     }
 }


### PR DESCRIPTION
## Filter-builder breadth coverage (coverage+overhead loop, PR-F)

The audit found the filter-condition builders were only partially covered per engine (match_any tested everywhere, but OR-branch, full range operators, geo, distance mapping, and numeric/bool exact-match arms under-tested). Adds **+112 focused pure-logic unit tests** across 9 engine filter builders (redis, valkey, qdrant, es, os, weaviate, milvus, pgvector, vectorsets — mongodb covered separately), each pinning the engine's **exact** emitted form. 325 unit tests total.

### Coverage added per engine
- **OR-branch** + combined AND+OR (every engine — previously almost all tests used only `and`).
- **Range operators**: lt/lte/gt/gte (exclusive/inclusive), two-sided, unknown-op→skip, null-bound→skip.
- **Geo**: with-radius, default-radius, missing lat/lon→None; and the engines that intentionally don't support geo pinned to return None.
- **Distance mapping**: cosine/dot/l2 + unknown→Err/default (behavior-preserving pure-fn extractions: `map_distance_metric`, `map_qdrant_distance`, `es_similarity`, `os_space_type`, `map_weaviate_distance`, `map_milvus_metric_type`, `map_pg_distance_ops`).
- **Exact-match** int/float/bool arms + non-scalar→None.

### Real bug found and fixed
- **vectorsets `build_range_clause`**: a null range bound (`{"range":{"gt":null}}`) emitted `.n > 0` (via `format_number(Null)→"0"`) instead of skipping it like every other engine — a filter that wrongly constrains. Fixed by guarding each bound with `is_number()`; the test that exposed it is now an active regression guard.

### Documented cross-engine inconsistencies (not fixed here — noted for follow-up)
- ES/OS/weaviate/milvus/pgvector forward a non-scalar exact-match `value` verbatim (no None guard) unlike qdrant/redis/valkey/vectorsets. Low-impact (datasets use `match.any` for lists); tests pin the actual behavior.
- qdrant `range` with an unknown op / null bound yields an empty (unconstraining) Range rather than None.

### Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean; 325 unit tests, 0 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)