### PR TITLE
fix(redis,valkey): RESP3 skip unparseable doc id; prime datetime/text field maps on search path (fixes #124, #125)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -1360,11 +1360,14 @@ fn parse_ft_search_resp3(pairs: &[(redis::Value, redis::Value)]) -> Vec<(i64, f6
         let redis::Value::Map(fields) = doc else {
             continue;
         };
-        let mut id = 0i64;
+        // A doc whose `id` is missing or cannot be parsed to an integer is
+        // skipped (mirrors the RESP2 trailing-id drop) rather than emitted as a
+        // phantom id=0 hit.
+        let mut id: Option<i64> = None;
         let mut score = 0.0f64;
         for (k, v) in fields {
             match value_as_string(k).as_deref() {
-                Some("id") => id = value_as_string(v).and_then(|s| s.parse().ok()).unwrap_or(0),
+                Some("id") => id = value_as_string(v).and_then(|s| s.parse().ok()),
                 Some("extra_attributes") => {
                     if let redis::Value::Map(attrs) = v {
                         for (ak, av) in attrs {
@@ -1379,7 +1382,9 @@ fn parse_ft_search_resp3(pairs: &[(redis::Value, redis::Value)]) -> Vec<(i64, f6
                 _ => {}
             }
         }
-        out.push((id, score));
+        if let Some(id) = id {
+            out.push((id, score));
+        }
     }
     out
 }
@@ -1470,8 +1475,16 @@ fn encode_string_field(config: &RedisEngineConfig, key: &str, value: &str) -> St
 
 /// Collect the schema field names typed `datetime`.
 fn datetime_fields_from_schema(dataset: &Dataset) -> HashSet<String> {
+    prime_datetime_fields(dataset.config.schema.as_ref())
+}
+
+/// Pure schema → datetime-field-set priming. Extracted so it can be primed both
+/// during `configure()` (upload path) and at the start of `search()` (the
+/// `--skip-upload` path, where configure() never runs), and unit-tested without
+/// a full `Dataset`.
+fn prime_datetime_fields(schema: Option<&serde_json::Value>) -> HashSet<String> {
     let mut set = HashSet::new();
-    if let Some(schema) = dataset.config.schema.as_ref().and_then(|s| s.as_object()) {
+    if let Some(schema) = schema.and_then(|s| s.as_object()) {
         for (field, ty) in schema {
             if ty.as_str() == Some("datetime") {
                 set.insert(field.clone());
@@ -1613,6 +1626,13 @@ impl Engine for RedisEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // Prime the datetime field-type map from the schema so datetime range
+        // filters are built with the correct field type even on the
+        // `--skip-upload` path, where configure() (which normally primes it) is
+        // never called. Idempotent: on the upload path this reproduces exactly
+        // what configure() already set.
+        self.config.datetime_fields = Arc::new(datetime_fields_from_schema(dataset));
+
         if self.config.skip_vector_index {
             return self.search_filter_only(dataset, params, num_queries);
         }
@@ -1823,6 +1843,11 @@ impl Engine for RedisEngine {
         num_queries: i64,
         ratio: &UpdateSearchRatio,
     ) -> Result<SearchResults, String> {
+        // Prime the datetime field-type map from the schema so the update half of
+        // the mixed workload encodes datetime payloads as epoch seconds even on
+        // the `--skip-upload` path (configure() does not run there). Idempotent.
+        self.config.datetime_fields = Arc::new(datetime_fields_from_schema(dataset));
+
         let ef = params
             .search_params
             .as_ref()
@@ -2622,20 +2647,69 @@ mod tests {
     }
 
     #[test]
-    fn parse_ft_search_resp3_id_parse_failure_yields_zero_id_doc() {
-        // A map doc whose `id` is unparseable is NOT skipped: id falls back to 0
-        // and the doc is still emitted (score parsed independently).
+    fn parse_ft_search_resp3_id_parse_failure_skips_doc() {
+        // A map doc whose `id` is unparseable is SKIPPED (mirrors the RESP2
+        // trailing-id drop), not emitted as a phantom id=0 hit. A sibling doc
+        // with a valid id still parses and is emitted.
+        let bad = Value::Map(vec![
+            (bulk("id"), bulk("not-a-number")),
+            (
+                bulk("extra_attributes"),
+                Value::Map(vec![(bulk("vector_score"), bulk("0.5"))]),
+            ),
+        ]);
+        let good = Value::Map(vec![
+            (bulk("id"), bulk("42")),
+            (
+                bulk("extra_attributes"),
+                Value::Map(vec![(bulk("vector_score"), bulk("0.9"))]),
+            ),
+        ]);
+        let resp = Value::Map(vec![(bulk("results"), Value::Array(vec![bad, good]))]);
+        // Only the valid-id doc survives; the unparseable one is dropped.
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(42, 0.9)]);
+    }
+
+    #[test]
+    fn parse_ft_search_resp3_missing_id_skips_doc() {
+        // A doc with no `id` field at all is also skipped, not emitted as id=0.
         let resp = Value::Map(vec![(
             bulk("results"),
-            Value::Array(vec![Value::Map(vec![
-                (bulk("id"), bulk("not-a-number")),
-                (
-                    bulk("extra_attributes"),
-                    Value::Map(vec![(bulk("vector_score"), bulk("0.5"))]),
-                ),
-            ])]),
+            Value::Array(vec![Value::Map(vec![(
+                bulk("extra_attributes"),
+                Value::Map(vec![(bulk("vector_score"), bulk("0.5"))]),
+            )])]),
         )]);
-        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(0, 0.5)]);
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![]);
+    }
+
+    // ── field-type map priming (#125) ─────────────────────────────────────
+    // These primed maps must be identical whether upload runs (configure())
+    // or not (--skip-upload, primed at the start of search()). Cover the pure
+    // priming fn directly so both call sites stay correct.
+    #[test]
+    fn prime_datetime_fields_selects_only_datetime_schema_fields() {
+        use super::prime_datetime_fields;
+        let schema = serde_json::json!({
+            "created_at": "datetime",
+            "updated_at": "datetime",
+            "price": "int",
+            "brand": "keyword",
+            "title": "text",
+        });
+        let got = prime_datetime_fields(Some(&schema));
+        let mut expected = std::collections::HashSet::new();
+        expected.insert("created_at".to_string());
+        expected.insert("updated_at".to_string());
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn prime_datetime_fields_empty_for_none_or_no_datetime() {
+        use super::prime_datetime_fields;
+        assert!(prime_datetime_fields(None).is_empty());
+        let schema = serde_json::json!({ "price": "int", "brand": "keyword" });
+        assert!(prime_datetime_fields(Some(&schema)).is_empty());
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -1383,11 +1383,14 @@ fn parse_ft_search_resp3(pairs: &[(redis::Value, redis::Value)]) -> Vec<(i64, f6
         let redis::Value::Map(fields) = doc else {
             continue;
         };
-        let mut id = 0i64;
+        // A doc whose `id` is missing or cannot be parsed to an integer is
+        // skipped (mirrors the RESP2 trailing-id drop) rather than emitted as a
+        // phantom id=0 hit.
+        let mut id: Option<i64> = None;
         let mut score = 0.0f64;
         for (k, v) in fields {
             match value_as_string(k).as_deref() {
-                Some("id") => id = value_as_string(v).and_then(|s| s.parse().ok()).unwrap_or(0),
+                Some("id") => id = value_as_string(v).and_then(|s| s.parse().ok()),
                 Some("extra_attributes") => {
                     if let redis::Value::Map(attrs) = v {
                         for (ak, av) in attrs {
@@ -1402,7 +1405,9 @@ fn parse_ft_search_resp3(pairs: &[(redis::Value, redis::Value)]) -> Vec<(i64, f6
                 _ => {}
             }
         }
-        out.push((id, score));
+        if let Some(id) = id {
+            out.push((id, score));
+        }
     }
     out
 }
@@ -1538,9 +1543,17 @@ fn tokenize_text_to_tag(text: &str) -> String {
 
 /// Collect schema fields typed `datetime` and `text` (in that order).
 fn schema_transform_fields(dataset: &Dataset) -> (HashSet<String>, HashSet<String>) {
+    prime_field_types(dataset.config.schema.as_ref())
+}
+
+/// Pure schema → (datetime-fields, text-fields) priming. Extracted so the maps
+/// can be primed both during `configure()` (upload path) and at the start of
+/// `search()` (the `--skip-upload` path, where configure() never runs), and
+/// unit-tested without a full `Dataset`.
+fn prime_field_types(schema: Option<&serde_json::Value>) -> (HashSet<String>, HashSet<String>) {
     let mut datetime_fields = HashSet::new();
     let mut text_fields = HashSet::new();
-    if let Some(schema) = dataset.config.schema.as_ref().and_then(|s| s.as_object()) {
+    if let Some(schema) = schema.and_then(|s| s.as_object()) {
         for (field, ty) in schema {
             match ty.as_str() {
                 Some("datetime") => {
@@ -1687,6 +1700,15 @@ impl Engine for ValkeyEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // Prime the datetime/text field-type maps from the schema so range and
+        // text/tag filters are built with the correct field type even on the
+        // `--skip-upload` path, where configure() (which normally primes them) is
+        // never called. Idempotent: on the upload path this reproduces exactly
+        // what configure() already set.
+        let (dt_fields, text_fields) = schema_transform_fields(dataset);
+        self.config.datetime_fields = Arc::new(dt_fields);
+        self.config.text_tag_fields = Arc::new(text_fields);
+
         if self.config.skip_vector_index {
             return self.search_filter_only(dataset, params, num_queries);
         }
@@ -1895,6 +1917,14 @@ impl Engine for ValkeyEngine {
         num_queries: i64,
         ratio: &UpdateSearchRatio,
     ) -> Result<SearchResults, String> {
+        // Prime the datetime/text field-type maps from the schema so the update
+        // half of the mixed workload encodes datetime payloads as epoch seconds
+        // and text payloads as tokenised TAGs even on the `--skip-upload` path
+        // (configure() does not run there). Idempotent.
+        let (dt_fields, text_fields) = schema_transform_fields(dataset);
+        self.config.datetime_fields = Arc::new(dt_fields);
+        self.config.text_tag_fields = Arc::new(text_fields);
+
         let ef = params
             .search_params
             .as_ref()
@@ -2569,20 +2599,74 @@ mod tests {
     }
 
     #[test]
-    fn parse_ft_search_resp3_id_parse_failure_yields_zero_id_doc() {
-        // A map doc whose `id` is unparseable is NOT skipped: id falls back to 0
-        // and the doc is still emitted (score parsed independently).
+    fn parse_ft_search_resp3_id_parse_failure_skips_doc() {
+        // A map doc whose `id` is unparseable is SKIPPED (mirrors the RESP2
+        // trailing-id drop), not emitted as a phantom id=0 hit. A sibling doc
+        // with a valid id still parses and is emitted.
+        let bad = Value::Map(vec![
+            (bulk("id"), bulk("not-a-number")),
+            (
+                bulk("extra_attributes"),
+                Value::Map(vec![(bulk("vector_score"), bulk("0.5"))]),
+            ),
+        ]);
+        let good = Value::Map(vec![
+            (bulk("id"), bulk("42")),
+            (
+                bulk("extra_attributes"),
+                Value::Map(vec![(bulk("vector_score"), bulk("0.9"))]),
+            ),
+        ]);
+        let resp = Value::Map(vec![(bulk("results"), Value::Array(vec![bad, good]))]);
+        // Only the valid-id doc survives; the unparseable one is dropped.
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(42, 0.9)]);
+    }
+
+    #[test]
+    fn parse_ft_search_resp3_missing_id_skips_doc() {
+        // A doc with no `id` field at all is also skipped, not emitted as id=0.
         let resp = Value::Map(vec![(
             bulk("results"),
-            Value::Array(vec![Value::Map(vec![
-                (bulk("id"), bulk("not-a-number")),
-                (
-                    bulk("extra_attributes"),
-                    Value::Map(vec![(bulk("vector_score"), bulk("0.5"))]),
-                ),
-            ])]),
+            Value::Array(vec![Value::Map(vec![(
+                bulk("extra_attributes"),
+                Value::Map(vec![(bulk("vector_score"), bulk("0.5"))]),
+            )])]),
         )]);
-        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(0, 0.5)]);
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![]);
+    }
+
+    // ── field-type map priming (#125) ─────────────────────────────────────
+    // The datetime/text maps must be identical whether upload runs (configure())
+    // or not (--skip-upload, primed at the start of search()). Cover the pure
+    // priming fn directly so both call sites stay correct.
+    #[test]
+    fn prime_field_types_splits_datetime_and_text_schema_fields() {
+        use super::prime_field_types;
+        let schema = serde_json::json!({
+            "created_at": "datetime",
+            "body": "text",
+            "title": "text",
+            "price": "int",
+            "brand": "keyword",
+        });
+        let (dt, txt) = prime_field_types(Some(&schema));
+        let mut expected_dt = std::collections::HashSet::new();
+        expected_dt.insert("created_at".to_string());
+        let mut expected_txt = std::collections::HashSet::new();
+        expected_txt.insert("body".to_string());
+        expected_txt.insert("title".to_string());
+        assert_eq!(dt, expected_dt);
+        assert_eq!(txt, expected_txt);
+    }
+
+    #[test]
+    fn prime_field_types_empty_for_none_or_no_matching_fields() {
+        use super::prime_field_types;
+        let (dt, txt) = prime_field_types(None);
+        assert!(dt.is_empty() && txt.is_empty());
+        let schema = serde_json::json!({ "price": "int", "brand": "keyword" });
+        let (dt, txt) = prime_field_types(Some(&schema));
+        assert!(dt.is_empty() && txt.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Two redis/valkey robustness bugs from the coverage+overhead audit.

## Fixes #124 — RESP3 unparseable doc id emitted phantom `(0, score)`
`parse_ft_search_resp3` (both engines) accumulated `id = 0` via `.unwrap_or(0)` and unconditionally pushed `(id, score)`, so a doc whose `id` couldn't be parsed became a phantom `(0, score)` hit. Now the id is `Option<i64>` and a missing/malformed id **skips the doc** (mirrors the RESP2 trailing-id drop); a valid id emits exactly as before.
- Tests updated: `parse_ft_search_resp3_id_parse_failure_skips_doc` (unparseable id dropped, sibling valid id `(42, 0.9)` still emits) + `parse_ft_search_resp3_missing_id_skips_doc`.

## Fixes #125 — datetime/text field-type maps not primed on `--skip-upload`
`datetime_fields` / `text_tag_fields` (consumed by `encode_string_field` for ISO→epoch and text→TAG on the **write** paths, incl. the mixed-update half) were primed only in `configure()`. The `--skip-upload` path runs neither `configure()` nor `upload()`, so on a `--skip-upload` + mixed workload newly-written datetime/text payloads were stored un-transformed.
- Now the schema-driven priming also runs at the start of `search()`/`search_mixed()`, sourced from `dataset.config.schema`. It's idempotent and deterministic, so the normal upload path produces identical maps.
- Extracted pure `prime_datetime_fields` / `prime_field_types` with direct unit tests.
- **Honest limitation**: no e2e two-run `--skip-upload` integration test — the single-shot binary calls `engine.delete()` at the end of every run (drops index+data), so a second `--skip-upload` run would find nothing. Pure-fn unit tests are the coverage.

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean; 404 unit tests
- Live redis:8.8.0 + valkey-bundle: **integration_redis 23/23, integration_valkey 18/18** — datetime/fulltext/mixed/tenancy/resp3 all pass, no recall/precision regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)