### PR TITLE
test+ci: cover --help/--describe in the blocking suite; run bin-crate unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,15 @@ jobs:
     - uses: Swatinem/rust-cache@v2
 
     - name: Run unit tests
-      run: cargo test --lib --release
+      # --lib AND --bins: the bulk of the unit tests (engine filter builders,
+      # CLI/config parsing, per-engine helpers) live in the binary crate, so
+      # `--lib` alone never executed them in CI.
+      run: cargo test --lib --bins --release
+
+    - name: Run CLI smoke tests (no container)
+      # --help / --describe datasets|engines — the same paths the docker-build
+      # job smoke-tests, now in the blocking suite.
+      run: cargo test --test integration_cli --release
 
   integration-redis:
     name: Integration tests (Redis)

--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -149,4 +149,20 @@ mod tests {
         assert!(!parse(&["--exit-on-error", "false"]).exit_on_error);
         assert!(!parse(&["--exit-on-error=false"]).exit_on_error);
     }
+
+    // `--describe datasets|engines` is what the docker-build smoke test exercises;
+    // pin that it parses (and is absent by default) so the dispatch in main.rs
+    // always receives the expected value.
+    #[test]
+    fn describe_option_parses() {
+        assert_eq!(parse(&[]).describe, None, "omitted → None");
+        assert_eq!(
+            parse(&["--describe", "datasets"]).describe.as_deref(),
+            Some("datasets")
+        );
+        assert_eq!(
+            parse(&["--describe", "engines"]).describe.as_deref(),
+            Some("engines")
+        );
+    }
 }

--- a/src/bin/vector_db_benchmark/config.rs
+++ b/src/bin/vector_db_benchmark/config.rs
@@ -435,4 +435,30 @@ mod tests {
         // budget → returns the bare base "1 field".
         assert_eq!(format_schema(&json!({"category": "keyword"}), 5), "1 field");
     }
+
+    // `--describe datasets|engines` (smoke-tested by the docker-build job) drives
+    // these two functions over the REAL registries. Asserting Ok pins that every
+    // shipped datasets.json / engine config parses and that the formatting helpers
+    // don't panic on any real entry — a regression the docker smoke would catch
+    // but only in the non-blocking build job.
+    #[test]
+    fn describe_datasets_over_real_registry_is_ok() {
+        assert!(
+            describe_datasets(false).is_ok(),
+            "compact --describe datasets"
+        );
+        assert!(
+            describe_datasets(true).is_ok(),
+            "verbose --describe datasets"
+        );
+    }
+
+    #[test]
+    fn describe_engines_over_real_registry_is_ok() {
+        assert!(
+            describe_engines(false).is_ok(),
+            "compact --describe engines"
+        );
+        assert!(describe_engines(true).is_ok(), "verbose --describe engines");
+    }
 }

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -1,0 +1,70 @@
+//! CLI smoke tests — the exact commands the docker-build validation job runs
+//! (`--help`, `--describe datasets`, `--describe engines`), promoted into the
+//! blocking test suite so a regression fails CI without waiting on the
+//! non-blocking docker-build job. No engine/container required.
+
+use std::process::Command;
+
+mod common;
+
+/// Run the built binary with `args`, returning (success, stdout, stderr).
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(common::binary_path())
+        .args(args)
+        .output()
+        .expect("failed to spawn benchmark binary");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn help_exits_zero_and_lists_key_flags() {
+    let (ok, stdout, _stderr) = run(&["--help"]);
+    assert!(ok, "--help should exit 0");
+    // clap renders usage + the flags the docker smoke and users rely on.
+    assert!(stdout.contains("Usage"), "help missing Usage: {stdout}");
+    for flag in ["--engines", "--datasets", "--describe"] {
+        assert!(stdout.contains(flag), "help missing {flag}");
+    }
+}
+
+#[test]
+fn describe_datasets_exits_zero_and_lists_a_known_dataset() {
+    let (ok, stdout, stderr) = run(&["--describe", "datasets"]);
+    assert!(ok, "--describe datasets should exit 0; stderr={stderr}");
+    // random-100 ships in the image and is what the docker smoke benchmarks.
+    assert!(
+        stdout.contains("random-100"),
+        "expected random-100 in --describe datasets output:\n{stdout}"
+    );
+}
+
+#[test]
+fn describe_engines_exits_zero_and_lists_known_engines() {
+    let (ok, stdout, stderr) = run(&["--describe", "engines"]);
+    assert!(ok, "--describe engines should exit 0; stderr={stderr}");
+    assert!(
+        stdout.contains("Available engines"),
+        "missing header:\n{stdout}"
+    );
+    // pin a couple of Redis-family engines incl. the newest (dragonfly).
+    for engine in ["redis", "dragonfly"] {
+        assert!(
+            stdout.contains(engine),
+            "expected engine '{engine}' in --describe engines output:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn describe_unknown_option_errors_out() {
+    let (ok, _stdout, stderr) = run(&["--describe", "bogus"]);
+    assert!(!ok, "--describe bogus should exit non-zero");
+    assert!(
+        stderr.contains("Unknown describe option"),
+        "expected a helpful error on stderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Follow-up to the metadata PR — re: the docker-build validation comment that smoke-tests `--help` and `--describe datasets`. Those paths (and, it turns out, **all bin-crate unit tests**) weren't actually running in the blocking CI suite.

## Coverage added for the docker-smoke commands
- **`cli.rs`**: assert `--describe datasets|engines` parses (defaults to `None`).
- **`config.rs`**: assert `describe_datasets`/`describe_engines(verbose = t/f)` return `Ok` over the **real** registries — pins that every shipped `datasets.json` entry / engine config parses and the formatters never panic on a real entry.
- **`tests/integration_cli.rs`** (new, no container): runs the built binary through the exact docker-smoke commands — `--help` (exit 0, lists `--engines`/`--datasets`/`--describe`), `--describe datasets` (lists `random-100`), `--describe engines` (lists `redis` + `dragonfly`), and unknown `--describe bogus` (non-zero exit + helpful error).

## CI gap fixed (the important part)
The **Unit tests** job ran `cargo test --lib --release` — **library-only**. The binary crate holds the bulk of the unit tests (all engine filter-builder tests, CLI/config parsing, per-engine helpers, the new Dragonfly tests, etc.); `--lib` never executed them — they were only *compiled* by `clippy --all-targets`, never *run*. Changed to `cargo test --lib --bins --release` (so they actually execute) and added a step running the container-less `integration_cli` suite.

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --lib --bins`: 456 unit tests pass (incl. the 3 new describe tests)
- `integration_cli`: 4/4 pass (help, describe datasets, describe engines, unknown option)

🤖 Generated with [Claude Code](https://claude.com/claude-code)