### PR TITLE
feat(datasets): local synthetic dataset generator for sparse/hybrid/filter (fixes #122)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,7 @@ path = "src/bin/bench_npy.rs"
 [[bin]]
 name = "vector-db-benchmark"
 path = "src/bin/vector_db_benchmark/main.rs"
+
+[[bin]]
+name = "generate-dataset"
+path = "src/bin/generate_dataset.rs"

--- a/README.md
+++ b/README.md
@@ -238,6 +238,48 @@ Most datasets are automatically downloaded on first use. The image includes `ran
 | Random Match Keyword Small Vocab-256: Small vocabulary keyword matching (with filters)                     |        256 |   1,000,000 |    10,000 |       100 | Cosine    |
 | Random Match Keyword Small Vocab-256: Small vocabulary keyword matching (no filters)                       |        256 |   1,000,000 |    10,000 |       100 | Cosine    |
 
+### Generating local datasets
+
+The sparse-vector, hybrid (dense+sparse fusion), and multi-datatype filter code
+paths ship with **locally-generated** synthetic datasets — small, deterministic
+(fixed-seed) fixtures with **no public download link**. Generate them once with:
+
+```bash
+cargo run --release --bin generate-dataset          # writes into ./datasets
+# or a subset / custom location:
+cargo run --release --bin generate-dataset -- --only sparse --out-dir /tmp/ds
+```
+
+This writes three datasets under `datasets/` (each in the exact on-disk layout
+its reader expects), registered in [`datasets/datasets.json`](./datasets/datasets.json):
+
+| Dataset                | Type     | Dims | Distance | Layout                                                                                  |
+| ---------------------- | -------- | ---: | -------- | --------------------------------------------------------------------------------------- |
+| `synthetic-sparse-300` | `sparse` |  300 | dot      | `data.csr` + `queries.csr` + `neighbours.jsonl` (dot/MIPS ground truth)                 |
+| `synthetic-hybrid-16`  | `hybrid` |   16 | l2       | `vectors.npy` + `queries.npy` + `data.csr` + `queries.csr` + shared `neighbours.jsonl`  |
+| `synthetic-filter-32`  | `tar`    |   32 | l2       | `vectors.npy` + `payloads.jsonl` + `tests.jsonl` (per-query `conditions` + filtered GT) |
+
+`synthetic-filter-32`'s per-query `conditions` rotate through **keyword**, **int**,
+**bool** and **datetime** filters (schema `color:keyword, size:int, flag:bool, ts:datetime`),
+each with ground truth brute-forced over only the matching documents, so a high
+recall proves the engine actually applied the filter. The generated files are
+git-ignored — regenerate them on any checkout with the command above.
+
+Example runs against a generated dataset (start the engine first, e.g.
+`docker compose -f tests/docker-compose.test.yml up -d qdrant redis`):
+
+```bash
+# Sparse (Qdrant):
+cargo run --release --bin vector-db-benchmark -- \
+  --engines qdrant-default --datasets synthetic-sparse-300
+# Hybrid dense+sparse fusion (Qdrant):
+cargo run --release --bin vector-db-benchmark -- \
+  --engines qdrant-hybrid --datasets synthetic-hybrid-16
+# Filter datatypes (Redis):
+cargo run --release --bin vector-db-benchmark -- \
+  --engines redis-docker-test --datasets synthetic-filter-32
+```
+
 ## Engine Configurations
 
 Engine configurations live in [`experiments/configurations/`](./experiments/configurations/). Each JSON file defines one or more experiment configurations specifying the engine, index parameters, search parameters, and upload parallelism.

--- a/datasets/datasets.json
+++ b/datasets/datasets.json
@@ -1367,5 +1367,35 @@
     "link": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/vectorsearch/cohere-wikipedia-22-12-en-embeddings/documents-10m.hdf5.bz2",
     "vector_count": 10000000,
     "description": "Wikipedia embeddings"
+  },
+  {
+    "name": "synthetic-sparse-300",
+    "vector_size": 300,
+    "distance": "dot",
+    "type": "sparse",
+    "path": "synthetic-sparse-300",
+    "description": "Locally-generated sparse dataset (data.csr + queries.csr + neighbours.jsonl), dot/MIPS ground truth. NO public download — generate with `cargo run --release --bin generate-dataset` (writes into datasets/). Exercises the sparse code path end-to-end, e.g. --engines qdrant-default --datasets synthetic-sparse-300."
+  },
+  {
+    "name": "synthetic-hybrid-16",
+    "vector_size": 16,
+    "distance": "l2",
+    "type": "hybrid",
+    "path": "synthetic-hybrid-16",
+    "description": "Locally-generated hybrid dense+sparse dataset (vectors.npy + queries.npy + data.csr + queries.csr + shared neighbours.jsonl). Ground truth is recoverable ONLY by fusing both modalities (RRF). NO public download — generate with `cargo run --release --bin generate-dataset`. Exercises the hybrid path, e.g. --engines qdrant-hybrid --datasets synthetic-hybrid-16."
+  },
+  {
+    "name": "synthetic-filter-32",
+    "vector_size": 32,
+    "distance": "l2",
+    "type": "tar",
+    "path": "synthetic-filter-32/",
+    "schema": {
+      "color": "keyword",
+      "size": "int",
+      "flag": "bool",
+      "ts": "datetime"
+    },
+    "description": "Locally-generated filter-datatype dataset (compound: vectors.npy + payloads.jsonl + tests.jsonl). Per-query `conditions` rotate through keyword/int/bool/datetime filters, each with filtered ground truth. NO public download — generate with `cargo run --release --bin generate-dataset`. Exercises the filter path, e.g. --engines redis-docker-test --datasets synthetic-filter-32."
   }
 ]

--- a/src/bin/generate_dataset.rs
+++ b/src/bin/generate_dataset.rs
@@ -1,0 +1,305 @@
+//! `generate-dataset` — emit small, deterministic synthetic datasets on disk in
+//! the exact layouts the benchmark's sparse / hybrid / compound(tar) readers
+//! expect, so the sparse, hybrid and filter-datatype code paths can be run
+//! end-to-end from a registered dataset name (not just from the integration
+//! tests).
+//!
+//! The datasets are registered in `datasets/datasets.json` with LOCAL paths and
+//! NO download link — they do not exist until this binary writes them. Run:
+//!
+//! ```text
+//! cargo run --release --bin generate-dataset          # writes into ./datasets
+//! cargo run --release --bin generate-dataset -- --out-dir /tmp/ds --only sparse
+//! ```
+//!
+//! What it writes (all sizes are tiny so generation + a smoke run are fast):
+//!   * `synthetic-sparse-300/`  — CSR `data.csr` + `queries.csr` +
+//!     `neighbours.jsonl` (sparse, dot/MIPS).
+//!   * `synthetic-hybrid-16/`   — dense `vectors.npy`/`queries.npy` + sparse
+//!     `data.csr`/`queries.csr` + shared `neighbours.jsonl` (hybrid, RRF fusion).
+//!   * `synthetic-filter-32/`   — compound `vectors.npy` + `payloads.jsonl`
+//!     (keyword/int/bool/datetime fields) + `tests.jsonl` (per-query `conditions`
+//!     filter + filtered ground truth). `type: "tar"`.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{Duration, TimeZone, Utc};
+use clap::Parser;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+use vector_db_benchmark::readers::{write_npy_vectors, write_sparse_matrix};
+use vector_db_benchmark::synthetic::{
+    generate_hybrid, generate_sparse, write_neighbours_jsonl, SparseData,
+};
+
+/// Dataset names as registered in `datasets/datasets.json`.
+const SPARSE_NAME: &str = "synthetic-sparse-300";
+const HYBRID_NAME: &str = "synthetic-hybrid-16";
+const FILTER_NAME: &str = "synthetic-filter-32";
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "generate-dataset",
+    about = "Generate small deterministic synthetic datasets (sparse / hybrid / filter) on disk."
+)]
+struct Args {
+    /// Base directory to write datasets into (each dataset gets its own subdir).
+    #[arg(long, default_value = "datasets")]
+    out_dir: PathBuf,
+
+    /// Generate only one dataset kind. Omit to generate all three.
+    #[arg(long, value_parser = ["sparse", "hybrid", "filter"])]
+    only: Option<String>,
+}
+
+fn main() {
+    let args = Args::parse();
+    if let Err(e) = run(&args) {
+        eprintln!("generate-dataset: error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn run(args: &Args) -> Result<(), String> {
+    std::fs::create_dir_all(&args.out_dir)
+        .map_err(|e| format!("create {}: {}", args.out_dir.display(), e))?;
+
+    let want = |kind: &str| args.only.as_deref().map(|o| o == kind).unwrap_or(true);
+
+    if want("sparse") {
+        gen_sparse(&args.out_dir)?;
+    }
+    if want("hybrid") {
+        gen_hybrid(&args.out_dir)?;
+    }
+    if want("filter") {
+        gen_filter(&args.out_dir)?;
+    }
+    println!("\nDone. Register/select these datasets by the names printed above.");
+    Ok(())
+}
+
+/// Report a written file with its on-disk size.
+fn note(path: &Path) -> Result<(), String> {
+    let len = std::fs::metadata(path)
+        .map_err(|e| format!("stat {}: {}", path.display(), e))?
+        .len();
+    println!("    {:<20} {:>8} bytes", file_name(path), len);
+    Ok(())
+}
+
+fn file_name(path: &Path) -> String {
+    path.file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+// ── sparse ──────────────────────────────────────────────────────────────────
+
+fn gen_sparse(base: &Path) -> Result<(), String> {
+    // dim=300, nnz=10, 150 docs, 10 queries, top-10 GT. Fixed seed → reproducible.
+    let SparseData {
+        data,
+        queries,
+        neighbours,
+    } = generate_sparse(0x5A5A_5EED, 300, 10, 150, 10, 10);
+
+    let dir = base.join(SPARSE_NAME);
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    println!(
+        "[sparse]  {SPARSE_NAME}/  ({} docs, {} queries)",
+        data.len(),
+        queries.len()
+    );
+
+    let data_csr = dir.join("data.csr");
+    let queries_csr = dir.join("queries.csr");
+    let nb = dir.join("neighbours.jsonl");
+    write_sparse_matrix(data_csr.to_str().ok_or("bad path")?, &data)?;
+    write_sparse_matrix(queries_csr.to_str().ok_or("bad path")?, &queries)?;
+    write_neighbours_jsonl(&nb, &neighbours)?;
+    note(&data_csr)?;
+    note(&queries_csr)?;
+    note(&nb)?;
+    Ok(())
+}
+
+// ── hybrid ──────────────────────────────────────────────────────────────────
+
+fn gen_hybrid(base: &Path) -> Result<(), String> {
+    let h = generate_hybrid(0xB19_1DEA);
+
+    let dir = base.join(HYBRID_NAME);
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    println!(
+        "[hybrid]  {HYBRID_NAME}/  ({} docs, {} queries, dim {}, top {})",
+        h.dense.len(),
+        h.dense_queries.len(),
+        h.dim,
+        h.top
+    );
+
+    let vectors_npy = dir.join("vectors.npy");
+    let queries_npy = dir.join("queries.npy");
+    let data_csr = dir.join("data.csr");
+    let queries_csr = dir.join("queries.csr");
+    let nb = dir.join("neighbours.jsonl");
+    write_npy_vectors(vectors_npy.to_str().ok_or("bad path")?, &h.dense)?;
+    write_npy_vectors(queries_npy.to_str().ok_or("bad path")?, &h.dense_queries)?;
+    write_sparse_matrix(data_csr.to_str().ok_or("bad path")?, &h.sparse)?;
+    write_sparse_matrix(queries_csr.to_str().ok_or("bad path")?, &h.sparse_queries)?;
+    write_neighbours_jsonl(&nb, &h.neighbours)?;
+    for p in [&vectors_npy, &queries_npy, &data_csr, &queries_csr, &nb] {
+        note(p)?;
+    }
+    Ok(())
+}
+
+// ── filter (compound / tar) ─────────────────────────────────────────────────
+
+/// Keyword values assigned round-robin by `id % 4`.
+const COLORS: [&str; 4] = ["red", "green", "blue", "dark blue"];
+
+fn color_for(id: usize) -> &'static str {
+    COLORS[id % COLORS.len()]
+}
+fn size_for(id: usize) -> i64 {
+    (id % 5) as i64 + 1
+}
+fn flag_for(id: usize) -> bool {
+    id.is_multiple_of(2)
+}
+
+/// A per-query filter: the `conditions` JSON attached to the query and the
+/// predicate deciding which document ids satisfy it (used to brute-force the
+/// filtered ground truth). Rotating these across queries exercises the keyword,
+/// int, bool and datetime filter datatypes in a single dataset.
+struct QueryFilter {
+    conditions: serde_json::Value,
+    matches: Box<dyn Fn(usize) -> bool>,
+}
+
+fn gen_filter(base: &Path) -> Result<(), String> {
+    const N: usize = 400;
+    const N_QUERIES: usize = 12;
+    const DIM: usize = 32;
+    const TOP: usize = 10;
+
+    // Fixed seed → reproducible vectors, queries and ground truth.
+    let mut rng = StdRng::seed_from_u64(0xF117E_u64);
+    let gen_vec =
+        |rng: &mut StdRng| -> Vec<f32> { (0..DIM).map(|_| rng.gen_range(-1.0f32..1.0)).collect() };
+    let vectors: Vec<Vec<f32>> = (0..N).map(|_| gen_vec(&mut rng)).collect();
+    let queries: Vec<Vec<f32>> = (0..N_QUERIES).map(|_| gen_vec(&mut rng)).collect();
+
+    // datetime field: one ISO-8601 timestamp per doc, one day apart from base.
+    let base_ts = Utc.timestamp_opt(1_609_459_200, 0).unwrap(); // 2021-01-01T00:00:00Z
+    let iso_for = move |day: i64| (base_ts + Duration::days(day)).to_rfc3339();
+    let ts_gte = iso_for(100);
+    let ts_lt = iso_for(300);
+
+    // Per-query filter, rotating through the four datatypes.
+    let filter_for = |q: usize| -> QueryFilter {
+        match q % 4 {
+            0 => QueryFilter {
+                // keyword match_any: color IN {red, blue}
+                conditions: serde_json::json!({
+                    "and": [ { "color": { "match": { "any": ["red", "blue"] } } } ]
+                }),
+                matches: Box::new(|id| ["red", "blue"].contains(&color_for(id))),
+            },
+            1 => QueryFilter {
+                // int match_any: size IN {1, 2, 3}
+                conditions: serde_json::json!({
+                    "and": [ { "size": { "match": { "any": [1, 2, 3] } } } ]
+                }),
+                matches: Box::new(|id| [1, 2, 3].contains(&size_for(id))),
+            },
+            2 => QueryFilter {
+                // bool: flag == true
+                conditions: serde_json::json!({
+                    "and": [ { "flag": { "match": { "value": true } } } ]
+                }),
+                matches: Box::new(flag_for),
+            },
+            _ => {
+                // datetime range: ts IN [day 100, day 300)
+                let gte = ts_gte.clone();
+                let lt = ts_lt.clone();
+                QueryFilter {
+                    conditions: serde_json::json!({
+                        "and": [ { "ts": { "range": { "gte": gte, "lt": lt } } } ]
+                    }),
+                    matches: Box::new(|id| (100..300).contains(&id)),
+                }
+            }
+        }
+    };
+
+    // Ground truth: top-TOP nearest by L2 over ONLY the docs matching the filter.
+    let filtered_gt = |q_vec: &[f32], matches: &dyn Fn(usize) -> bool| -> Vec<i64> {
+        let l2 = |a: &[f32], b: &[f32]| -> f64 {
+            a.iter()
+                .zip(b)
+                .map(|(x, y)| (*x as f64 - *y as f64).powi(2))
+                .sum()
+        };
+        let mut scored: Vec<(i64, f64)> = (0..N)
+            .filter(|id| matches(*id))
+            .map(|id| (id as i64, l2(q_vec, &vectors[id])))
+            .collect();
+        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        scored.iter().take(TOP).map(|(id, _)| *id).collect()
+    };
+
+    let dir = base.join(FILTER_NAME);
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    println!(
+        "[filter]  {FILTER_NAME}/  ({N} docs, {N_QUERIES} queries, dim {DIM}, \
+         fields color/size/flag/ts)"
+    );
+
+    // vectors.npy (implicit ids 0..N).
+    let vectors_npy = dir.join("vectors.npy");
+    write_npy_vectors(vectors_npy.to_str().ok_or("bad path")?, &vectors)?;
+
+    // payloads.jsonl: keyword/int/bool/datetime per doc.
+    let payloads: String = (0..N)
+        .map(|id| {
+            serde_json::json!({
+                "color": color_for(id),
+                "size": size_for(id),
+                "flag": flag_for(id),
+                "ts": iso_for(id as i64),
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let payloads_path = dir.join("payloads.jsonl");
+    std::fs::write(&payloads_path, payloads).map_err(|e| e.to_string())?;
+
+    // tests.jsonl: query + conditions + filtered ground truth.
+    let tests: String = queries
+        .iter()
+        .enumerate()
+        .map(|(q, q_vec)| {
+            let f = filter_for(q);
+            serde_json::json!({
+                "query": q_vec.iter().map(|x| *x as f64).collect::<Vec<_>>(),
+                "conditions": f.conditions,
+                "closest_ids": filtered_gt(q_vec, &f.matches),
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let tests_path = dir.join("tests.jsonl");
+    std::fs::write(&tests_path, tests).map_err(|e| e.to_string())?;
+
+    note(&vectors_npy)?;
+    note(&payloads_path)?;
+    note(&tests_path)?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod metrics;
 pub mod readers;
 pub mod redis_client;
+pub mod synthetic;
 
 // Re-export commonly used types
 pub use config::RedisConfig;

--- a/src/synthetic.rs
+++ b/src/synthetic.rs
@@ -1,0 +1,309 @@
+//! Deterministic synthetic dataset generation.
+//!
+//! Shared, fixed-seed generators for the small synthetic datasets used to
+//! exercise the sparse / hybrid / filter code paths end-to-end. The SAME
+//! generators back both:
+//!   * the `generate-dataset` binary (writes runnable datasets under `datasets/`
+//!     that are registered in `datasets/datasets.json`), and
+//!   * the `tests/common` integration fixtures (temp-project scaffolding + engine
+//!     configs around the identical data),
+//!
+//! so there is a single source of truth for the planted data and its ground
+//! truth. Only the on-disk serialization primitives (`write_sparse_matrix`,
+//! `write_npy_vectors`) live in [`crate::readers`]; this module adds the
+//! remaining jsonl writers and the pure data-generation logic.
+
+use std::path::Path;
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+use crate::readers::SparseVector;
+
+/// Write `neighbours.jsonl` (one JSON id-array per line) at `path`. This is the
+/// ground-truth layout the sparse/hybrid readers expect (see
+/// `dataset.rs::read_neighbours_strict`).
+pub fn write_neighbours_jsonl(path: &Path, neighbours: &[Vec<i64>]) -> Result<(), String> {
+    let body = neighbours
+        .iter()
+        .map(|nn| serde_json::to_string(nn).map_err(|e| e.to_string()))
+        .collect::<Result<Vec<_>, _>>()?
+        .join("\n");
+    std::fs::write(path, body).map_err(|e| format!("write {}: {}", path.display(), e))
+}
+
+/// Write `vectors` as a `.jsonl` file (one JSON float-array per line), the
+/// layout the `type:"jsonl"` reader expects.
+pub fn write_jsonl_vectors(path: &Path, vectors: &[Vec<f32>]) -> Result<(), String> {
+    let body = vectors
+        .iter()
+        .map(|v| {
+            serde_json::to_string(&v.iter().map(|x| *x as f64).collect::<Vec<_>>())
+                .map_err(|e| e.to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .join("\n");
+    std::fs::write(path, body).map_err(|e| format!("write {}: {}", path.display(), e))
+}
+
+/// A generated sparse dataset: `data` (corpus) + `queries`, with `neighbours`
+/// the top-`top` brute-force dot-product (descending / MIPS) ground truth.
+pub struct SparseData {
+    pub data: Vec<SparseVector>,
+    pub queries: Vec<SparseVector>,
+    pub neighbours: Vec<Vec<i64>>,
+}
+
+/// Generate a deterministic random sparse dataset and its dot-product
+/// (descending) ground truth. Sparse similarity is MIPS — larger dot = more
+/// similar — so the neighbours are sorted DESCENDING by dot product.
+///
+/// `seed` fixes the RNG; `dim` is the sparse dimensionality, `nnz` the non-zeros
+/// per vector, `n` the corpus size, `q` the query count and `top` the number of
+/// ground-truth neighbours per query.
+pub fn generate_sparse(
+    seed: u64,
+    dim: usize,
+    nnz: usize,
+    n: usize,
+    q: usize,
+    top: usize,
+) -> SparseData {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut make = |count: usize| -> Vec<SparseVector> {
+        (0..count)
+            .map(|_| {
+                let mut idx: Vec<u32> = Vec::with_capacity(nnz);
+                while idx.len() < nnz {
+                    let c = rng.gen_range(0..dim as u32);
+                    if !idx.contains(&c) {
+                        idx.push(c);
+                    }
+                }
+                idx.sort_unstable();
+                let values: Vec<f32> = (0..nnz).map(|_| rng.gen_range(0.1..1.0)).collect();
+                SparseVector {
+                    indices: idx,
+                    values,
+                }
+            })
+            .collect()
+    };
+    let data = make(n);
+    let queries = make(q);
+
+    // Brute-force sparse dot product; sort DESCENDING (MIPS).
+    let dot = |a: &SparseVector, b: &SparseVector| -> f64 {
+        let mut s = 0.0f64;
+        for (i, &ai) in a.indices.iter().enumerate() {
+            if let Some(j) = b.indices.iter().position(|&bi| bi == ai) {
+                s += a.values[i] as f64 * b.values[j] as f64;
+            }
+        }
+        s
+    };
+    let neighbours: Vec<Vec<i64>> = queries
+        .iter()
+        .map(|qv| {
+            let mut scored: Vec<(i64, f64)> = data
+                .iter()
+                .enumerate()
+                .map(|(i, d)| (i as i64, dot(qv, d)))
+                .collect();
+            // DESCENDING by dot product (b vs a). Do NOT flip this.
+            scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+            scored.iter().take(top).map(|(id, _)| *id).collect()
+        })
+        .collect();
+
+    SparseData {
+        data,
+        queries,
+        neighbours,
+    }
+}
+
+/// A generated hybrid (dense + sparse) dataset. The fused (RRF) top-`top` ground
+/// truth is recoverable ONLY by combining both modalities — neither dense nor
+/// sparse alone reaches it (see the detailed planting rationale below).
+pub struct HybridData {
+    pub dense: Vec<Vec<f32>>,
+    pub dense_queries: Vec<Vec<f32>>,
+    pub sparse: Vec<SparseVector>,
+    pub sparse_queries: Vec<SparseVector>,
+    pub neighbours: Vec<Vec<i64>>,
+    /// Dense dimensionality.
+    pub dim: usize,
+    /// Ground-truth / top-k set size.
+    pub top: usize,
+}
+
+/// Generate a deterministic PLANTED hybrid dataset whose fused (RRF) top-K
+/// ground truth is recoverable ONLY by combining a dense prefetch and a sparse
+/// prefetch. Per query, K ground-truth docs are split into two halves and two
+/// rings of single-modality distractors so that:
+///   * dense-only top-K  → recall(R) ≈ 0.5
+///   * sparse-only top-K → recall(R) ≈ 0.5
+///   * fused (RRF) top-K → recall(R) ≈ 1.0
+///
+/// This is the exact construction validated by the qdrant hybrid integration
+/// test (and its dense-only negative control).
+pub fn generate_hybrid(seed: u64) -> HybridData {
+    const K: usize = 8; // top-k / ground-truth-set size (must be even)
+    const HALF: usize = K / 2; // per-half / per-distractor-ring size
+    const Q: usize = 6; // queries (and dense centre axes)
+    const DENSE_DIM: usize = 16; // >= Q centre dims + HALF distractor bump dims
+    const PER_Q: usize = 4 * HALF; // R_dense + R_sparse + D_d + D_s per query
+    const FILLER: usize = 24;
+    const N: usize = Q * PER_Q + FILLER; // = 120
+    const BIG: f32 = 100.0; // centre magnitude → regions ~141 apart, origin ~100
+
+    // Sparse layout: query q owns index block F_q = [q*HALF .. q*HALF+HALF);
+    // dense-only distractors / filler use a disjoint "junk" block J (dot 0).
+    const F_TOTAL: usize = Q * HALF;
+
+    let mut rng = StdRng::seed_from_u64(seed);
+    let tiny = |rng: &mut StdRng| -> f32 { rng.gen_range(-0.01f32..0.01) };
+
+    // Doc-id block layout for query q: base = q*PER_Q, then four HALF-sized rings.
+    let base = |q: usize| q * PER_Q;
+    let r_dense_id = |q: usize, j: usize| base(q) + j; //            [base,       base+HALF)
+    let r_sparse_id = |q: usize, j: usize| base(q) + HALF + j; //    [base+HALF,  base+2HALF)
+    let d_d_id = |q: usize, j: usize| base(q) + 2 * HALF + j; //     [base+2HALF, base+3HALF)
+    let d_s_id = |q: usize, j: usize| base(q) + 3 * HALF + j; //     [base+3HALF, base+4HALF)
+    let filler_start = Q * PER_Q;
+
+    // Dense centre for query q: BIG on axis q, else 0.
+    let centre = |q: usize| -> Vec<f32> {
+        let mut v = vec![0.0f32; DENSE_DIM];
+        v[q] = BIG;
+        v
+    };
+    // A dense doc = centre + `mag` along a distractor axis (dims Q..DENSE_DIM),
+    // so its L2 distance from the query (= centre) is exactly `mag`.
+    let offset_from = |c: &[f32], mag: f32, j: usize| -> Vec<f32> {
+        let mut v = c.to_vec();
+        v[Q + (j % (DENSE_DIM - Q))] += mag;
+        v
+    };
+
+    let junk: Vec<u32> = (F_TOTAL..F_TOTAL + HALF).map(|i| i as u32).collect();
+
+    let mut dense: Vec<Vec<f32>> = vec![vec![0.0f32; DENSE_DIM]; N];
+    let mut sparse: Vec<SparseVector> = vec![
+        SparseVector {
+            indices: vec![],
+            values: vec![]
+        };
+        N
+    ];
+
+    for q in 0..Q {
+        let c = centre(q);
+        let f_q: Vec<u32> = (q * HALF..q * HALF + HALF).map(|i| i as u32).collect();
+        // Per-doc tiny increments break ties so tiers stay crisply ordered.
+        let sp = |indices: &[u32], val: f32, j: usize| SparseVector {
+            indices: indices.to_vec(),
+            values: indices.iter().map(|_| val + 0.001 * j as f32).collect(),
+        };
+        for j in 0..HALF {
+            // R_dense: dense dist 1.0 (ranks 0..HALF); sparse dot ~ HALF*1 (low).
+            dense[r_dense_id(q, j)] = offset_from(&c, 1.0, j);
+            sparse[r_dense_id(q, j)] = sp(&f_q, 1.0, j);
+
+            // D_d: dense dist 2.0 (ranks HALF..K); sparse = junk → dot 0.
+            dense[d_d_id(q, j)] = offset_from(&c, 2.0, HALF + j);
+            sparse[d_d_id(q, j)] = sp(&junk, 1.0, j);
+
+            // R_sparse: dense dist 3.0 (ranks K..3K/2); sparse dot ~ HALF*3 (top).
+            dense[r_sparse_id(q, j)] = offset_from(&c, 3.0, 2 * HALF + j);
+            sparse[r_sparse_id(q, j)] = sp(&f_q, 3.0, j);
+
+            // D_s: dense ≈ origin (dist ~BIG, absent from dense top); sparse dot ~
+            // HALF*2 (ranks HALF..K, between R_sparse and R_dense).
+            let mut ds_v = vec![0.0f32; DENSE_DIM];
+            for x in ds_v.iter_mut() {
+                *x += tiny(&mut rng);
+            }
+            dense[d_s_id(q, j)] = ds_v;
+            sparse[d_s_id(q, j)] = sp(&f_q, 2.0, j);
+        }
+    }
+    // Filler: dense ≈ origin, sparse in junk block (dot 0 with every query).
+    for id in filler_start..N {
+        let mut fv = vec![0.0f32; DENSE_DIM];
+        for x in fv.iter_mut() {
+            *x += tiny(&mut rng);
+        }
+        dense[id] = fv;
+        sparse[id] = SparseVector {
+            indices: junk.clone(),
+            values: vec![1.0f32; HALF],
+        };
+    }
+
+    // Queries: dense = centre_q, sparse = ones on F_q. Ground truth R_q =
+    // R_dense ∪ R_sparse (the full K planted docs).
+    let mut dense_q: Vec<Vec<f32>> = Vec::with_capacity(Q);
+    let mut sparse_q: Vec<SparseVector> = Vec::with_capacity(Q);
+    let mut neighbours: Vec<Vec<i64>> = Vec::with_capacity(Q);
+    for q in 0..Q {
+        dense_q.push(centre(q));
+        sparse_q.push(SparseVector {
+            indices: (q * HALF..q * HALF + HALF).map(|i| i as u32).collect(),
+            values: vec![1.0f32; HALF],
+        });
+        let mut gt: Vec<i64> = (0..HALF).map(|j| r_dense_id(q, j) as i64).collect();
+        gt.extend((0..HALF).map(|j| r_sparse_id(q, j) as i64));
+        neighbours.push(gt);
+    }
+
+    HybridData {
+        dense,
+        dense_queries: dense_q,
+        sparse,
+        sparse_queries: sparse_q,
+        neighbours,
+        dim: DENSE_DIM,
+        top: K,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sparse_generation_is_deterministic_and_shaped() {
+        let a = generate_sparse(0x5A5A_5EED, 300, 10, 150, 10, 10);
+        let b = generate_sparse(0x5A5A_5EED, 300, 10, 150, 10, 10);
+        assert_eq!(a.data.len(), 150);
+        assert_eq!(a.queries.len(), 10);
+        assert_eq!(a.neighbours.len(), 10);
+        assert!(a.neighbours.iter().all(|n| n.len() == 10));
+        // Every vector has exactly nnz non-zeros with distinct, sorted indices.
+        for v in a.data.iter().chain(a.queries.iter()) {
+            assert_eq!(v.indices.len(), 10);
+            assert_eq!(v.values.len(), 10);
+            assert!(v.indices.windows(2).all(|w| w[0] < w[1]));
+        }
+        // Deterministic across calls.
+        assert_eq!(a.data, b.data);
+        assert_eq!(a.neighbours, b.neighbours);
+    }
+
+    #[test]
+    fn hybrid_generation_is_deterministic_and_row_aligned() {
+        let h = generate_hybrid(0xB19_1DEA);
+        assert_eq!(h.dim, 16);
+        assert_eq!(h.top, 8);
+        assert_eq!(h.dense.len(), h.sparse.len());
+        assert_eq!(h.dense_queries.len(), h.sparse_queries.len());
+        assert_eq!(h.neighbours.len(), h.dense_queries.len());
+        assert!(h.neighbours.iter().all(|n| n.len() == h.top));
+        assert!(h.dense.iter().all(|v| v.len() == h.dim));
+        let h2 = generate_hybrid(0xB19_1DEA);
+        assert_eq!(h.dense, h2.dense);
+        assert_eq!(h.neighbours, h2.neighbours);
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,7 +17,8 @@ use std::path::{Path, PathBuf};
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use vector_db_benchmark::readers::{write_npy_vectors, write_sparse_matrix, SparseVector};
+use vector_db_benchmark::readers::{write_npy_vectors, write_sparse_matrix};
+use vector_db_benchmark::synthetic::{generate_hybrid, generate_sparse, HybridData, SparseData};
 
 /// Keyword values assigned round-robin to documents by `id % 4`.
 ///
@@ -729,52 +730,13 @@ pub fn write_sparse_project(dataset_name: &str, engine_configs_json: &str) -> Sp
     const TOP: usize = 10;
 
     // Fixed seed → reproducible data/queries/ground-truth across engines & runs.
-    let mut rng = StdRng::seed_from_u64(0x5A5A_5EED);
-    let mut make = |count: usize| -> Vec<SparseVector> {
-        (0..count)
-            .map(|_| {
-                let mut idx: Vec<u32> = Vec::with_capacity(NNZ);
-                while idx.len() < NNZ {
-                    let c = rng.gen_range(0..DIM as u32);
-                    if !idx.contains(&c) {
-                        idx.push(c);
-                    }
-                }
-                idx.sort_unstable();
-                let values: Vec<f32> = (0..NNZ).map(|_| rng.gen_range(0.1..1.0)).collect();
-                SparseVector {
-                    indices: idx,
-                    values,
-                }
-            })
-            .collect()
-    };
-    let data = make(N);
-    let queries = make(Q);
-
-    // Brute-force sparse dot product; sort DESCENDING (MIPS).
-    let dot = |a: &SparseVector, b: &SparseVector| -> f64 {
-        let mut s = 0.0f64;
-        for (i, &ai) in a.indices.iter().enumerate() {
-            if let Some(j) = b.indices.iter().position(|&bi| bi == ai) {
-                s += a.values[i] as f64 * b.values[j] as f64;
-            }
-        }
-        s
-    };
-    let neighbors: Vec<Vec<i64>> = queries
-        .iter()
-        .map(|qv| {
-            let mut scored: Vec<(i64, f64)> = data
-                .iter()
-                .enumerate()
-                .map(|(i, d)| (i as i64, dot(qv, d)))
-                .collect();
-            // DESCENDING by dot product (b vs a). Do NOT flip this.
-            scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-            scored.iter().take(TOP).map(|(id, _)| *id).collect()
-        })
-        .collect();
+    // Generation is shared with the `generate-dataset` binary via
+    // `vector_db_benchmark::synthetic` so both produce byte-identical datasets.
+    let SparseData {
+        data,
+        queries,
+        neighbours: neighbors,
+    } = generate_sparse(0x5A5A_5EED, DIM, NNZ, N, Q, TOP);
 
     let tmp = tempfile::tempdir().expect("temp dir");
     let root = tmp.path().to_path_buf();
@@ -861,114 +823,20 @@ pub struct HybridProject {
 /// Build a temp project with a deterministic planted hybrid dataset whose fused
 /// (RRF) top-K ground truth is recoverable ONLY by combining both modalities.
 pub fn write_hybrid_project(dataset_name: &str, engine_configs_json: &str) -> HybridProject {
-    const K: usize = 8; // top-k / ground-truth-set size (must be even)
-    const HALF: usize = K / 2; // per-half / per-distractor-ring size
-    const Q: usize = 6; // queries (and dense centre axes)
-    const DENSE_DIM: usize = 16; // >= Q centre dims + HALF distractor bump dims
-    const PER_Q: usize = 4 * HALF; // R_dense + R_sparse + D_d + D_s per query
-    const FILLER: usize = 24;
-    const N: usize = Q * PER_Q + FILLER; // = 120
-    const BIG: f32 = 100.0; // centre magnitude → regions ~141 apart, origin ~100
-
-    // Sparse layout: query q owns index block F_q = [q*HALF .. q*HALF+HALF);
-    // dense-only distractors / filler use a disjoint "junk" block J (dot 0).
-    const F_TOTAL: usize = Q * HALF;
-
-    let mut rng = StdRng::seed_from_u64(0xB19_1DEA);
-    let tiny = |rng: &mut StdRng| -> f32 { rng.gen_range(-0.01f32..0.01) };
-
-    // Doc-id block layout for query q: base = q*PER_Q, then four HALF-sized rings.
-    let base = |q: usize| q * PER_Q;
-    let r_dense_id = |q: usize, j: usize| base(q) + j; //            [base,       base+HALF)
-    let r_sparse_id = |q: usize, j: usize| base(q) + HALF + j; //    [base+HALF,  base+2HALF)
-    let d_d_id = |q: usize, j: usize| base(q) + 2 * HALF + j; //     [base+2HALF, base+3HALF)
-    let d_s_id = |q: usize, j: usize| base(q) + 3 * HALF + j; //     [base+3HALF, base+4HALF)
-    let filler_start = Q * PER_Q;
-
-    // Dense centre for query q: BIG on axis q, else 0.
-    let centre = |q: usize| -> Vec<f32> {
-        let mut v = vec![0.0f32; DENSE_DIM];
-        v[q] = BIG;
-        v
-    };
-    // A dense doc = centre + `mag` along a distractor axis (dims Q..DENSE_DIM),
-    // so its L2 distance from the query (= centre) is exactly `mag`.
-    let offset_from = |c: &[f32], mag: f32, j: usize| -> Vec<f32> {
-        let mut v = c.to_vec();
-        v[Q + (j % (DENSE_DIM - Q))] += mag;
-        v
-    };
-
-    let junk: Vec<u32> = (F_TOTAL..F_TOTAL + HALF).map(|i| i as u32).collect();
-
-    let mut dense: Vec<Vec<f32>> = vec![vec![0.0f32; DENSE_DIM]; N];
-    let mut sparse: Vec<SparseVector> = vec![
-        SparseVector {
-            indices: vec![],
-            values: vec![]
-        };
-        N
-    ];
-
-    for q in 0..Q {
-        let c = centre(q);
-        let f_q: Vec<u32> = (q * HALF..q * HALF + HALF).map(|i| i as u32).collect();
-        // Per-doc tiny increments break ties so tiers stay crisply ordered.
-        let sp = |indices: &[u32], val: f32, j: usize| SparseVector {
-            indices: indices.to_vec(),
-            values: indices.iter().map(|_| val + 0.001 * j as f32).collect(),
-        };
-        for j in 0..HALF {
-            // R_dense: dense dist 1.0 (ranks 0..HALF); sparse dot ~ HALF*1 (low).
-            dense[r_dense_id(q, j)] = offset_from(&c, 1.0, j);
-            sparse[r_dense_id(q, j)] = sp(&f_q, 1.0, j);
-
-            // D_d: dense dist 2.0 (ranks HALF..K); sparse = junk → dot 0.
-            dense[d_d_id(q, j)] = offset_from(&c, 2.0, HALF + j);
-            sparse[d_d_id(q, j)] = sp(&junk, 1.0, j);
-
-            // R_sparse: dense dist 3.0 (ranks K..3K/2); sparse dot ~ HALF*3 (top).
-            dense[r_sparse_id(q, j)] = offset_from(&c, 3.0, 2 * HALF + j);
-            sparse[r_sparse_id(q, j)] = sp(&f_q, 3.0, j);
-
-            // D_s: dense ≈ origin (dist ~BIG, absent from dense top); sparse dot ~
-            // HALF*2 (ranks HALF..K, between R_sparse and R_dense).
-            let mut ds_v = vec![0.0f32; DENSE_DIM];
-            for x in ds_v.iter_mut() {
-                *x += tiny(&mut rng);
-            }
-            dense[d_s_id(q, j)] = ds_v;
-            sparse[d_s_id(q, j)] = sp(&f_q, 2.0, j);
-        }
-    }
-    // Filler: dense ≈ origin, sparse in junk block (dot 0 with every query).
-    for id in filler_start..N {
-        let mut fv = vec![0.0f32; DENSE_DIM];
-        for x in fv.iter_mut() {
-            *x += tiny(&mut rng);
-        }
-        dense[id] = fv;
-        sparse[id] = SparseVector {
-            indices: junk.clone(),
-            values: vec![1.0f32; HALF],
-        };
-    }
-
-    // Queries: dense = centre_q, sparse = ones on F_q. Ground truth R_q =
-    // R_dense ∪ R_sparse (the full K planted docs).
-    let mut dense_q: Vec<Vec<f32>> = Vec::with_capacity(Q);
-    let mut sparse_q: Vec<SparseVector> = Vec::with_capacity(Q);
-    let mut neighbours: Vec<Vec<i64>> = Vec::with_capacity(Q);
-    for q in 0..Q {
-        dense_q.push(centre(q));
-        sparse_q.push(SparseVector {
-            indices: (q * HALF..q * HALF + HALF).map(|i| i as u32).collect(),
-            values: vec![1.0f32; HALF],
-        });
-        let mut gt: Vec<i64> = (0..HALF).map(|j| r_dense_id(q, j) as i64).collect();
-        gt.extend((0..HALF).map(|j| r_sparse_id(q, j) as i64));
-        neighbours.push(gt);
-    }
+    // The planted dataset is generated by the shared `synthetic::generate_hybrid`
+    // (same code path as the `generate-dataset` binary), so the fixture and the
+    // registered dataset are byte-identical. See that function for the full
+    // fused-only-recoverable planting rationale.
+    let HybridData {
+        dense,
+        dense_queries: dense_q,
+        sparse,
+        sparse_queries: sparse_q,
+        neighbours,
+        dim: dense_dim,
+        top: k,
+    } = generate_hybrid(0xB19_1DEA);
+    let n = dense.len();
 
     let tmp = tempfile::tempdir().expect("temp dir");
     let root = tmp.path().to_path_buf();
@@ -997,11 +865,11 @@ pub fn write_hybrid_project(dataset_name: &str, engine_configs_json: &str) -> Hy
     let datasets_json = serde_json::json!([
         {
             "name": dataset_name, "type": "hybrid", "path": dataset_name,
-            "distance": "l2", "vector_size": DENSE_DIM, "vector_count": N,
+            "distance": "l2", "vector_size": dense_dim, "vector_count": n,
         },
         {
             "name": dense_dataset_name, "type": "jsonl", "path": format!("{dense_dataset_name}/"),
-            "distance": "l2", "vector_size": DENSE_DIM, "vector_count": N,
+            "distance": "l2", "vector_size": dense_dim, "vector_count": n,
         },
     ]);
     fs::write(
@@ -1019,29 +887,24 @@ pub fn write_hybrid_project(dataset_name: &str, engine_configs_json: &str) -> Hy
         root,
         dataset_name: dataset_name.to_string(),
         dense_dataset_name,
-        top: K,
+        top: k,
     }
 }
 
-/// Write `vectors` as a `.jsonl` file (one JSON float-array per line), the
-/// layout the `type:"jsonl"` reader expects.
+/// Write `vectors` as a `.jsonl` file (delegates to the shared serializer in
+/// `vector_db_benchmark::synthetic`, so there is a single source of truth).
 fn write_jsonl_vectors(path: &Path, vectors: &[Vec<f32>]) {
-    let body = vectors
-        .iter()
-        .map(|v| serde_json::to_string(&v.iter().map(|x| *x as f64).collect::<Vec<_>>()).unwrap())
-        .collect::<Vec<_>>()
-        .join("\n");
-    fs::write(path, body).unwrap();
+    vector_db_benchmark::synthetic::write_jsonl_vectors(path, vectors).unwrap();
 }
 
-/// Write `neighbours.jsonl` (one JSON id-array per line) into `ds_dir`.
+/// Write `neighbours.jsonl` (one JSON id-array per line) into `ds_dir`
+/// (delegates to the shared serializer in `vector_db_benchmark::synthetic`).
 fn write_neighbours(ds_dir: &Path, neighbours: &[Vec<i64>]) {
-    let nb = neighbours
-        .iter()
-        .map(|nn| serde_json::to_string(nn).unwrap())
-        .collect::<Vec<_>>()
-        .join("\n");
-    fs::write(ds_dir.join("neighbours.jsonl"), nb).unwrap();
+    vector_db_benchmark::synthetic::write_neighbours_jsonl(
+        &ds_dir.join("neighbours.jsonl"),
+        neighbours,
+    )
+    .unwrap();
 }
 
 /// Path to the compiled binary under test. Cargo exports

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -904,3 +904,91 @@ fn test_binary_qdrant_quantization_is_applied() {
          not appear to be applied to the read path"
     );
 }
+
+// ---------------------------------------------------------------------------
+// generate-dataset binary coverage (issue #122): prove that a dataset written
+// by the `generate-dataset` binary is consumable end-to-end by the benchmark.
+//
+// This is stronger than the fixture-based `test_binary_qdrant_sparse`: it runs
+// the SHIPPED binary (its own CLI, its own on-disk writes into a fresh
+// `datasets/` dir), registers the result exactly as `datasets/datasets.json`
+// does (local `path`, no download link), and runs the real engine against it.
+// ---------------------------------------------------------------------------
+
+/// Path to the compiled `generate-dataset` binary (Cargo exports this env var
+/// to integration tests automatically).
+fn generate_dataset_bin() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_generate-dataset"))
+}
+
+#[test]
+fn test_generate_dataset_binary_sparse_end_to_end() {
+    wait_for_qdrant();
+
+    // Fresh temp project: <root>/datasets, <root>/experiments/..., <root>/results.
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().to_path_buf();
+    let datasets_dir = root.join("datasets");
+    std::fs::create_dir_all(&datasets_dir).unwrap();
+    std::fs::create_dir_all(root.join("experiments/configurations")).unwrap();
+    std::fs::create_dir_all(root.join("results")).unwrap();
+
+    // 1. Run the REAL generator binary, writing only the sparse dataset.
+    let ds_name = "synthetic-sparse-300";
+    let out = std::process::Command::new(generate_dataset_bin())
+        .args([
+            "--out-dir",
+            datasets_dir.to_str().unwrap(),
+            "--only",
+            "sparse",
+        ])
+        .output()
+        .expect("run generate-dataset");
+    assert!(
+        out.status.success(),
+        "generate-dataset failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Layout check: the sparse reader needs exactly these three files.
+    for f in ["data.csr", "queries.csr", "neighbours.jsonl"] {
+        assert!(
+            datasets_dir.join(ds_name).join(f).exists(),
+            "generator did not write {f}"
+        );
+    }
+
+    // 2. Register the generated dataset (local path, NO link) + an engine config,
+    //    exactly as datasets/datasets.json does for the shipped entry.
+    let datasets_json = serde_json::json!([{
+        "name": ds_name, "type": "sparse", "path": ds_name,
+        "distance": "dot", "vector_size": 300,
+    }]);
+    std::fs::write(
+        datasets_dir.join("datasets.json"),
+        serde_json::to_string_pretty(&datasets_json).unwrap(),
+    )
+    .unwrap();
+    let configs = serde_json::json!([{
+        "name": "qdrant-gen-sparse", "engine": "qdrant",
+        "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+        "search_params": [{"parallel": 1}], "upload_params": {"parallel": 1, "batch_size": 50}
+    }]);
+    std::fs::write(
+        root.join("experiments/configurations/test.json"),
+        serde_json::to_string(&configs).unwrap(),
+    )
+    .unwrap();
+
+    // 3. Run the benchmark against the GENERATED dataset and check recall.
+    assert!(
+        run_qdrant_binary(&root, "qdrant-gen-sparse", ds_name),
+        "benchmark run over generated sparse dataset failed"
+    );
+    let precision = read_precision(&root, "qdrant-gen-sparse");
+    println!("generated sparse dataset precision={precision:.3}");
+    assert!(
+        precision >= 0.9,
+        "generated sparse precision {precision:.3} < 0.9"
+    );
+}


### PR DESCRIPTION
## Fixes #122 — sparse/hybrid/filter paths had no runnable registered dataset

The sparse, hybrid, and filter-datatype code paths were engine-tested but not runnable end-to-end from a dataset name (no registered dataset, and we won't fabricate a hosted download link). This adds a **local Rust generator** so those paths are runnable with small synthetic data.

### `generate-dataset` binary (`src/bin/generate_dataset.rs`)
`cargo run --release --bin generate-dataset [-- --out-dir <DIR> --only sparse|hybrid|filter]` writes three deterministic (fixed-seed) datasets in the exact layout each reader expects:
- **synthetic-sparse-300** — `data.csr`/`queries.csr`/`neighbours.jsonl` (dot/MIPS ground truth)
- **synthetic-hybrid-16** — `vectors.npy`/`queries.npy`/`data.csr`/`queries.csr`/`neighbours.jsonl` (ground truth recoverable only via RRF fusion)
- **synthetic-filter-32** — compound/tar `vectors.npy`/`payloads.jsonl` (keyword/int/bool/datetime fields)/`tests.jsonl` (per-query `conditions` rotating all four datatypes + filtered ground truth)

### Shared writers — deduped, not duplicated
New lib module `src/synthetic.rs` holds the sparse/hybrid data generators + jsonl/neighbours serializers; both the generator binary and `tests/common/mod.rs` now delegate to it (tests/common shrinks ~173 lines). The strict-floor `test_binary_qdrant_sparse`/`_hybrid` (incl. the hybrid negative control) still pass, proving byte-identical output.

### Registration + docs
`datasets/datasets.json` gains the three entries with local `path`, correct `vector_size`/`distance`/`schema`, and a description noting they're locally-generated — **no `link`, no fabricated `vector_count`**. Generated files are git-ignored (regenerated on demand, matching the `random-768-25-tenants` precedent). README gains a "Generating local datasets" section.

### Verification (all live)
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean; 432 unit tests (+2 synthetic)
- End-to-end: sparse → qdrant recall **1.000**; hybrid → qdrant RRF recall **1.000**; filter → redis recall **1.000** (keyword/int/bool/datetime all applied)
- New `test_generate_dataset_binary_sparse_end_to_end`: runs the shipped binary → registers → drives through the benchmark → precision **1.000**

🤖 Generated with [Claude Code](https://claude.com/claude-code)