### PR TITLE
fix(es,os): apply full-text match.text filter instead of running unfiltered (fixes #120)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -530,10 +530,19 @@ fn build_filter(
             if let Some(any) = criteria.get("any").and_then(|v| v.as_array()) {
                 return Some(serde_json::json!({"terms": {field_name: any}}));
             }
-            // follow-up: full-text `{"match": {"text": …}}` conditions are dropped
-            // here (no "value" key → None). This is PRE-EXISTING and shared with
-            // OpenSearch's build_filter; fixing text filtering in both is out of
-            // scope for this PR.
+            // Full-text `{"match": {"text": …}}` conditions: emit an ES `match`
+            // query against the analyzed `text` field. `match` tokenizes the
+            // query the same way the field is analyzed, so it matches docs
+            // CONTAINING the term(s) — aligning with the tokenized semantics
+            // redis uses via `@field:($tok)` and the ground truth in
+            // `write_fulltext_project` (docs whose body CONTAINS "quick"). We use
+            // `match` (not `match_phrase`) because the fixture filters on single
+            // tokens; dropping this clause would leave `bool.must:[]`, which ES
+            // treats as match-ALL — silently running the kNN query UNFILTERED
+            // while recall is scored against the filtered ground truth (#120).
+            if let Some(text) = criteria.get("text") {
+                return Some(serde_json::json!({"match": {field_name: text}}));
+            }
             let value = criteria.get("value")?;
             Some(serde_json::json!({"match": {field_name: value}}))
         }
@@ -1057,6 +1066,29 @@ mod tests {
         )
         .unwrap();
         assert_eq!(c, serde_json::json!({"terms": {"color": ["red", "blue"]}}));
+    }
+
+    // #120: a full-text `{"match": {"text": …}}` condition must emit an analyzed
+    // `match` query — NOT be dropped. Dropping it leaves `bool.must:[]`, which ES
+    // treats as match-ALL, silently running the kNN query UNFILTERED.
+    #[test]
+    fn test_match_text_emits_match_query() {
+        let c = build_filter("body", "match", &serde_json::json!({"text": "quick"})).unwrap();
+        assert_eq!(c, serde_json::json!({"match": {"body": "quick"}}));
+    }
+
+    #[test]
+    fn es_text_only_condition_not_dropped() {
+        // `{"and":[{"body":{"match":{"text":"quick"}}}]}` — the exact fixture
+        // condition from `write_fulltext_project`. Must yield a non-empty
+        // `bool.must` containing the `match` clause (was None → dropped → #120).
+        let conditions = serde_json::json!({"and": [{"body": {"match": {"text": "quick"}}}]});
+        let parsed =
+            parse_es_conditions(&conditions).expect("text-only filter must not be dropped");
+        assert_eq!(
+            parsed,
+            serde_json::json!({"bool": {"must": [{"match": {"body": "quick"}}]}})
+        );
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -577,6 +577,20 @@ fn build_filter(
             if let Some(any) = criteria.get("any").and_then(|v| v.as_array()) {
                 return Some(serde_json::json!({"terms": {field_name: any}}));
             }
+            // Full-text `{"match": {"text": …}}` conditions: emit an OpenSearch
+            // `match` query against the analyzed `text` field. `match` tokenizes
+            // the query the same way the field is analyzed, so it matches docs
+            // CONTAINING the term(s) — aligning with the tokenized semantics
+            // redis uses via `@field:($tok)` and the ground truth in
+            // `write_fulltext_project` (docs whose body CONTAINS "quick"). We use
+            // `match` (not `match_phrase`) because the fixture filters on single
+            // tokens; dropping this clause would leave `bool.must:[]`, which
+            // OpenSearch treats as match-ALL — silently running the kNN query
+            // UNFILTERED while recall is scored against filtered ground truth
+            // (#120).
+            if let Some(text) = criteria.get("text") {
+                return Some(serde_json::json!({"match": {field_name: text}}));
+            }
             let value = criteria.get("value")?;
             Some(serde_json::json!({"match": {field_name: value}}))
         }
@@ -1096,6 +1110,29 @@ mod tests {
     fn test_match_exact_value_still_works() {
         let c = build_filter("color", "match", &json!({"value": "red"})).unwrap();
         assert_eq!(c, json!({"match": {"color": "red"}}));
+    }
+
+    // #120: a full-text `{"match": {"text": …}}` condition must emit an analyzed
+    // `match` query — NOT be dropped. Dropping it leaves `bool.must:[]`, which
+    // OpenSearch treats as match-ALL, silently running the kNN query UNFILTERED.
+    #[test]
+    fn test_match_text_emits_match_query() {
+        let c = build_filter("body", "match", &json!({"text": "quick"})).unwrap();
+        assert_eq!(c, json!({"match": {"body": "quick"}}));
+    }
+
+    #[test]
+    fn os_text_only_condition_not_dropped() {
+        // `{"and":[{"body":{"match":{"text":"quick"}}}]}` — the exact fixture
+        // condition from `write_fulltext_project`. Must yield a non-empty
+        // `bool.must` containing the `match` clause (was None → dropped → #120).
+        let conditions = json!({"and": [{"body": {"match": {"text": "quick"}}}]});
+        let parsed =
+            parse_os_conditions(&conditions).expect("text-only filter must not be dropped");
+        assert_eq!(
+            parsed,
+            json!({"bool": {"must": [{"match": {"body": "quick"}}]}})
+        );
     }
 
     // Regression for qdrant/vector-db-benchmark#167: the filter must land inside

--- a/tests/integration_elasticsearch.rs
+++ b/tests/integration_elasticsearch.rs
@@ -948,3 +948,46 @@ fn test_binary_elasticsearch_match_any() {
     println!("es match_any recall={:.3}", recall);
     assert!(recall >= 0.9, "es match_any recall {:.3} < 0.9", recall);
 }
+
+/// End-to-end full-text filter (#120): the query carries a single
+/// `{"body":{"match":{"text":"quick"}}}` condition and ground truth is
+/// brute-forced over only the docs whose body CONTAINS "quick". Before the fix,
+/// ES dropped the text clause and ran the kNN query UNFILTERED, so recall was
+/// scored against the filtered ground truth and collapsed. A high recall here
+/// proves the analyzed `match` filter arm is applied end-to-end.
+#[test]
+fn test_binary_elasticsearch_fulltext() {
+    wait_for_elasticsearch();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "es-text", "engine": "elasticsearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_fulltext_project("text-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(
+        proj.matching_docs >= proj.top,
+        "fixture must have >= top matching docs (got {})",
+        proj.matching_docs
+    );
+
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "es-text",
+            "text-test",
+            "127.0.0.1",
+            &[
+                ("ELASTIC_PORT", "9201"),
+                ("ELASTIC_INDEX", "bench_fulltext")
+            ],
+        ),
+        "es fulltext run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, "es-text");
+    println!("es fulltext recall={:.3}", recall);
+    assert!(recall >= 0.9, "es fulltext recall {:.3} < 0.9", recall);
+}

--- a/tests/integration_opensearch.rs
+++ b/tests/integration_opensearch.rs
@@ -731,3 +731,53 @@ fn test_binary_opensearch_match_any() {
         recall
     );
 }
+
+/// End-to-end full-text filter (#120): the query carries a single
+/// `{"body":{"match":{"text":"quick"}}}` condition and ground truth is
+/// brute-forced over only the docs whose body CONTAINS "quick". Before the fix,
+/// OpenSearch dropped the text clause and ran the kNN query UNFILTERED, so
+/// recall was scored against the filtered ground truth and collapsed. A high
+/// recall here proves the analyzed `match` filter arm is applied end-to-end.
+#[test]
+fn test_binary_opensearch_fulltext() {
+    wait_for_opensearch();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "os-text", "engine": "opensearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_fulltext_project("text-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(
+        proj.matching_docs >= proj.top,
+        "fixture must have >= top matching docs (got {})",
+        proj.matching_docs
+    );
+
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "os-text",
+            "text-test",
+            // Explicit http:// scheme: the OpenSearch engine defaults to https
+            // for a bare host, but the CI container runs plaintext http (security
+            // plugin disabled).
+            "http://127.0.0.1",
+            &[
+                ("OPENSEARCH_PORT", "9202"),
+                ("OPENSEARCH_INDEX", "bench_fulltext"),
+            ],
+        ),
+        "opensearch fulltext run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, "os-text");
+    println!("opensearch fulltext recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "opensearch fulltext recall {:.3} < 0.9",
+        recall
+    );
+}


### PR DESCRIPTION
## Fixes #120 — ES/OS full-text filters silently ran unfiltered

`build_filter` in `elasticsearch.rs` / `opensearch.rs` handled only `match.any` (terms) and `match.value` (match); a full-text condition `{"<field>":{"match":{"text":"..."}}}` returned `None`. For a text-only filter that collapsed `bool.must` to empty, so ES/OS treated it as match-**ALL** and ran the kNN query **unfiltered**, while recall was scored against the text-filtered ground truth → **inflated recall/QPS**. (Same failure class as the silent-unfiltered bugs fixed in #107, for the `text` datatype on these two engines.)

## Fix
Add a `text` arm emitting an analyzed `match` query `{"match": {field: text}}`. The `text` schema type already maps to ES/OS `text` (analyzed), so `match` tokenizes and matches docs **containing** the term — aligning with redis's `@field:($tok)` and the `write_fulltext_project` ground truth.

## Coverage + teeth
- Unit tests (both engines): the text arm emits the `match` clause; a text-only condition is not dropped (non-empty `bool.must`).
- Integration: `test_binary_{elasticsearch,opensearch}_fulltext` (reusing `write_fulltext_project`) — **recall 1.000** on both, verified live.
- **Teeth**: reverting the arm drops ES fulltext recall to **0.410** (unfiltered) — fails the ≥0.9 floor.

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean; 402 unit tests
- ES + OS fulltext integration: recall 1.000

🤖 Generated with [Claude Code](https://claude.com/claude-code)