### PR TITLE
feat(metadata): type JSON numbers as Int/Float — fix numeric filters on Qdrant/Milvus (#87)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -617,6 +617,8 @@ fn upload_bulk_batch(
             for (k, v) in &meta.fields {
                 let val = match v {
                     MetadataValue::String(s) => serde_json::Value::String(s.clone()),
+                    MetadataValue::Int(n) => serde_json::Value::from(*n),
+                    MetadataValue::Float(f) => serde_json::json!(*f),
                     MetadataValue::Labels(labels) => serde_json::Value::Array(
                         labels
                             .iter()

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -422,6 +422,8 @@ fn insert_batch(
             for (k, v) in &meta.fields {
                 let val = match v {
                     MetadataValue::String(s) => serde_json::Value::String(s.clone()),
+                    MetadataValue::Int(n) => serde_json::Value::from(*n),
+                    MetadataValue::Float(f) => serde_json::json!(*f),
                     MetadataValue::Labels(labels) => {
                         // For VarChar fields, join labels into single string
                         serde_json::Value::String(labels.join(","))

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -4,6 +4,7 @@
 //! Supports HNSW index with configurable M/efConstruction,
 //! multiple distance metrics (L2, IP, COSINE), and schema-based collections.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -330,6 +331,7 @@ impl MilvusEngine {
         ids: &[i64],
         vectors: &[Vec<f32>],
         metadata: &[Option<MetadataItem>],
+        schema_types: &HashMap<String, String>,
     ) -> Result<(), String> {
         let pb = self.create_progress_bar(ids.len());
         let batches: Vec<(usize, usize)> = (0..ids.len())
@@ -380,6 +382,7 @@ impl MilvusEngine {
                             &ids[batch_start..batch_end],
                             &vectors[batch_start..batch_end],
                             &metadata[batch_start..batch_end],
+                            schema_types,
                         ) {
                             *error.lock().unwrap() = Some(e);
                             break;
@@ -400,6 +403,20 @@ impl MilvusEngine {
 }
 
 /// Insert a batch of vectors using Milvus REST API.
+/// Extract `field -> declared-type` from the dataset schema, so uploads keep a
+/// numeric-valued keyword field as a string (the column is declared VarChar).
+fn schema_type_map(dataset: &Dataset) -> HashMap<String, String> {
+    let mut m = HashMap::new();
+    if let Some(obj) = dataset.config.schema.as_ref().and_then(|s| s.as_object()) {
+        for (k, v) in obj {
+            if let Some(t) = v.as_str() {
+                m.insert(k.clone(), t.to_string());
+            }
+        }
+    }
+    m
+}
+
 fn insert_batch(
     client: &reqwest::blocking::Client,
     base_url: &str,
@@ -407,6 +424,7 @@ fn insert_batch(
     ids: &[i64],
     vectors: &[Vec<f32>],
     metadata: &[Option<MetadataItem>],
+    schema_types: &HashMap<String, String>,
 ) -> Result<(), String> {
     use vector_db_benchmark::readers::metadata::MetadataValue;
 
@@ -420,7 +438,10 @@ fn insert_batch(
         if let Some(meta) = &metadata[i] {
             let row_obj = row.as_object_mut().unwrap();
             for (k, v) in &meta.fields {
-                let val = match v {
+                // A numeric value under a keyword/text-declared field must stay a
+                // string, or the strict VarChar column rejects the whole batch.
+                let v = v.coerce_for_schema(schema_types.get(k).map(|s| s.as_str()));
+                let val = match v.as_ref() {
                     MetadataValue::String(s) => serde_json::Value::String(s.clone()),
                     MetadataValue::Int(n) => serde_json::Value::from(*n),
                     MetadataValue::Float(f) => serde_json::json!(*f),
@@ -813,7 +834,8 @@ impl Engine for MilvusEngine {
             self.parallel, self.batch_size
         );
         let upload_start = Instant::now();
-        self.upload_parallel(&ids, &vectors, &metadata)?;
+        let schema_types = schema_type_map(dataset);
+        self.upload_parallel(&ids, &vectors, &metadata, &schema_types)?;
         let upload_time = upload_start.elapsed().as_secs_f64();
 
         println!(

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -744,6 +744,8 @@ fn metadata_value_to_bson(
                 .unwrap_or_else(|_| mongodb::bson::Bson::String(s.clone())),
             _ => mongodb::bson::Bson::String(s.clone()),
         },
+        MetadataValue::Int(n) => mongodb::bson::Bson::Int64(*n),
+        MetadataValue::Float(f) => mongodb::bson::Bson::Double(*f),
         MetadataValue::Labels(labels) => {
             let arr: Vec<mongodb::bson::Bson> = labels
                 .iter()
@@ -1755,6 +1757,19 @@ mod tests {
         let price =
             metadata_value_to_bson("price", &MetadataValue::String("3.5".to_string()), &schema);
         assert_eq!(price.as_f64(), Some(3.5));
+    }
+
+    // A native numeric MetadataValue (the reader now types JSON numbers, issue
+    // #87) must map to native BSON regardless of the schema hint — the value is
+    // already unambiguous, so `match_any`/range/exact filters see a real number.
+    #[test]
+    fn native_numeric_metadata_stored_as_native_bson() {
+        use vector_db_benchmark::readers::metadata::MetadataValue;
+        let schema = HashMap::new(); // no schema hint needed for typed values
+        let i = metadata_value_to_bson("size", &MetadataValue::Int(2), &schema);
+        assert_eq!(i.as_i64(), Some(2), "Int must store as native Int64");
+        let f = metadata_value_to_bson("price", &MetadataValue::Float(3.5), &schema);
+        assert_eq!(f.as_f64(), Some(3.5), "Float must store as native Double");
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -665,6 +665,8 @@ fn upload_bulk_batch(
             for (k, v) in &meta.fields {
                 let val = match v {
                     MetadataValue::String(s) => serde_json::Value::String(s.clone()),
+                    MetadataValue::Int(n) => serde_json::Value::from(*n),
+                    MetadataValue::Float(f) => serde_json::json!(*f),
                     MetadataValue::Labels(labels) => serde_json::Value::Array(
                         labels
                             .iter()

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -41,6 +41,10 @@ fn copy_field(meta: Option<&MetadataItem>, column: &str) -> String {
     let value = meta.and_then(|m| m.fields.iter().find(|(k, _)| k == column).map(|(_, v)| v));
     match value {
         Some(MetadataValue::String(s)) => escape_copy_text(s),
+        // Numeric columns receive the literal digits; COPY coerces them into the
+        // declared BIGINT/DOUBLE column. No escaping needed (digits/./-/e only).
+        Some(MetadataValue::Int(n)) => n.to_string(),
+        Some(MetadataValue::Float(f)) => f.to_string(),
         Some(MetadataValue::Labels(labels)) => escape_copy_text(&labels.join(";")),
         // geo / missing → NULL (geo isn't a scalar filter column here)
         _ => "\\N".to_string(),
@@ -841,6 +845,20 @@ mod tests {
         assert_eq!(copy_field(Some(&meta), "labels"), "a;b");
         assert_eq!(copy_field(Some(&meta), "missing"), "\\N");
         assert_eq!(copy_field(None, "category"), "\\N");
+    }
+
+    // Native numeric fields (issue #87) must COPY the literal digits into the
+    // BIGINT/DOUBLE column — NOT fall through to the `_ => NULL` arm.
+    #[test]
+    fn copy_field_emits_numeric_literals() {
+        let meta = MetadataItem {
+            fields: vec![
+                ("size".to_string(), MetadataValue::Int(42)),
+                ("price".to_string(), MetadataValue::Float(3.5)),
+            ],
+        };
+        assert_eq!(copy_field(Some(&meta), "size"), "42");
+        assert_eq!(copy_field(Some(&meta), "price"), "3.5");
     }
 
     // Parse with the production base offset ($1 = vector, $2 = LIMIT, filter

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -4,6 +4,7 @@
 //! Wraps async calls with a tokio runtime (block_on) since the
 //! benchmark Engine trait is synchronous.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -502,6 +503,7 @@ impl QdrantEngine {
         ids: &[i64],
         vectors: &[Vec<f32>],
         metadata: &[Option<MetadataItem>],
+        schema_types: &HashMap<String, String>,
     ) -> Result<(), String> {
         use vector_db_benchmark::readers::metadata::MetadataValue;
 
@@ -551,7 +553,13 @@ impl QdrantEngine {
                             let mut payload = Payload::new();
                             if let Some(meta) = &metadata[i] {
                                 for (k, v) in &meta.fields {
-                                    match v {
+                                    // A numeric value under a keyword-declared field
+                                    // must stay a string, or the keyword index won't
+                                    // match it (integer payload vs string condition).
+                                    let v = v.coerce_for_schema(
+                                        schema_types.get(k).map(|s| s.as_str()),
+                                    );
+                                    match v.as_ref() {
                                         MetadataValue::String(s) => {
                                             payload.insert(k.clone(), s.clone());
                                         }
@@ -825,6 +833,20 @@ fn build_quantization(q: &serde_json::Value) -> Result<Option<Quantization>, Str
     }
 }
 
+/// Extract `field -> declared-type` from the dataset schema, so uploads keep a
+/// numeric-valued keyword field as a string (matching its keyword index).
+fn schema_type_map(dataset: &Dataset) -> HashMap<String, String> {
+    let mut m = HashMap::new();
+    if let Some(obj) = dataset.config.schema.as_ref().and_then(|s| s.as_object()) {
+        for (k, v) in obj {
+            if let Some(t) = v.as_str() {
+                m.insert(k.clone(), t.to_string());
+            }
+        }
+    }
+    m
+}
+
 fn build_qdrant_filter(
     field_name: &str,
     condition_type: &str,
@@ -981,7 +1003,8 @@ impl Engine for QdrantEngine {
             self.parallel, self.batch_size
         );
         let upload_start = Instant::now();
-        self.upload_parallel(&ids, &vectors, &metadata)?;
+        let schema_types = schema_type_map(dataset);
+        self.upload_parallel(&ids, &vectors, &metadata, &schema_types)?;
         let upload_time = upload_start.elapsed().as_secs_f64();
 
         println!(

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -555,6 +555,12 @@ impl QdrantEngine {
                                         MetadataValue::String(s) => {
                                             payload.insert(k.clone(), s.clone());
                                         }
+                                        MetadataValue::Int(n) => {
+                                            payload.insert(k.clone(), *n);
+                                        }
+                                        MetadataValue::Float(f) => {
+                                            payload.insert(k.clone(), *f);
+                                        }
                                         MetadataValue::Labels(labels) => {
                                             let arr: Vec<qdrant_client::qdrant::Value> =
                                                 labels.iter().map(|l| l.clone().into()).collect();

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -694,6 +694,12 @@ fn upload_batch_internal(
                             encode_string_field(config, k, s).into_bytes(),
                         ));
                     }
+                    MetadataValue::Int(n) => {
+                        fields.push((k.as_bytes().to_vec(), n.to_string().into_bytes()));
+                    }
+                    MetadataValue::Float(f) => {
+                        fields.push((k.as_bytes().to_vec(), f.to_string().into_bytes()));
+                    }
                     MetadataValue::Labels(labels) => {
                         fields.push((k.as_bytes().to_vec(), labels.join(";").into_bytes()));
                     }
@@ -1324,6 +1330,12 @@ fn hset_single(
             match v {
                 MetadataValue::String(s) => {
                     cmd.arg(k.as_str()).arg(encode_string_field(config, k, s));
+                }
+                MetadataValue::Int(n) => {
+                    cmd.arg(k.as_str()).arg(n.to_string());
+                }
+                MetadataValue::Float(f) => {
+                    cmd.arg(k.as_str()).arg(f.to_string());
                 }
                 MetadataValue::Labels(labels) => {
                     cmd.arg(k.as_str()).arg(labels.join(";"));

--- a/src/bin/vector_db_benchmark/engine/turbopuffer.rs
+++ b/src/bin/vector_db_benchmark/engine/turbopuffer.rs
@@ -172,6 +172,8 @@ fn metadata_value_to_json(val: &MetadataValue) -> serde_json::Value {
                 serde_json::json!(s)
             }
         }
+        MetadataValue::Int(n) => serde_json::json!(*n),
+        MetadataValue::Float(f) => serde_json::json!(*f),
         MetadataValue::Labels(labels) => serde_json::json!(labels),
         MetadataValue::Geo { lon, lat } => {
             serde_json::json!({"lon": lon, "lat": lat})

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -743,6 +743,12 @@ fn upload_batch_internal(
                             encode_string_field(config, k, s).into_bytes(),
                         ));
                     }
+                    MetadataValue::Int(n) => {
+                        fields.push((k.as_bytes().to_vec(), n.to_string().into_bytes()));
+                    }
+                    MetadataValue::Float(f) => {
+                        fields.push((k.as_bytes().to_vec(), f.to_string().into_bytes()));
+                    }
                     MetadataValue::Labels(labels) => {
                         fields.push((k.as_bytes().to_vec(), labels.join(";").into_bytes()));
                     }
@@ -1497,6 +1503,12 @@ fn hset_single(
             match v {
                 MetadataValue::String(s) => {
                     cmd.arg(k.as_str()).arg(encode_string_field(config, k, s));
+                }
+                MetadataValue::Int(n) => {
+                    cmd.arg(k.as_str()).arg(n.to_string());
+                }
+                MetadataValue::Float(f) => {
+                    cmd.arg(k.as_str()).arg(f.to_string());
                 }
                 MetadataValue::Labels(labels) => {
                     cmd.arg(k.as_str()).arg(labels.join(";"));

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -1142,8 +1142,8 @@ fn escape_str(s: &str) -> String {
 ///   (verified on Redis 8.8), whereas scalar `.labels == "v"` could never match an
 ///   array. The `in` form is safe here BECAUSE the field is an array — the
 ///   substring hazard above only applies to scalar strings.
-/// - numeric element (i64 OR f64) → `.field == <n>` — VSIM coerces numeric
-///   strings ("1" == 1; numbers are stored as JSON strings on upload).
+/// - numeric element (i64 OR f64) → `.field == <n>` — matches the native JSON
+///   number stored on upload (SETATTR emits a real number for Int/Float fields).
 /// - OR all representable elements, parenthesized. Empty-string tokens are dropped
 ///   (they can never match an exact keyword).
 /// - Empty / no representable values → a never-match contradiction so an empty

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -254,6 +254,12 @@ fn vadd_batch(
                         MetadataValue::String(s) => {
                             map.insert(k.clone(), serde_json::Value::String(s.clone()));
                         }
+                        MetadataValue::Int(n) => {
+                            map.insert(k.clone(), serde_json::Value::from(*n));
+                        }
+                        MetadataValue::Float(f) => {
+                            map.insert(k.clone(), serde_json::json!(*f));
+                        }
                         MetadataValue::Labels(labels) => {
                             map.insert(
                                 k.clone(),
@@ -398,6 +404,12 @@ fn vadd_single(
                 match v {
                     MetadataValue::String(s) => {
                         map.insert(k.clone(), serde_json::Value::String(s.clone()));
+                    }
+                    MetadataValue::Int(n) => {
+                        map.insert(k.clone(), serde_json::Value::from(*n));
+                    }
+                    MetadataValue::Float(f) => {
+                        map.insert(k.clone(), serde_json::json!(*f));
                     }
                     MetadataValue::Labels(labels) => {
                         map.insert(

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -441,7 +441,10 @@ fn coerce_metadata_value(
     value: &vector_db_benchmark::readers::metadata::MetadataValue,
 ) -> serde_json::Value {
     use vector_db_benchmark::readers::metadata::MetadataValue;
-    match value {
+    // A numeric value under a keyword/text-declared property must stay a string,
+    // or Weaviate rejects the whole object (the property is declared `text`).
+    let value = value.coerce_for_schema(schema_type);
+    match value.as_ref() {
         MetadataValue::String(s) => match schema_type {
             Some("int") => s
                 .parse::<i64>()

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -453,6 +453,8 @@ fn coerce_metadata_value(
                 .unwrap_or_else(|_| serde_json::Value::String(s.clone())),
             _ => serde_json::Value::String(s.clone()),
         },
+        MetadataValue::Int(n) => serde_json::Value::from(*n),
+        MetadataValue::Float(f) => serde_json::json!(*f),
         MetadataValue::Labels(labels) => serde_json::Value::Array(
             labels
                 .iter()

--- a/src/readers/metadata.rs
+++ b/src/readers/metadata.rs
@@ -25,6 +25,36 @@ pub enum MetadataValue {
     },
 }
 
+impl MetadataValue {
+    /// Coerce a stray numeric value to a string when the dataset schema declares
+    /// the field as a non-numeric scalar (`keyword`/`text`/`uuid`/`bool`).
+    ///
+    /// The reader types every JSON number as [`MetadataValue::Int`]/[`Float`],
+    /// but engines declare each column/property/index type from the dataset
+    /// schema. If a field is declared `keyword` yet a record carries a numeric
+    /// value (e.g. an all-digit SKU or zip code), emitting a native number would
+    /// make strict engines reject the insert (Milvus VarChar, Weaviate `text`)
+    /// or silently fail to match (Qdrant keyword index). Coercing to a string
+    /// keeps storage aligned with the declared type. Numeric-declared fields
+    /// (`int`/`float`) and non-numeric variants pass through unchanged.
+    pub fn coerce_for_schema(
+        &self,
+        schema_type: Option<&str>,
+    ) -> std::borrow::Cow<'_, MetadataValue> {
+        use std::borrow::Cow;
+        match (self, schema_type) {
+            (MetadataValue::Int(n), Some("keyword" | "text" | "uuid" | "bool")) => {
+                Cow::Owned(MetadataValue::String(n.to_string()))
+            }
+            (MetadataValue::Float(f), Some("keyword" | "text" | "uuid" | "bool")) => {
+                Cow::Owned(MetadataValue::String(f.to_string()))
+            }
+            // No coercion needed: borrow (no clone on the upload hot path).
+            _ => Cow::Borrowed(self),
+        }
+    }
+}
+
 /// Parse metadata from a serde_json Value.
 pub fn parse_metadata_from_json(json_value: serde_json::Value) -> Option<MetadataItem> {
     if let serde_json::Value::Object(map) = json_value {
@@ -38,11 +68,15 @@ pub fn parse_metadata_from_json(json_value: serde_json::Value) -> Option<Metadat
                 serde_json::Value::Number(n) => {
                     if let Some(i) = n.as_i64() {
                         fields.push((key, MetadataValue::Int(i)));
+                    } else if n.as_u64().is_some() {
+                        // u64 above i64::MAX: there is no lossless integer variant,
+                        // and `as_f64()` would round (e.g. a 64-bit ID). Keep the
+                        // exact digits as a string so exact-match filters still work.
+                        fields.push((key, MetadataValue::String(n.to_string())));
                     } else if let Some(f) = n.as_f64() {
                         fields.push((key, MetadataValue::Float(f)));
                     } else {
-                        // u64 above i64::MAX with no exact f64 form: keep the raw
-                        // digits rather than lose precision.
+                        // Not representable at all (shouldn't happen for valid JSON).
                         fields.push((key, MetadataValue::String(n.to_string())));
                     }
                 }
@@ -101,17 +135,47 @@ mod parse_tests {
     }
 
     #[test]
-    fn u64_above_i64_max_falls_back() {
-        // u64::MAX does not fit in i64; keep it representable (lossy f64) or as
-        // raw digits rather than silently truncating.
+    fn u64_above_i64_max_kept_as_exact_string() {
+        // u64::MAX doesn't fit i64 and rounds as f64; it must be kept as exact
+        // digits so a 64-bit ID still matches exactly (regression: the old
+        // `as_f64` path rounded 18446744073709551615 -> 18446744073709552000).
         let big = u64::MAX;
         let m = parse_metadata_from_json(serde_json::json!({ "n": big })).unwrap();
         match &m.fields[0].1 {
-            MetadataValue::Float(_) | MetadataValue::String(_) => {}
-            other => panic!(
-                "expected Float/String fallback for huge u64, got {:?}",
-                other
-            ),
+            MetadataValue::String(s) => assert_eq!(s, "18446744073709551615"),
+            other => panic!("expected exact String for huge u64, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn coerce_for_schema_stringifies_numeric_keyword() {
+        // A numeric value under a keyword-declared field must become a string so
+        // strict engines (Milvus VarChar, Weaviate text, Qdrant keyword) accept
+        // and match it. Numeric-declared fields keep their typed value.
+        assert!(matches!(
+            MetadataValue::Int(42).coerce_for_schema(Some("keyword")).as_ref(),
+            MetadataValue::String(s) if s == "42"
+        ));
+        assert!(matches!(
+            MetadataValue::Float(3.5).coerce_for_schema(Some("text")).as_ref(),
+            MetadataValue::String(s) if s == "3.5"
+        ));
+        assert!(matches!(
+            MetadataValue::Int(42)
+                .coerce_for_schema(Some("int"))
+                .as_ref(),
+            MetadataValue::Int(42)
+        ));
+        assert!(matches!(
+            MetadataValue::Float(3.5)
+                .coerce_for_schema(Some("float"))
+                .as_ref(),
+            MetadataValue::Float(_)
+        ));
+        // No schema hint -> leave typed (best-effort numeric).
+        assert!(matches!(
+            MetadataValue::Int(7).coerce_for_schema(None).as_ref(),
+            MetadataValue::Int(7)
+        ));
     }
 }

--- a/src/readers/metadata.rs
+++ b/src/readers/metadata.rs
@@ -11,8 +11,18 @@ pub struct MetadataItem {
 #[derive(Clone, Debug)]
 pub enum MetadataValue {
     String(String),
+    /// A JSON integer that fits in `i64`. Kept typed (rather than stringified)
+    /// so engines emit a real numeric value — otherwise numeric exact-match,
+    /// range, and `match_any` filters silently match nothing on engines that
+    /// store the payload verbatim (e.g. Qdrant, Milvus). See issue #87.
+    Int(i64),
+    /// A JSON non-integer number, kept typed for the same reason as [`Int`].
+    Float(f64),
     Labels(Vec<String>),
-    Geo { lon: f64, lat: f64 },
+    Geo {
+        lon: f64,
+        lat: f64,
+    },
 }
 
 /// Parse metadata from a serde_json Value.
@@ -26,7 +36,15 @@ pub fn parse_metadata_from_json(json_value: serde_json::Value) -> Option<Metadat
                     fields.push((key, MetadataValue::String(s)));
                 }
                 serde_json::Value::Number(n) => {
-                    fields.push((key, MetadataValue::String(n.to_string())));
+                    if let Some(i) = n.as_i64() {
+                        fields.push((key, MetadataValue::Int(i)));
+                    } else if let Some(f) = n.as_f64() {
+                        fields.push((key, MetadataValue::Float(f)));
+                    } else {
+                        // u64 above i64::MAX with no exact f64 form: keep the raw
+                        // digits rather than lose precision.
+                        fields.push((key, MetadataValue::String(n.to_string())));
+                    }
                 }
                 serde_json::Value::Array(arr) => {
                     if key == "labels" {
@@ -55,5 +73,45 @@ pub fn parse_metadata_from_json(json_value: serde_json::Value) -> Option<Metadat
         Some(MetadataItem { fields })
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::*;
+
+    #[test]
+    fn integers_and_floats_are_typed() {
+        let m = parse_metadata_from_json(serde_json::json!({"i": 7, "f": 1.5})).unwrap();
+        let get = |k: &str| {
+            m.fields
+                .iter()
+                .find(|(n, _)| n == k)
+                .map(|(_, v)| v)
+                .unwrap()
+        };
+        assert!(matches!(get("i"), MetadataValue::Int(7)));
+        assert!(matches!(get("f"), MetadataValue::Float(x) if *x == 1.5));
+    }
+
+    #[test]
+    fn negative_integer_is_int() {
+        let m = parse_metadata_from_json(serde_json::json!({"i": -3})).unwrap();
+        assert!(matches!(m.fields[0].1, MetadataValue::Int(-3)));
+    }
+
+    #[test]
+    fn u64_above_i64_max_falls_back() {
+        // u64::MAX does not fit in i64; keep it representable (lossy f64) or as
+        // raw digits rather than silently truncating.
+        let big = u64::MAX;
+        let m = parse_metadata_from_json(serde_json::json!({ "n": big })).unwrap();
+        match &m.fields[0].1 {
+            MetadataValue::Float(_) | MetadataValue::String(_) => {}
+            other => panic!(
+                "expected Float/String fallback for huge u64, got {:?}",
+                other
+            ),
+        }
     }
 }

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -180,8 +180,20 @@ mod tests {
 
         assert_eq!(meta.fields.len(), 1);
         match &meta.fields[0].1 {
-            MetadataValue::String(s) => assert_eq!(s, "42"),
-            _ => panic!("Expected String variant for number"),
+            MetadataValue::Int(n) => assert_eq!(*n, 42),
+            other => panic!("Expected Int variant for integer, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_metadata_parse_float_field() {
+        let json: serde_json::Value = serde_json::json!({"price": 3.5});
+        let meta = parse_metadata_from_json(json).unwrap();
+
+        assert_eq!(meta.fields.len(), 1);
+        match &meta.fields[0].1 {
+            MetadataValue::Float(f) => assert_eq!(*f, 3.5),
+            other => panic!("Expected Float variant for non-integer, got {:?}", other),
         }
     }
 

--- a/src/redisearch/upload.rs
+++ b/src/redisearch/upload.rs
@@ -1186,6 +1186,12 @@ fn upload_batch_internal(
                     MetadataValue::String(s) => {
                         fields.push((k.as_bytes().to_vec(), s.as_bytes().to_vec()));
                     }
+                    MetadataValue::Int(n) => {
+                        fields.push((k.as_bytes().to_vec(), n.to_string().into_bytes()));
+                    }
+                    MetadataValue::Float(f) => {
+                        fields.push((k.as_bytes().to_vec(), f.to_string().into_bytes()));
+                    }
                     MetadataValue::Labels(labels) => {
                         fields.push((k.as_bytes().to_vec(), labels.join(";").into_bytes()));
                     }


### PR DESCRIPTION
Fixes #87.

## Problem

`readers::metadata::MetadataValue` had only `String`/`Labels`/`Geo` variants, and `parse_metadata_from_json` converted **every** JSON number to `String(n.to_string())`. Numeric payload fields were therefore uploaded as strings. Engines that store the payload verbatim matched **zero** documents on integer exact-match, numeric range, and int `match_any` filters:

- **Milvus** was fully broken — the collection declares numeric fields as strict `Int64`/`Double` (`enableDynamicField: false`), so a JSON *string* into an `Int64` column **rejected the whole insert batch**.
- **Qdrant** stored numbers as string payload, so an integer/range condition never matched.
- MongoDB/Weaviate only worked via brittle schema-driven string re-parsing.

## Fix

Add `MetadataValue::Int(i64)` / `Float(f64)`; the reader types JSON integers/floats into them. Each engine upload path emits the correct typed value:

| Engine | Numeric value |
|---|---|
| Qdrant | native integer / double payload *(core fix)* |
| Milvus / ES / OpenSearch / Turbopuffer / VectorSets | JSON number |
| MongoDB | `Bson::Int64` / `Bson::Double` (no string round-trip) |
| Weaviate | JSON number into the `int`/`number` property |
| pgvector | literal digits into the `BIGINT`/`DOUBLE` COPY column |
| Redis / Valkey / RediSearch | numeric string for the `NUMERIC` index |

## Adversarial review (3 agents, per engine family) + fixes

Three independent reviewers traced every engine's **filter builder and schema-creation** path against the new storage typing. They confirmed the fix is correct for all shipped datasets and **repairs the hard Milvus upload failure**, and surfaced two latent regressions vs. the old stringify-everything behavior, both now fixed:

1. **u64 > i64::MAX precision loss** — with serde_json's default features `as_f64()` returns `Some` for every number, so the intended "String fallback" was dead code and a 64-bit ID rounded (`…551615` → `…552000`), breaking exact TAG match. Now checks `as_u64()` before `as_f64()` and keeps exact digits.
2. **Numeric value under a `keyword`-declared field** (e.g. all-digit SKU/zip) — would emit a native number that strict engines reject (Milvus VarChar, Weaviate `text`) or silently fail to match (Qdrant keyword index). Added `MetadataValue::coerce_for_schema` (returns `Cow` — no clone when untouched) that stringifies Int/Float when the schema type is `keyword`/`text`/`uuid`/`bool`; applied in Weaviate and threaded `schema_types` into Milvus `insert_batch` and the Qdrant upload payload builder.

MongoDB and Turbopuffer were confirmed **safe** (the filter builder types from the query JSON, so storage and query always agree). NaN/Inf is unreachable (JSON has no such literal).

## Tests

`cargo test --lib --bins` (537 pass). New: numeric parse (int/float/negative/exact-u64-string), `coerce_for_schema` matrix, MongoDB native `Int64`/`Double`, pgvector numeric COPY literals. `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.

## Follow-up (not in this PR)

Live-engine integration coverage — extend the `match_any` fixture (`tests/common/mod.rs`) with an integer field + integer `match_any`/range query across the Docker engine suites. Deferred to a focused PR since it touches every engine integration test's schema and needs live containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)