### PR TITLE
test: engine parsing/conversion pure-fn coverage (RESP, memory, qdrant quant, BSON, ES/OS mapping)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -140,21 +140,7 @@ impl ElasticsearchEngine {
         let vector_size = dataset.vector_size();
 
         let dist_lower = distance.to_lowercase();
-        if dist_lower == "dot" || dist_lower == "ip" {
-            return Err(
-                "Elasticsearch does not support DOT product distance for benchmarking".to_string(),
-            );
-        }
-        if vector_size > 2048 {
-            return Err(format!(
-                "Elasticsearch does not support vector_size > 2048 (got {})",
-                vector_size
-            ));
-        }
-
-        // dot/ip already rejected above; es_similarity is only reached for the
-        // supported/unknown arms here (its dot arm exists for direct unit-testing).
-        let similarity = es_similarity(&dist_lower)?;
+        let similarity = resolve_index_similarity(&dist_lower, vector_size)?;
 
         let mut properties = serde_json::json!({
             "vector": {
@@ -424,6 +410,26 @@ fn id_to_uuid_hex(id: i64) -> String {
 fn uuid_hex_to_int(hex: &str) -> Result<i64, String> {
     let uuid = Uuid::parse_str(hex).map_err(|e| format!("Invalid UUID hex '{}': {}", hex, e))?;
     Ok(uuid.as_u128() as i64)
+}
+
+/// Validate index build parameters and resolve the `dense_vector` similarity.
+/// Extracted verbatim from `create_index` so the guard order + error strings are
+/// unit-testable without a live Elasticsearch. `dist_lower` must already be
+/// lowercased. Order matters: dot/ip is rejected first (with the DOT-specific
+/// message), then the dim cap, then the general similarity mapping.
+fn resolve_index_similarity(dist_lower: &str, vector_size: i64) -> Result<&'static str, String> {
+    if dist_lower == "dot" || dist_lower == "ip" {
+        return Err(
+            "Elasticsearch does not support DOT product distance for benchmarking".to_string(),
+        );
+    }
+    if vector_size > 2048 {
+        return Err(format!(
+            "Elasticsearch does not support vector_size > 2048 (got {})",
+            vector_size
+        ));
+    }
+    es_similarity(dist_lower)
 }
 
 /// Map a dataset distance name to the Elasticsearch `dense_vector` similarity.
@@ -1333,5 +1339,78 @@ mod tests {
             build_filter("n", "match", &serde_json::json!({"value":[1,2]})).unwrap(),
             serde_json::json!({"match":{"n":[1,2]}})
         );
+    }
+
+    // ── uuid_hex_to_int round-trip + invalid input ─────────────────────────
+    #[test]
+    fn uuid_hex_to_int_round_trips_with_id_to_uuid_hex() {
+        for id in [0i64, 1, 255, 12345, 9_999_999] {
+            let hex = id_to_uuid_hex(id);
+            assert_eq!(uuid_hex_to_int(&hex).unwrap(), id, "round-trip id={}", id);
+        }
+    }
+
+    #[test]
+    fn uuid_hex_to_int_rejects_invalid_hex() {
+        let err = uuid_hex_to_int("not-a-uuid").unwrap_err();
+        assert!(
+            err.starts_with("Invalid UUID hex 'not-a-uuid':"),
+            "err={}",
+            err
+        );
+    }
+
+    // ── extract_knn_hits: happy path + missing-field errors ────────────────
+    #[test]
+    fn extract_knn_hits_reads_id_and_score() {
+        let body = serde_json::json!({
+            "hits": {"hits": [
+                {"_id": id_to_uuid_hex(7), "_score": 0.9},
+                {"_id": id_to_uuid_hex(3), "_score": 0.5},
+            ]}
+        });
+        assert_eq!(extract_knn_hits(&body).unwrap(), vec![(7, 0.9), (3, 0.5)]);
+    }
+
+    #[test]
+    fn extract_knn_hits_missing_hits_hits_errors() {
+        let body = serde_json::json!({"hits": {"total": 0}});
+        assert_eq!(
+            extract_knn_hits(&body).unwrap_err(),
+            "Missing hits.hits in search response"
+        );
+    }
+
+    #[test]
+    fn extract_knn_hits_missing_id_errors() {
+        let body = serde_json::json!({"hits": {"hits": [{"_score": 0.9}]}});
+        assert_eq!(extract_knn_hits(&body).unwrap_err(), "Missing _id in hit");
+    }
+
+    #[test]
+    fn extract_knn_hits_missing_score_defaults_zero() {
+        // A hit without `_score` is not an error — score defaults to 0.0.
+        let body = serde_json::json!({"hits": {"hits": [{"_id": id_to_uuid_hex(4)}]}});
+        assert_eq!(extract_knn_hits(&body).unwrap(), vec![(4, 0.0)]);
+    }
+
+    // ── resolve_index_similarity: distance mapping + rejections ────────────
+    #[test]
+    fn resolve_index_similarity_maps_and_rejects() {
+        assert_eq!(resolve_index_similarity("cosine", 128).unwrap(), "cosine");
+        assert_eq!(resolve_index_similarity("l2", 2048).unwrap(), "l2_norm");
+        // dot/ip rejected with the DOT-specific message (before the dim check).
+        assert_eq!(
+            resolve_index_similarity("dot", 128).unwrap_err(),
+            "Elasticsearch does not support DOT product distance for benchmarking"
+        );
+        assert!(resolve_index_similarity("ip", 128).is_err());
+        // dim > 2048 rejected.
+        assert_eq!(
+            resolve_index_similarity("cosine", 4096).unwrap_err(),
+            "Elasticsearch does not support vector_size > 2048 (got 4096)"
+        );
+        // Unknown distance still errors (via es_similarity).
+        assert!(resolve_index_similarity("nope", 128).is_err());
     }
 }

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -1776,4 +1776,119 @@ mod tests {
         let doc = parse_mongo_conditions(&e).unwrap();
         assert_eq!(doc.get_str("color").unwrap(), "red");
     }
+
+    // ── json_to_bson: non-Int scalar + container arms ──────────────────────
+    #[test]
+    fn json_to_bson_covers_all_arms() {
+        use mongodb::bson::Bson;
+        assert_eq!(json_to_bson(&json!(null)), Bson::Null);
+        assert_eq!(json_to_bson(&json!(true)), Bson::Boolean(true));
+        assert_eq!(json_to_bson(&json!(false)), Bson::Boolean(false));
+        // Integer JSON numbers map to Int64, floats to Double.
+        assert_eq!(json_to_bson(&json!(7)), Bson::Int64(7));
+        assert_eq!(json_to_bson(&json!(1.5)), Bson::Double(1.5));
+        assert_eq!(json_to_bson(&json!("hi")), Bson::String("hi".to_string()));
+        // Array preserves order and recurses per element.
+        assert_eq!(
+            json_to_bson(&json!([1, "a"])),
+            Bson::Array(vec![Bson::Int64(1), Bson::String("a".to_string())])
+        );
+        // Object → Document with recursively-converted values.
+        match json_to_bson(&json!({"k": 2})) {
+            Bson::Document(d) => assert_eq!(d.get_i64("k").unwrap(), 2),
+            other => panic!("expected Document, got {:?}", other),
+        }
+    }
+
+    // ── metadata_value_to_bson: fallback / Labels / Geo ────────────────────
+    #[test]
+    fn metadata_int_field_unparseable_falls_back_to_string() {
+        use vector_db_benchmark::readers::metadata::MetadataValue;
+        let mut schema = HashMap::new();
+        schema.insert("size".to_string(), "int".to_string());
+        // Schema says int but the value is not a valid i64 → keep the raw string.
+        let v = metadata_value_to_bson(
+            "size",
+            &MetadataValue::String("not-a-number".into()),
+            &schema,
+        );
+        assert_eq!(v.as_str(), Some("not-a-number"));
+    }
+
+    #[test]
+    fn metadata_labels_become_bson_string_array() {
+        use mongodb::bson::Bson;
+        use vector_db_benchmark::readers::metadata::MetadataValue;
+        let schema = HashMap::new();
+        let v = metadata_value_to_bson(
+            "tags",
+            &MetadataValue::Labels(vec!["a".into(), "b".into()]),
+            &schema,
+        );
+        assert_eq!(
+            v,
+            Bson::Array(vec![Bson::String("a".into()), Bson::String("b".into()),])
+        );
+    }
+
+    #[test]
+    fn metadata_geo_becomes_geojson_point() {
+        use vector_db_benchmark::readers::metadata::MetadataValue;
+        let schema = HashMap::new();
+        let v = metadata_value_to_bson(
+            "loc",
+            &MetadataValue::Geo {
+                lon: 10.0,
+                lat: 20.0,
+            },
+            &schema,
+        );
+        // GeoJSON Point: {type:"Point", coordinates:[lon, lat]} (lon first).
+        let expected = mongodb::bson::Bson::Document(doc! {
+            "type": "Point",
+            "coordinates": [10.0f64, 20.0f64],
+        });
+        assert_eq!(v, expected);
+    }
+
+    // ── build_uri: passthrough / auth / no-auth ────────────────────────────
+    // Sequenced in ONE test so the shared MONGODB_USER/PASSWORD env vars are not
+    // mutated concurrently by parallel test threads (no serial_test dep here).
+    #[test]
+    fn build_uri_covers_passthrough_auth_and_noauth() {
+        let saved_user = std::env::var("MONGODB_USER").ok();
+        let saved_pass = std::env::var("MONGODB_PASSWORD").ok();
+
+        // Full mongodb:// URI is passed through verbatim (env ignored).
+        std::env::set_var("MONGODB_USER", "u");
+        std::env::set_var("MONGODB_PASSWORD", "p");
+        assert_eq!(
+            build_uri("mongodb+srv://cluster.example.net/db", 27017),
+            "mongodb+srv://cluster.example.net/db"
+        );
+
+        // user + password present → credentialled URI.
+        assert_eq!(
+            build_uri("host1", 27018),
+            "mongodb://u:p@host1:27018/?directConnection=true"
+        );
+
+        // No credentials → plain URI.
+        std::env::remove_var("MONGODB_USER");
+        std::env::remove_var("MONGODB_PASSWORD");
+        assert_eq!(
+            build_uri("host2", 27019),
+            "mongodb://host2:27019/?directConnection=true"
+        );
+
+        // Restore the environment for any other test that may read it.
+        match saved_user {
+            Some(v) => std::env::set_var("MONGODB_USER", v),
+            None => std::env::remove_var("MONGODB_USER"),
+        }
+        match saved_pass {
+            Some(v) => std::env::set_var("MONGODB_PASSWORD", v),
+            None => std::env::remove_var("MONGODB_PASSWORD"),
+        }
+    }
 }

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -138,20 +138,7 @@ impl OpenSearchEngine {
         let vector_size = dataset.vector_size();
 
         let dist_lower = distance.to_lowercase();
-        if dist_lower == "dot" || dist_lower == "ip" {
-            return Err("OpenSearch does not support DOT product distance".to_string());
-        }
-        if vector_size > 2048 {
-            return Err(format!(
-                "OpenSearch does not support vector_size > 2048 (got {})",
-                vector_size
-            ));
-        }
-
-        // Map distance metric (OpenSearch uses different names than ES).
-        // dot/ip already rejected above; os_space_type is only reached for the
-        // supported/unknown arms here (its dot arm exists for direct unit-testing).
-        let space_type = os_space_type(&dist_lower)?;
+        let space_type = resolve_index_space_type(&dist_lower, vector_size)?;
 
         // Build properties with knn_vector type
         let mut properties = serde_json::json!({
@@ -481,6 +468,23 @@ fn id_to_uuid_hex(id: i64) -> String {
 fn uuid_hex_to_int(hex: &str) -> Result<i64, String> {
     let uuid = Uuid::parse_str(hex).map_err(|e| format!("Invalid UUID hex '{}': {}", hex, e))?;
     Ok(uuid.as_u128() as i64)
+}
+
+/// Validate index build parameters and resolve the knn `space_type`. Extracted
+/// verbatim from `create_index` so the guard order + error strings are unit-
+/// testable without a live OpenSearch. `dist_lower` must already be lowercased.
+/// dot/ip is rejected first, then the dim cap, then the general mapping.
+fn resolve_index_space_type(dist_lower: &str, vector_size: i64) -> Result<&'static str, String> {
+    if dist_lower == "dot" || dist_lower == "ip" {
+        return Err("OpenSearch does not support DOT product distance".to_string());
+    }
+    if vector_size > 2048 {
+        return Err(format!(
+            "OpenSearch does not support vector_size > 2048 (got {})",
+            vector_size
+        ));
+    }
+    os_space_type(dist_lower)
 }
 
 /// Map a dataset distance name to the OpenSearch knn `space_type`. `dot`/`ip`
@@ -1292,5 +1296,78 @@ mod tests {
             build_filter("n", "match", &json!({"value":[1,2]})).unwrap(),
             json!({"match":{"n":[1,2]}})
         );
+    }
+
+    // ── uuid_hex_to_int round-trip + invalid input ─────────────────────────
+    #[test]
+    fn uuid_hex_to_int_round_trips_with_id_to_uuid_hex() {
+        for id in [0i64, 1, 255, 12345, 9_999_999] {
+            let hex = id_to_uuid_hex(id);
+            assert_eq!(uuid_hex_to_int(&hex).unwrap(), id, "round-trip id={}", id);
+        }
+    }
+
+    #[test]
+    fn uuid_hex_to_int_rejects_invalid_hex() {
+        let err = uuid_hex_to_int("not-a-uuid").unwrap_err();
+        assert!(
+            err.starts_with("Invalid UUID hex 'not-a-uuid':"),
+            "err={}",
+            err
+        );
+    }
+
+    // ── extract_knn_hits: happy path + missing-field errors ────────────────
+    #[test]
+    fn extract_knn_hits_reads_id_and_score() {
+        // Trimmed hits carry the id under fields._id[0].
+        let body = json!({
+            "hits": {"hits": [
+                {"fields": {"_id": [id_to_uuid_hex(7)]}, "_score": 0.9},
+                {"fields": {"_id": [id_to_uuid_hex(3)]}, "_score": 0.5},
+            ]}
+        });
+        assert_eq!(extract_knn_hits(&body).unwrap(), vec![(7, 0.9), (3, 0.5)]);
+    }
+
+    #[test]
+    fn extract_knn_hits_missing_hits_hits_errors() {
+        let body = json!({"hits": {"total": 0}});
+        assert_eq!(
+            extract_knn_hits(&body).unwrap_err(),
+            "Missing hits.hits in search response"
+        );
+    }
+
+    #[test]
+    fn extract_knn_hits_missing_id_errors() {
+        let body = json!({"hits": {"hits": [{"_score": 0.9}]}});
+        assert_eq!(extract_knn_hits(&body).unwrap_err(), "Missing _id in hit");
+    }
+
+    #[test]
+    fn extract_knn_hits_missing_score_defaults_zero() {
+        let body = json!({"hits": {"hits": [{"_id": id_to_uuid_hex(4)}]}});
+        assert_eq!(extract_knn_hits(&body).unwrap(), vec![(4, 0.0)]);
+    }
+
+    // ── resolve_index_space_type: distance mapping + rejections ────────────
+    #[test]
+    fn resolve_index_space_type_maps_and_rejects() {
+        assert_eq!(
+            resolve_index_space_type("cosine", 128).unwrap(),
+            "cosinesimil"
+        );
+        assert_eq!(resolve_index_space_type("l2", 2048).unwrap(), "l2");
+        assert_eq!(
+            resolve_index_space_type("dot", 128).unwrap_err(),
+            "OpenSearch does not support DOT product distance"
+        );
+        assert!(resolve_index_space_type("ip", 128).is_err());
+        assert_eq!(
+            resolve_index_space_type("cosine", 4096).unwrap_err(),
+            "OpenSearch does not support vector_size > 2048 (got 4096)"
+        );
+        assert!(resolve_index_space_type("nope", 128).is_err());
     }
 }

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -263,40 +263,7 @@ impl QdrantEngine {
         }
 
         if let Some(q) = self.collection_params_extra.get("quantization_config") {
-            let quantization = if let Some(s) = q.get("scalar") {
-                let qtype = match s.get("type").and_then(|v| v.as_str()) {
-                    Some("int8") | None => QuantizationType::Int8,
-                    Some(other) => {
-                        return Err(format!("Unsupported scalar quantization type: {}", other))
-                    }
-                };
-                Some(Quantization::Scalar(ScalarQuantization {
-                    r#type: qtype.into(),
-                    quantile: s.get("quantile").and_then(|v| v.as_f64()).map(|v| v as f32),
-                    always_ram: s.get("always_ram").and_then(|v| v.as_bool()),
-                }))
-            } else if let Some(p) = q.get("product") {
-                let compression = match p.get("compression").and_then(|v| v.as_str()) {
-                    Some(s) => parse_compression_ratio(s)?,
-                    None => {
-                        return Err(
-                            "Product quantization requires a `compression` value".to_string()
-                        )
-                    }
-                };
-                Some(Quantization::Product(ProductQuantization {
-                    compression: compression.into(),
-                    always_ram: p.get("always_ram").and_then(|v| v.as_bool()),
-                }))
-            } else {
-                q.get("binary").map(|b| {
-                    Quantization::Binary(BinaryQuantization {
-                        always_ram: b.get("always_ram").and_then(|v| v.as_bool()),
-                        ..Default::default()
-                    })
-                })
-            };
-            if let Some(quantization) = quantization {
+            if let Some(quantization) = build_quantization(q)? {
                 create_builder = create_builder.quantization_config(quantization);
             }
         }
@@ -814,6 +781,41 @@ fn parse_compression_ratio(s: &str) -> Result<CompressionRatio, String> {
             "Unsupported product quantization compression: {} (expected one of x4, x8, x16, x32, x64)",
             other
         )),
+    }
+}
+
+/// Translate a `quantization_config` JSON object into a Qdrant `Quantization`.
+/// Recognizes `scalar` (int8 default, rejects other types), `product` (requires
+/// a valid `compression`), and `binary`. Returns `Ok(None)` when none of those
+/// keys are present. Extracted verbatim from `apply_optimizers_and_quantization`
+/// so the branch logic is unit-testable without a live Qdrant.
+fn build_quantization(q: &serde_json::Value) -> Result<Option<Quantization>, String> {
+    if let Some(s) = q.get("scalar") {
+        let qtype = match s.get("type").and_then(|v| v.as_str()) {
+            Some("int8") | None => QuantizationType::Int8,
+            Some(other) => return Err(format!("Unsupported scalar quantization type: {}", other)),
+        };
+        Ok(Some(Quantization::Scalar(ScalarQuantization {
+            r#type: qtype.into(),
+            quantile: s.get("quantile").and_then(|v| v.as_f64()).map(|v| v as f32),
+            always_ram: s.get("always_ram").and_then(|v| v.as_bool()),
+        })))
+    } else if let Some(p) = q.get("product") {
+        let compression = match p.get("compression").and_then(|v| v.as_str()) {
+            Some(s) => parse_compression_ratio(s)?,
+            None => return Err("Product quantization requires a `compression` value".to_string()),
+        };
+        Ok(Some(Quantization::Product(ProductQuantization {
+            compression: compression.into(),
+            always_ram: p.get("always_ram").and_then(|v| v.as_bool()),
+        })))
+    } else {
+        Ok(q.get("binary").map(|b| {
+            Quantization::Binary(BinaryQuantization {
+                always_ram: b.get("always_ram").and_then(|v| v.as_bool()),
+                ..Default::default()
+            })
+        }))
     }
 }
 
@@ -1651,5 +1653,109 @@ rest_responses_total{method=\"GET\"} 42
     #[test]
     fn exact_match_array_value_is_none() {
         assert!(build_qdrant_filter("n", "match", &json!({"value":[1,2]})).is_none());
+    }
+
+    // ── parse_qdrant_conditions edge cases + subfilter builder ──────────────
+    use super::build_qdrant_subfilters;
+
+    #[test]
+    fn empty_conditions_object_is_none() {
+        assert!(parse_qdrant_conditions(&json!({})).is_none());
+    }
+
+    #[test]
+    fn and_only_populates_must_not_should() {
+        let cond = json!({"and":[
+            {"a":{"match":{"value":"x"}}},
+            {"b":{"match":{"value":"y"}}},
+        ]});
+        let filter = parse_qdrant_conditions(&cond).unwrap();
+        assert_eq!(filter.must.len(), 2, "and → 2 must entries");
+        assert!(filter.should.is_empty(), "and-only leaves should empty");
+    }
+
+    #[test]
+    fn subfilters_build_match_any_keyword_list() {
+        // A keyword match_any list → one Condition carrying a keyword Match.
+        let entries = vec![json!({"cat":{"match":{"any":["a","b"]}}})];
+        let conds = build_qdrant_subfilters(&entries);
+        assert_eq!(conds.len(), 1);
+        let fc = field_condition(&conds[0]);
+        assert_eq!(fc.key, "cat");
+        assert!(
+            fc.r#match.is_some(),
+            "match_any keyword list should set a Match"
+        );
+    }
+
+    // ── Quantization config builder ─────────────────────────────────────────
+    use super::build_quantization;
+    use qdrant_client::qdrant::quantization_config::Quantization;
+    use qdrant_client::qdrant::QuantizationType;
+
+    #[test]
+    fn quantization_scalar_int8_happy_path() {
+        let q = build_quantization(
+            &json!({"scalar":{"type":"int8","quantile":0.99,"always_ram":true}}),
+        )
+        .unwrap()
+        .unwrap();
+        match q {
+            Quantization::Scalar(sq) => {
+                assert_eq!(sq.r#type, i32::from(QuantizationType::Int8));
+                assert_eq!(sq.quantile, Some(0.99));
+                assert_eq!(sq.always_ram, Some(true));
+            }
+            other => panic!("expected Scalar, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn quantization_scalar_defaults_type_to_int8() {
+        // Missing `type` defaults to Int8 (not an error).
+        let q = build_quantization(&json!({"scalar":{}})).unwrap().unwrap();
+        assert!(
+            matches!(q, Quantization::Scalar(sq) if sq.r#type == i32::from(QuantizationType::Int8))
+        );
+    }
+
+    #[test]
+    fn quantization_scalar_bogus_type_errors() {
+        let err = build_quantization(&json!({"scalar":{"type":"int4"}})).unwrap_err();
+        assert_eq!(err, "Unsupported scalar quantization type: int4");
+    }
+
+    #[test]
+    fn quantization_product_happy_path() {
+        let q = build_quantization(&json!({"product":{"compression":"x8","always_ram":false}}))
+            .unwrap()
+            .unwrap();
+        match q {
+            Quantization::Product(pq) => {
+                assert_eq!(pq.compression, i32::from(CompressionRatio::X8));
+                assert_eq!(pq.always_ram, Some(false));
+            }
+            other => panic!("expected Product, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn quantization_product_without_compression_errors() {
+        let err = build_quantization(&json!({"product":{}})).unwrap_err();
+        assert_eq!(err, "Product quantization requires a `compression` value");
+    }
+
+    #[test]
+    fn quantization_binary_happy_path() {
+        let q = build_quantization(&json!({"binary":{"always_ram":true}}))
+            .unwrap()
+            .unwrap();
+        assert!(matches!(q, Quantization::Binary(bq) if bq.always_ram == Some(true)));
+    }
+
+    #[test]
+    fn quantization_none_when_no_known_key() {
+        assert!(build_quantization(&json!({})).unwrap().is_none());
+        assert!(build_quantization(&json!({"unknown":1})).unwrap().is_none());
     }
 }

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -748,6 +748,17 @@ fn redis_value_to_json(val: &redis::Value) -> serde_json::Value {
     }
 }
 
+/// Parse the `used_memory:` value (bytes) out of an `INFO memory` text block.
+/// Returns 0 when the line is absent or unparseable. The `used_memory:` prefix
+/// is exact, so it never matches sibling keys like `used_memory_rss:`.
+fn parse_used_memory(info: &str) -> i64 {
+    info.lines()
+        .find(|l| l.starts_with("used_memory:"))
+        .and_then(|l| l.strip_prefix("used_memory:"))
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(0)
+}
+
 // ── Condition parser ─────────────────────────────────────────────────────
 // Mirrors Python v0/engine/clients/redis/parser.py RedisConditionParser.
 // Converts JSON filter conditions into RediSearch query filter syntax.
@@ -2079,12 +2090,7 @@ impl Engine for RedisEngine {
 
         // Get used_memory from INFO memory (returns bulk string, parse key:value lines)
         let info_str: String = redis::cmd("INFO").arg("memory").query(&mut conn).ok()?;
-        let used_memory: i64 = info_str
-            .lines()
-            .find(|l| l.starts_with("used_memory:"))
-            .and_then(|l| l.strip_prefix("used_memory:"))
-            .and_then(|v| v.trim().parse().ok())
-            .unwrap_or(0);
+        let used_memory: i64 = parse_used_memory(&info_str);
 
         // Get FT.INFO for index stats
         let ft_info: Option<serde_json::Value> = redis::cmd("FT.INFO")
@@ -2550,6 +2556,100 @@ mod tests {
         // Non-exhaustive/other variant → non-empty JSON string, never dropped.
         let okay = redis_value_to_json(&Value::Okay);
         assert!(okay.as_str().map(|s| !s.is_empty()).unwrap_or(false));
+    }
+
+    #[test]
+    fn redis_value_to_json_covers_remaining_scalar_arms() {
+        // Arms not exercised by the scalar/fallthrough test above.
+        assert_eq!(redis_value_to_json(&Value::Nil), serde_json::Value::Null);
+        assert_eq!(
+            redis_value_to_json(&Value::Double(1.5)),
+            serde_json::json!(1.5)
+        );
+        assert_eq!(
+            redis_value_to_json(&Value::Boolean(true)),
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            redis_value_to_json(&Value::SimpleString("PONG".into())),
+            serde_json::json!("PONG")
+        );
+        // Invalid UTF-8 BulkString → "<N bytes>" placeholder (never a panic/drop).
+        assert_eq!(
+            redis_value_to_json(&Value::BulkString(vec![0xff, 0xfe])),
+            serde_json::json!("<2 bytes>")
+        );
+        // Map with a string key → JSON object keyed by that string.
+        assert_eq!(
+            redis_value_to_json(&Value::Map(vec![(bulk("k"), Value::Int(9))])),
+            serde_json::json!({"k": 9})
+        );
+    }
+
+    #[test]
+    fn value_as_i64_reads_simplestring_id() {
+        use super::value_as_i64;
+        // Redis-8 RESP2 can return the doc id as a SimpleString (e.g. "7").
+        assert_eq!(value_as_i64(&Value::SimpleString("7".into())), 7);
+        // Bulk/Int arms already exercised via parse_ft_search_response; pin them too.
+        assert_eq!(value_as_i64(&bulk("42")), 42);
+        assert_eq!(value_as_i64(&Value::Int(5)), 5);
+        // Unparseable / unsupported → 0.
+        assert_eq!(value_as_i64(&Value::SimpleString("x".into())), 0);
+        assert_eq!(value_as_i64(&Value::Nil), 0);
+    }
+
+    #[test]
+    fn parse_ft_search_resp2_drops_trailing_id_without_fields() {
+        // Odd trailing element: [count, id] with no field block → the dangling id
+        // is dropped (no doc emitted), it is NOT surfaced with a zero score.
+        let resp = Value::Array(vec![Value::Int(1), bulk("5")]);
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_ft_search_resp3_skips_non_map_doc_entries() {
+        // A non-map entry in `results` is skipped; sibling map docs still parse.
+        let doc = Value::Map(vec![
+            (bulk("id"), bulk("7")),
+            (
+                bulk("extra_attributes"),
+                Value::Map(vec![(bulk("vector_score"), bulk("0.25"))]),
+            ),
+        ]);
+        let resp = Value::Map(vec![(bulk("results"), Value::Array(vec![Value::Nil, doc]))]);
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(7, 0.25)]);
+    }
+
+    #[test]
+    fn parse_ft_search_resp3_id_parse_failure_yields_zero_id_doc() {
+        // A map doc whose `id` is unparseable is NOT skipped: id falls back to 0
+        // and the doc is still emitted (score parsed independently).
+        let resp = Value::Map(vec![(
+            bulk("results"),
+            Value::Array(vec![Value::Map(vec![
+                (bulk("id"), bulk("not-a-number")),
+                (
+                    bulk("extra_attributes"),
+                    Value::Map(vec![(bulk("vector_score"), bulk("0.5"))]),
+                ),
+            ])]),
+        )]);
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(0, 0.5)]);
+    }
+
+    #[test]
+    fn parse_used_memory_parses_real_info_block() {
+        use super::parse_used_memory;
+        let info = "# Memory\r\nused_memory:1048576\r\nused_memory_rss:2097152\r\nused_memory_peak:3000000\r\n";
+        // Exact-prefix match: picks used_memory, never used_memory_rss/_peak.
+        assert_eq!(parse_used_memory(info), 1_048_576);
+        // Missing line → 0.
+        assert_eq!(parse_used_memory("# Memory\r\nmaxmemory:0\r\n"), 0);
+        // Malformed value → 0.
+        assert_eq!(parse_used_memory("used_memory:not_a_number\r\n"), 0);
+        // A block with ONLY used_memory_rss must not match the used_memory prefix.
+        assert_eq!(parse_used_memory("used_memory_rss:999\r\n"), 0);
     }
 
     // ── OR-branch of the condition parser ──────────────────────────────────

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -818,6 +818,17 @@ fn redis_value_to_json(val: &redis::Value) -> serde_json::Value {
     }
 }
 
+/// Parse the `used_memory:` value (bytes) out of an `INFO memory` text block.
+/// Returns 0 when the line is absent or unparseable. The `used_memory:` prefix
+/// is exact, so it never matches sibling keys like `used_memory_rss:`.
+fn parse_used_memory(info: &str) -> i64 {
+    info.lines()
+        .find(|l| l.starts_with("used_memory:"))
+        .and_then(|l| l.strip_prefix("used_memory:"))
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(0)
+}
+
 // ── Condition parser ─────────────────────────────────────────────────────
 // Converts JSON filter conditions into Valkey Search query filter syntax.
 // Note: Valkey Search does not support $param inside TAG {…} brackets,
@@ -2144,12 +2155,7 @@ impl Engine for ValkeyEngine {
         let mut conn = self.get_connection().ok()?;
 
         let info_str: String = redis::cmd("INFO").arg("memory").query(&mut conn).ok()?;
-        let used_memory: i64 = info_str
-            .lines()
-            .find(|l| l.starts_with("used_memory:"))
-            .and_then(|l| l.strip_prefix("used_memory:"))
-            .and_then(|v| v.trim().parse().ok())
-            .unwrap_or(0);
+        let used_memory: i64 = parse_used_memory(&info_str);
 
         let ft_info: Option<serde_json::Value> = redis::cmd("FT.INFO")
             .arg("idx")
@@ -2509,6 +2515,95 @@ mod tests {
             "Okay should map to a non-empty JSON string, got {:?}",
             okay
         );
+    }
+
+    #[test]
+    fn redis_value_to_json_covers_double_simplestring_and_bad_utf8() {
+        // Arms not exercised by the test above.
+        assert_eq!(
+            redis_value_to_json(&Value::Double(1.5)),
+            serde_json::json!(1.5)
+        );
+        assert_eq!(
+            redis_value_to_json(&Value::SimpleString("PONG".into())),
+            serde_json::json!("PONG")
+        );
+        // Invalid UTF-8 BulkString → "<N bytes>" placeholder (never a panic/drop).
+        assert_eq!(
+            redis_value_to_json(&Value::BulkString(vec![0xff, 0xfe])),
+            serde_json::json!("<2 bytes>")
+        );
+    }
+
+    #[test]
+    fn value_as_i64_reads_simplestring_id() {
+        use super::value_as_i64;
+        // Redis-8 RESP2 can return the doc id as a SimpleString (e.g. "7").
+        assert_eq!(value_as_i64(&Value::SimpleString("7".into())), 7);
+        assert_eq!(value_as_i64(&bulk("42")), 42);
+        assert_eq!(value_as_i64(&Value::Int(5)), 5);
+        assert_eq!(value_as_i64(&Value::SimpleString("x".into())), 0);
+        assert_eq!(value_as_i64(&Value::Nil), 0);
+    }
+
+    #[test]
+    fn parse_ft_search_resp2_drops_trailing_id_without_fields() {
+        // Odd trailing element: [count, id] with no field block → dangling id
+        // dropped (no doc emitted), NOT surfaced with a zero score.
+        let resp = Value::Array(vec![Value::Int(1), bulk("5")]);
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_ft_search_resp3_skips_non_map_doc_entries() {
+        // A non-map entry in `results` is skipped; sibling map docs still parse.
+        let doc = Value::Map(vec![
+            (bulk("id"), bulk("7")),
+            (
+                bulk("extra_attributes"),
+                Value::Map(vec![(bulk("vector_score"), bulk("0.25"))]),
+            ),
+        ]);
+        let resp = Value::Map(vec![(bulk("results"), Value::Array(vec![Value::Nil, doc]))]);
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(7, 0.25)]);
+    }
+
+    #[test]
+    fn parse_ft_search_resp3_id_parse_failure_yields_zero_id_doc() {
+        // A map doc whose `id` is unparseable is NOT skipped: id falls back to 0
+        // and the doc is still emitted (score parsed independently).
+        let resp = Value::Map(vec![(
+            bulk("results"),
+            Value::Array(vec![Value::Map(vec![
+                (bulk("id"), bulk("not-a-number")),
+                (
+                    bulk("extra_attributes"),
+                    Value::Map(vec![(bulk("vector_score"), bulk("0.5"))]),
+                ),
+            ])]),
+        )]);
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(0, 0.5)]);
+    }
+
+    #[test]
+    fn parse_ft_search_resp3_missing_results_key_is_empty() {
+        // RESP3 map with no `results` key → no hits.
+        let resp = Value::Map(vec![(bulk("total_results"), Value::Int(0))]);
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_used_memory_parses_real_info_block() {
+        use super::parse_used_memory;
+        let info = "# Memory\r\nused_memory:1048576\r\nused_memory_rss:2097152\r\nused_memory_peak:3000000\r\n";
+        // Exact-prefix match: picks used_memory, never used_memory_rss/_peak.
+        assert_eq!(parse_used_memory(info), 1_048_576);
+        // Missing line → 0.
+        assert_eq!(parse_used_memory("# Memory\r\nmaxmemory:0\r\n"), 0);
+        // Malformed value → 0.
+        assert_eq!(parse_used_memory("used_memory:not_a_number\r\n"), 0);
+        // A block with ONLY used_memory_rss must not match the used_memory prefix.
+        assert_eq!(parse_used_memory("used_memory_rss:999\r\n"), 0);
     }
 
     // ── OR-branch of the condition parser ──────────────────────────────────


### PR DESCRIPTION
## Engine pure-fn coverage (coverage+overhead loop, PR-G2)

Fills the audit's low-coverage engine parsing/conversion pure functions (the filter builders were covered in #115; the timed-window paths in #108–#114). +42 unit tests, behavior-preserving extractions only.

- **redis/valkey value + memory**: `redis_value_to_json` Nil/Double/Boolean/SimpleString/non-UTF8-BulkString/Map arms; extracted `parse_used_memory` (INFO `used_memory:` — pins that it does NOT match `used_memory_rss:`); RESP `value_as_i64` SimpleString arm; RESP2 trailing-id-drop; RESP3 non-map/missing-`results` handling.
- **qdrant**: extracted `build_quantization` (scalar/binary/product happy paths + bogus-type/missing-compression `Err`s with exact messages); `parse_qdrant_conditions` `{}`/and/subfilter. **26% → 32%**.
- **mongodb**: `json_to_bson` Bool/Double/Null/Array/Object; `metadata_value_to_bson` String-fallback/Labels/Geo (`{type:"Point",coordinates:[lon,lat]}`); `build_uri` passthrough/auth/no-auth. **14% → 21%**.
- **es/os**: extracted `resolve_index_similarity`/`resolve_index_space_type` (dot/ip + dim>2048 rejections with exact messages); `extract_knn_hits` error paths; `uuid_hex_to_int` round-trip + invalid. **~45→52% / 31→38%**.

No bugs found. One behavior asserted as-is and flagged: RESP3 with an unparseable doc id emits `(0, score)` rather than skipping (documented, not a regression).

### Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean; 398 bin tests pass, 0 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)