### PR TITLE
fix(filters): cross-engine filter-builder consistency (fixes #121)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -544,6 +544,14 @@ fn build_filter(
                 return Some(serde_json::json!({"match": {field_name: text}}));
             }
             let value = criteria.get("value")?;
+            // Guard non-scalar: an array/object/null under `value` is malformed
+            // input — the canonical model uses `match.any` for lists. Drop the
+            // clause (return None) instead of forwarding
+            // `{"match":{field:[1,2]}}` verbatim, matching qdrant/redis/valkey/
+            // vectorsets.
+            if !(value.is_string() || value.is_number() || value.is_boolean()) {
+                return None;
+            }
             Some(serde_json::json!({"match": {field_name: value}}))
         }
         "range" => {
@@ -1110,6 +1118,29 @@ mod tests {
         assert_eq!(c, serde_json::json!({"match": {"color": "red"}}));
     }
 
+    // #121: a non-scalar `value` (a JSON array) is malformed input — the
+    // canonical model uses `match.any` for lists. It must be dropped (None),
+    // not forwarded verbatim as `{"match":{"n":[1,2]}}`. Matches qdrant/redis/
+    // valkey/vectorsets.
+    #[test]
+    fn test_match_non_scalar_value_dropped() {
+        assert_eq!(
+            build_filter("n", "match", &serde_json::json!({"value": [1, 2]})),
+            None
+        );
+        assert_eq!(
+            build_filter("n", "match", &serde_json::json!({"value": {"x": 1}})),
+            None
+        );
+        assert_eq!(
+            build_filter("n", "match", &serde_json::json!({"value": null})),
+            None
+        );
+        // As the sole clause, the whole filter is dropped (no `bool.must`).
+        let conditions = serde_json::json!({"and": [{"n": {"match": {"value": [1, 2]}}}]});
+        assert_eq!(parse_es_conditions(&conditions), None);
+    }
+
     #[test]
     fn test_id_to_uuid_hex_one() {
         assert_eq!(id_to_uuid_hex(1), "00000000000000000000000000000001");
@@ -1364,12 +1395,13 @@ mod tests {
     }
 
     #[test]
-    fn exact_match_array_value_passes_through_unguarded() {
-        // ES build_filter has no scalar guard: a non-scalar value is forwarded as
-        // the match value (documents behavior; differs from qdrant's None).
+    fn exact_match_array_value_is_none() {
+        // #121: ES build_filter now guards the scalar exact-match arm; a
+        // non-scalar value is dropped (None), matching qdrant/redis/valkey/
+        // vectorsets (was previously forwarded verbatim as `{"match":{"n":[1,2]}}`).
         assert_eq!(
-            build_filter("n", "match", &serde_json::json!({"value":[1,2]})).unwrap(),
-            serde_json::json!({"match":{"n":[1,2]}})
+            build_filter("n", "match", &serde_json::json!({"value":[1,2]})),
+            None
         );
     }
 

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -716,8 +716,15 @@ fn build_milvus_filter(
             let value = criteria.get("value")?;
             if let Some(s) = value.as_str() {
                 Some(format!("{} == {}", field_name, quote_milvus_string(s)))
-            } else {
+            } else if value.is_number() || value.is_boolean() {
                 Some(format!("{} == {}", field_name, value))
+            } else {
+                // Non-scalar exact-match value (a JSON array/object/null) is
+                // malformed input — the canonical model uses `match.any` for
+                // lists. Drop the clause (return None) instead of forwarding
+                // `field == [1,2]` verbatim, matching qdrant/redis/valkey/
+                // vectorsets.
+                None
             }
         }
         "range" => {
@@ -1095,6 +1102,20 @@ mod tests {
         );
     }
 
+    // #121: a non-scalar `value` (a JSON array/object/null) is malformed input —
+    // the canonical model uses `match.any` for lists. It must be dropped (None),
+    // not forwarded verbatim as `n == [1,2]`. Matches qdrant/redis/valkey/
+    // vectorsets. (Scalar kinds int/float/bool covered by exact_match_int_float_bool.)
+    #[test]
+    fn match_non_scalar_value_dropped() {
+        assert!(build_milvus_filter("n", "match", &json!({"value": [1, 2]})).is_none());
+        assert!(build_milvus_filter("n", "match", &json!({"value": {"x": 1}})).is_none());
+        assert!(build_milvus_filter("n", "match", &json!({"value": null})).is_none());
+        // As the sole clause, the whole filter is dropped.
+        let e = json!({"and": [{"n": {"match": {"value": [1, 2]}}}]});
+        assert!(parse_milvus_conditions(&e).is_none());
+    }
+
     #[test]
     fn match_exact_value_escapes_quotes_and_backslashes() {
         // Exact-value string branch must escape through the shared helper:
@@ -1218,12 +1239,10 @@ mod tests {
     }
 
     #[test]
-    fn exact_match_array_value_inlines_json_array() {
-        // No scalar guard: a non-scalar value is Display-formatted verbatim
-        // (documents behavior).
-        assert_eq!(
-            build_milvus_filter("n", "match", &json!({"value":[1,2]})).unwrap(),
-            "n == [1,2]"
-        );
+    fn exact_match_array_value_is_none() {
+        // #121: the scalar exact-match arm now guards non-scalars; a JSON array
+        // value is dropped (None), matching qdrant/redis/valkey/vectorsets (was
+        // previously Display-formatted verbatim as `n == [1,2]`).
+        assert!(build_milvus_filter("n", "match", &json!({"value":[1,2]})).is_none());
     }
 }

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -592,6 +592,14 @@ fn build_filter(
                 return Some(serde_json::json!({"match": {field_name: text}}));
             }
             let value = criteria.get("value")?;
+            // Guard non-scalar: an array/object/null under `value` is malformed
+            // input — the canonical model uses `match.any` for lists. Drop the
+            // clause (return None) instead of forwarding
+            // `{"match":{field:[1,2]}}` verbatim, matching qdrant/redis/valkey/
+            // vectorsets.
+            if !(value.is_string() || value.is_number() || value.is_boolean()) {
+                return None;
+            }
             Some(serde_json::json!({"match": {field_name: value}}))
         }
         "range" => {
@@ -1112,6 +1120,23 @@ mod tests {
         assert_eq!(c, json!({"match": {"color": "red"}}));
     }
 
+    // #121: a non-scalar `value` (a JSON array) is malformed input — the
+    // canonical model uses `match.any` for lists. It must be dropped (None),
+    // not forwarded verbatim as `{"match":{"n":[1,2]}}`. Matches qdrant/redis/
+    // valkey/vectorsets.
+    #[test]
+    fn test_match_non_scalar_value_dropped() {
+        assert_eq!(build_filter("n", "match", &json!({"value": [1, 2]})), None);
+        assert_eq!(
+            build_filter("n", "match", &json!({"value": {"x": 1}})),
+            None
+        );
+        assert_eq!(build_filter("n", "match", &json!({"value": null})), None);
+        // As the sole clause, the whole filter is dropped (no `bool.must`).
+        let conditions = json!({"and": [{"n": {"match": {"value": [1, 2]}}}]});
+        assert_eq!(parse_os_conditions(&conditions), None);
+    }
+
     // #120: a full-text `{"match": {"text": …}}` condition must emit an analyzed
     // `match` query — NOT be dropped. Dropping it leaves `bool.must:[]`, which
     // OpenSearch treats as match-ALL, silently running the kNN query UNFILTERED.
@@ -1328,11 +1353,11 @@ mod tests {
     }
 
     #[test]
-    fn exact_match_array_value_passes_through_unguarded() {
-        assert_eq!(
-            build_filter("n", "match", &json!({"value":[1,2]})).unwrap(),
-            json!({"match":{"n":[1,2]}})
-        );
+    fn exact_match_array_value_is_none() {
+        // #121: OS build_filter now guards the scalar exact-match arm; a
+        // non-scalar value is dropped (None), matching qdrant/redis/valkey/
+        // vectorsets (was previously forwarded verbatim as `{"match":{"n":[1,2]}}`).
+        assert_eq!(build_filter("n", "match", &json!({"value":[1,2]})), None);
     }
 
     // ── uuid_hex_to_int round-trip + invalid input ─────────────────────────

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -748,10 +748,13 @@ fn build_pg_clause(entry: &serde_json::Value, builder: &mut FilterBuilder) -> Op
                             let ph = builder.bind(PgValue::Float(f));
                             parts.push(format!("\"{}\" = {}", field_name, ph));
                         } else {
-                            // Non-scalar match value (e.g. a JSON array) — never
-                            // emitted by real datasets. Inlined verbatim; this is
-                            // the ONE case whose SQL text is value-dependent.
-                            parts.push(format!("\"{}\" = {}", field_name, value));
+                            // Non-scalar match value (a JSON array/object/null)
+                            // is malformed input — the canonical model uses
+                            // `match.any` for lists. Drop the clause (emit
+                            // nothing) instead of inlining `"f" = [1,2]`
+                            // verbatim, matching qdrant/redis/valkey/vectorsets.
+                            // As the sole condition this leaves `parts` empty →
+                            // the builder returns None.
                         }
                     }
                 }
@@ -953,6 +956,25 @@ mod tests {
         assert!(vals.is_empty());
     }
 
+    // #121: a non-scalar `value` (a JSON array) is malformed input — the
+    // canonical model uses `match.any` for lists. The clause is dropped (no SQL,
+    // no bound value) rather than inlining `"n" = [1,2]` verbatim. As the sole
+    // condition the whole filter is None. Matches qdrant/redis/valkey/vectorsets.
+    #[test]
+    fn match_non_scalar_value_dropped() {
+        assert!(parse(&json!({"and": [{"n": {"match": {"value": [1, 2]}}}]})).is_none());
+        assert!(parse(&json!({"and": [{"n": {"match": {"value": {"x": 1}}}}]})).is_none());
+        assert!(parse(&json!({"and": [{"n": {"match": {"value": null}}}]})).is_none());
+        // A non-scalar clause is dropped but a sibling scalar clause survives.
+        let cond = json!({"and": [
+            {"n": {"match": {"value": [1, 2]}}},
+            {"c": {"match": {"value": "red"}}},
+        ]});
+        let (sql, vals) = parse(&cond).unwrap();
+        assert_eq!(sql, "(\"c\" = $3)");
+        assert_eq!(vals, vec![PgValue::Text("red".to_string())]);
+    }
+
     // ── OR-branch of the condition parser ──────────────────────────────────
 
     #[test]
@@ -1091,12 +1113,11 @@ mod tests {
     }
 
     #[test]
-    fn exact_match_array_value_inlines_json_array() {
-        // Non-scalar match values are never produced by real datasets; this one
-        // degenerate case stays inlined (no bound value), documented in
-        // build_pg_clause.
-        let (sql, vals) = parse(&json!({"and":[{"n":{"match":{"value":[1,2]}}}]})).unwrap();
-        assert_eq!(sql, "(\"n\" = [1,2])");
-        assert!(vals.is_empty());
+    fn exact_match_array_value_is_dropped() {
+        // #121: a non-scalar match value (a JSON array) is malformed input — the
+        // canonical model uses `match.any` for lists. The clause is dropped (as
+        // the sole condition → None), matching qdrant/redis/valkey/vectorsets
+        // (was previously inlined verbatim as `"n" = [1,2]`).
+        assert!(parse(&json!({"and":[{"n":{"match":{"value":[1,2]}}}]})).is_none());
     }
 }

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -894,6 +894,19 @@ fn build_qdrant_filter(
             if let Some(gte) = criteria_obj.get("gte").and_then(|v| v.as_f64()) {
                 range.gte = Some(gte);
             }
+            // If NO valid numeric bound was produced (all bounds unknown-op /
+            // null / non-numeric), SKIP the clause (return None) rather than
+            // emitting an empty, unconstraining Range — a present-but-vacuous
+            // condition that other engines drop. Mirrors the vectorsets
+            // null-bound fix (#115). A range with SOME valid bounds still
+            // produces a Range carrying just those.
+            if range.lt.is_none()
+                && range.gt.is_none()
+                && range.lte.is_none()
+                && range.gte.is_none()
+            {
+                return None;
+            }
             Some(Condition::range(field_name.to_string(), range))
         }
         "geo" => {
@@ -1581,18 +1594,29 @@ rest_responses_total{method=\"GET\"} 42
         assert_eq!(r.lt, Some(20.0));
     }
 
+    // #121: a range that produces NO valid numeric bound (unrecognized key,
+    // null/non-numeric bound) must be SKIPPED (None), not emitted as an empty,
+    // unconstraining Range (a present-but-vacuous condition). Mirrors the
+    // vectorsets null-bound fix (#115) and the other engines, which drop it.
     #[test]
-    fn range_unknown_op_yields_empty_numeric_range() {
-        // Qdrant emits an (empty) numeric Range for an unrecognized key rather
-        // than None — the condition is present but constrains nothing.
-        let r = numeric_range(json!({"foo":5}));
-        assert!(r.lt.is_none() && r.gt.is_none() && r.lte.is_none() && r.gte.is_none());
+    fn range_unknown_op_only_is_none() {
+        assert!(build_qdrant_filter("n", "range", &json!({"foo":5})).is_none());
     }
 
     #[test]
-    fn range_null_bound_yields_empty_numeric_range() {
-        let r = numeric_range(json!({"gte": serde_json::Value::Null}));
-        assert!(r.gte.is_none());
+    fn range_null_bound_only_is_none() {
+        assert!(
+            build_qdrant_filter("n", "range", &json!({"gte": serde_json::Value::Null})).is_none()
+        );
+    }
+
+    #[test]
+    fn range_valid_bound_survives_null_sibling() {
+        // A null/unknown bound is dropped, but a present valid bound still yields
+        // a Range carrying only that bound.
+        let r = numeric_range(json!({"gte": 5, "lt": serde_json::Value::Null, "foo": 9}));
+        assert_eq!(r.gte, Some(5.0));
+        assert!(r.lt.is_none() && r.gt.is_none() && r.lte.is_none());
     }
 
     // ── Geo filter ─────────────────────────────────────────────────────────

--- a/src/bin/vector_db_benchmark/engine/turbopuffer.rs
+++ b/src/bin/vector_db_benchmark/engine/turbopuffer.rs
@@ -272,10 +272,19 @@ fn parse_single_condition(condition: &serde_json::Value) -> Option<serde_json::V
                                 ]
                             ]));
                         }
-                        // follow-up: element-type coercion (int vs string) and
-                        // multi-valued attributes in turbopuffer's In are
-                        // dataset-dependent and cloud-only (untestable locally);
-                        // the common keyword/int IN-list is covered.
+                        // follow-up (cloud-only, untestable locally — NOT
+                        // implemented): scalar `In` here tests whole-value set
+                        // membership and does NOT do array CONTAINS-ANY for a
+                        // multi-valued attribute (e.g. `labels` stored as an
+                        // array), so it can't match a doc whose attribute is a
+                        // list. It also does NOT reconcile ELEMENT TYPES with the
+                        // upload-side string→number coercion in
+                        // `metadata_value_to_json` (a numeric-looking string is
+                        // stored as int/float, so a string `"1"` in the IN-list
+                        // would not equal the stored int `1`). The common
+                        // keyword/int IN-list is covered; both gaps are
+                        // dataset-dependent and require a live cloud namespace to
+                        // verify.
                         return Some(serde_json::json!([field_name, "In", any]));
                     }
                     // {"match": {"value": x}} => ["field_name", "Eq", x]

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -1091,13 +1091,18 @@ fn escape_str(s: &str) -> String {
 /// int AND float lists. Forms verified against a live VectorSets server
 /// (Redis 8.8):
 ///
-/// - string element → `.field == "<escaped>"` — EXACT equality. NOTE: the
-///   value-`in`-field form (`"v" in .field`) does SUBSTRING/word matching on a
-///   scalar string (`"blue" in .color` wrongly matches `.color == "dark blue"`),
-///   which violates the exact/whole-value keyword semantics of qdrant/redis
-///   match_any, so we use `==`. (A multi-valued `labels` array would need `in`
-///   for membership, but no keyword match_any in the benchmark targets an array
-///   field — keyword filters are scalar — and exact-match is the tested contract.)
+/// - string element on a SCALAR keyword field → `.field == "<escaped>"` — EXACT
+///   equality. NOTE: the value-`in`-field form (`"v" in .field`) does
+///   SUBSTRING/word matching on a scalar string (`"blue" in .color` wrongly
+///   matches `.color == "dark blue"`), which violates the exact/whole-value
+///   keyword semantics of qdrant/redis match_any, so we use `==` for scalars.
+/// - string element on the multi-valued `labels` field → `"<escaped>" in .labels`
+///   — ARRAY contains-any. `labels` is the ONLY array field (MetadataValue::Labels
+///   is produced solely for key == "labels", see readers::metadata); VSIM stores
+///   it as a JSON array and `"v" in .labels` performs true array membership
+///   (verified on Redis 8.8), whereas scalar `.labels == "v"` could never match an
+///   array. The `in` form is safe here BECAUSE the field is an array — the
+///   substring hazard above only applies to scalar strings.
 /// - numeric element (i64 OR f64) → `.field == <n>` — VSIM coerces numeric
 ///   strings ("1" == 1; numbers are stored as JSON strings on upload).
 /// - OR all representable elements, parenthesized. Empty-string tokens are dropped
@@ -1106,12 +1111,17 @@ fn escape_str(s: &str) -> String {
 ///   IN-set matches NOTHING rather than being dropped (dropping the sole clause
 ///   would leave no FILTER and run over ALL vectors — the inverse of the filter).
 fn build_match_any_clause(field_name: &str, any: &[serde_json::Value]) -> String {
+    // `labels` is the only multi-valued (array) field; it needs `in` for
+    // contains-any membership. All other keyword fields are scalar and use `==`.
+    let is_array_field = field_name == "labels";
     let clauses: Vec<String> = any
         .iter()
         .filter_map(|v| {
             if let Some(s) = v.as_str() {
                 if s.is_empty() {
                     None
+                } else if is_array_field {
+                    Some(format!("\"{}\" in .{}", escape_str(s), field_name))
                 } else {
                     Some(format!(".{} == \"{}\"", field_name, escape_str(s)))
                 }
@@ -1365,6 +1375,39 @@ mod filter_expr_tests {
         assert_eq!(
             build_filter_expression(&cond),
             Some(".color == \"red\"".to_string())
+        );
+    }
+
+    // #121: the multi-valued `labels` field is stored as a JSON ARRAY, so
+    // match_any must use `"v" in .labels` (array contains-any). On a live Redis
+    // 8.8 server `"x" in .labels` performs array membership; scalar
+    // `.labels == "x"` could never match an array.
+    #[test]
+    fn match_any_labels_uses_array_contains_any_in_form() {
+        let cond = json!({"and": [{"labels": {"match": {"any": ["red", "blue"]}}}]});
+        assert_eq!(
+            build_filter_expression(&cond),
+            Some("(\"red\" in .labels or \"blue\" in .labels)".to_string())
+        );
+    }
+
+    #[test]
+    fn match_any_labels_single_value_unwrapped_in_form() {
+        let cond = json!({"and": [{"labels": {"match": {"any": ["red"]}}}]});
+        assert_eq!(
+            build_filter_expression(&cond),
+            Some("\"red\" in .labels".to_string())
+        );
+    }
+
+    // A SCALAR keyword field (anything but `labels`) keeps EXACT `==`; the `in`
+    // form would do substring matching and break whole-value semantics.
+    #[test]
+    fn match_any_scalar_keyword_unchanged_exact_equality() {
+        let cond = json!({"and": [{"color": {"match": {"any": ["red", "blue"]}}}]});
+        assert_eq!(
+            build_filter_expression(&cond),
+            Some("(.color == \"red\" or .color == \"blue\")".to_string())
         );
     }
 

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -1069,6 +1069,14 @@ fn build_weaviate_filter(
             }
 
             let value = criteria.get("value")?;
+            // Guard non-scalar: an array/object/null under `value` is malformed
+            // input — the canonical model uses `match.any` for lists. Without
+            // this, `value_key` falls back to "valueText" and forwards the array
+            // verbatim. Drop the clause (return None) instead, matching
+            // qdrant/redis/valkey/vectorsets.
+            if !(value.is_string() || value.is_number() || value.is_boolean()) {
+                return None;
+            }
             let vk = value_key(value);
             Some(serde_json::json!({
                 "path": [field_name],
@@ -1713,6 +1721,17 @@ mod tests {
         assert_eq!(c["valueText"], "red");
     }
 
+    // #121: a non-scalar `value` (object/null) is malformed input — the
+    // canonical model uses `match.any` for lists. Without the guard, `value_key`
+    // falls back to "valueText" and forwards it verbatim. It must be dropped
+    // (None). Matches qdrant/redis/valkey/vectorsets. (Array case covered by
+    // exact_match_array_value_is_none.)
+    #[test]
+    fn match_non_scalar_value_dropped() {
+        assert!(build_weaviate_filter("n", "match", &json!({"value": {"x": 1}})).is_none());
+        assert!(build_weaviate_filter("n", "match", &json!({"value": null})).is_none());
+    }
+
     #[test]
     fn keyword_property_is_filterable_with_field_tokenization() {
         // Modern Weaviate needs `indexFilterable` (not the deprecated
@@ -1893,12 +1912,12 @@ mod tests {
     }
 
     #[test]
-    fn exact_match_array_value_falls_back_to_value_text() {
-        // No scalar guard: a non-scalar value falls through value_key's default
-        // (valueText) with the array as the value (documents behavior).
-        let f = build_weaviate_filter("n", "match", &json!({"value":[1,2]})).unwrap();
-        assert_eq!(f["operator"], "Equal");
-        assert_eq!(f["valueText"], json!([1, 2]));
+    fn exact_match_array_value_is_none() {
+        // #121: the scalar exact-match arm now guards non-scalars; a JSON array
+        // value is dropped (None) instead of falling through value_key's default
+        // (valueText) with the array as the value. Matches qdrant/redis/valkey/
+        // vectorsets.
+        assert!(build_weaviate_filter("n", "match", &json!({"value":[1,2]})).is_none());
     }
 
     // ── gRPC Filters translation (must mirror the GraphQL where-tree) ───────
@@ -2037,9 +2056,11 @@ mod tests {
 
     #[test]
     fn grpc_non_scalar_equal_value_is_untranslatable() {
-        // The degenerate array-under-valueText leaf can't become a proto scalar,
-        // so translation returns None → the run falls back to GraphQL.
-        let leaf = build_weaviate_filter("n", "match", &json!({"value":[1,2]})).unwrap();
+        // A degenerate array-under-valueText leaf (build_weaviate_filter no longer
+        // produces one after #121, so it's constructed directly here) can't become
+        // a proto scalar, so translation returns None → the run falls back to
+        // GraphQL. Guards the gRPC translator's own scalar-accessor check.
+        let leaf = json!({"path": ["n"], "operator": "Equal", "valueText": [1, 2]});
         assert!(where_json_to_grpc_filters(&leaf).is_none());
     }
 


### PR DESCRIPTION
## Fixes #121 — filter-builder cross-engine consistency

Aligns the filter-condition builders across engines. Builder-only changes (no harness/measurement code), each pinned by unit tests. 432 unit tests pass.

1. **Non-scalar exact-match guarded** (es/os/weaviate/milvus/pgvector): `{"match":{"value":[1,2]}}` (a JSON array under `value` — malformed; the model uses `match.any` for lists) now returns **None** (clause dropped) instead of being forwarded verbatim (e.g. milvus `n == [1,2]`, es `{"match":{"n":[1,2]}}`), matching qdrant/redis/valkey/vectorsets which already did. A sibling scalar clause still survives.
2. **qdrant range unknown-op / null-bound → None**: a `range` that produces no valid numeric bound now returns None (skip) instead of an empty, unconstraining `Range` — matching the vectorsets null-bound fix in #115. A range with some valid bounds still emits those.
3. **VectorSets multi-valued `labels` contains-any**: `match_any` on the array-valued `labels` field now emits `("v" in .labels or ...)` (array membership — verified on live Redis 8.8 VSIM), keeping exact `.field == "v"` for all scalar keyword fields. `"x" in .scalar` does substring matching, so this is deliberately special-cased to the only array field (`labels`).
4. **VectorSets full-text**: doc already states it's best-effort substring `contains`, not tokenized (no change needed).
5. **turbopuffer**: strengthened the `// follow-up:` note that scalar `In` doesn't do array contains-any and doesn't reconcile element types (cloud-only, not implemented).

Existing tests that pinned the old (inconsistent) behavior were updated to the corrected behavior.

### Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean; 432 unit tests
- Behavior changes are consistency fixes for degenerate/edge inputs; CI's full per-engine integration suite is the recall gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)