### PR TITLE
feat(filters): multi-valued keyword arrays — contains-any on Milvus/Weaviate/pgvector (#88)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -14,7 +14,7 @@ use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::{Engine, SearchResults, UploadStats};
-use vector_db_benchmark::readers::metadata::MetadataItem;
+use vector_db_benchmark::readers::metadata::{is_multivalued_keyword_field, MetadataItem};
 
 const DEFAULT_COLLECTION: &str = "Benchmark";
 
@@ -178,22 +178,38 @@ impl MilvusEngine {
             if let Some(schema_obj) = schema.as_object() {
                 for (field_name, field_type) in schema_obj {
                     let ft = field_type.as_str().unwrap_or("");
-                    let milvus_type = match ft {
-                        "int" => "Int64",
-                        "keyword" | "text" => "VarChar",
-                        "float" => "Double",
-                        _ => continue,
+                    // A multi-valued keyword field (`labels`) is declared as an
+                    // Array of VarChar so `array_contains_any` can match a single
+                    // element; a scalar VarChar could only test whole-string
+                    // equality against the joined value (issue #88).
+                    let field = if (ft == "keyword" || ft == "text")
+                        && is_multivalued_keyword_field(field_name)
+                    {
+                        serde_json::json!({
+                            "fieldName": field_name,
+                            "dataType": "Array",
+                            "elementDataType": "VarChar",
+                            "elementTypeParams": {"max_length": "500", "max_capacity": "128"},
+                        })
+                    } else {
+                        let milvus_type = match ft {
+                            "int" => "Int64",
+                            "keyword" | "text" => "VarChar",
+                            "float" => "Double",
+                            _ => continue,
+                        };
+                        let mut field = serde_json::json!({
+                            "fieldName": field_name,
+                            "dataType": milvus_type,
+                        });
+                        if milvus_type == "VarChar" {
+                            field.as_object_mut().unwrap().insert(
+                                "elementTypeParams".to_string(),
+                                serde_json::json!({"max_length": "500"}),
+                            );
+                        }
+                        field
                     };
-                    let mut field = serde_json::json!({
-                        "fieldName": field_name,
-                        "dataType": milvus_type,
-                    });
-                    if milvus_type == "VarChar" {
-                        field.as_object_mut().unwrap().insert(
-                            "elementTypeParams".to_string(),
-                            serde_json::json!({"max_length": "500"}),
-                        );
-                    }
                     fields.push(field);
                 }
             }
@@ -446,8 +462,14 @@ fn insert_batch(
                     MetadataValue::Int(n) => serde_json::Value::from(*n),
                     MetadataValue::Float(f) => serde_json::json!(*f),
                     MetadataValue::Labels(labels) => {
-                        // For VarChar fields, join labels into single string
-                        serde_json::Value::String(labels.join(","))
+                        // Multi-valued keyword field: store as a native Array so
+                        // `array_contains_any` can match individual elements (#88).
+                        serde_json::Value::Array(
+                            labels
+                                .iter()
+                                .map(|l| serde_json::Value::String(l.clone()))
+                                .collect(),
+                        )
                     }
                     MetadataValue::Geo { lon, lat } => {
                         // Milvus doesn't support geo natively; store as string
@@ -697,31 +719,19 @@ fn build_milvus_filter(
 ) -> Option<String> {
     match condition_type {
         "match" => {
-            // match_any: field value in a list -> Milvus `in [...]` expression,
-            // the OR-of-values semantics that mirror qdrant's
-            // Condition::matches(field, Vec). Strings are quoted/escaped,
-            // numbers inlined; bool/null/nested items are skipped so an invalid
-            // expression is never produced. An empty (or all-skipped) IN-set
-            // matches NOTHING: we still emit `field in []` (a valid
-            // match-nothing expression) rather than dropping the clause, since
-            // dropping the sole clause would leave no filter and silently
-            // return every row (the inverse of the filter).
+            // A multi-valued keyword field (`labels`) is stored as an Array of
+            // VarChar (see create_collection / insert_batch), so it uses Milvus's
+            // array membership functions — `array_contains_any` for `match_any`
+            // and `array_contains` for exact-match — which test per-element
+            // membership. A scalar field uses `in [...]` / `==`. (Issue #88.)
+            let multivalued = is_multivalued_keyword_field(field_name);
+            // match_any: OR-of-values, mirroring qdrant's Condition::matches.
+            // Strings are quoted/escaped, numbers inlined; bool/null/nested items
+            // are skipped so an invalid expression is never produced. An empty
+            // (or all-skipped) IN-set matches NOTHING — we still emit a valid
+            // match-nothing expression rather than dropping the sole clause,
+            // which would leave no filter and return every row (the inverse).
             if let Some(any) = criteria.get("any").and_then(|v| v.as_array()) {
-                // NOTE: match_any here supports SINGLE-VALUED keyword fields only.
-                // Milvus stores a multi-valued keyword field (MetadataValue::Labels,
-                // only for a field literally named `labels`) as a single
-                // comma-joined VarChar (see insert_batch: `labels.join(",")`), so
-                // `field in ["red","blue"]` tests whole-string set membership and
-                // cannot match a doc stored as `"red,green"`. True contains-any
-                // semantics (as pgvector's array-overlap / mongodb's array $in) would
-                // require changing storage to ARRAY(VarChar) + array_contains_any,
-                // which is out of scope here (no dataset to test against) and tracked
-                // as a follow-up. Strings are quoted/escaped, numbers inlined;
-                // bool/null/nested items are skipped so an invalid expression is
-                // never produced. An empty (or all-skipped) IN-set matches NOTHING:
-                // we still emit `field in []` (a valid match-nothing expression)
-                // rather than dropping the clause, since dropping the sole clause
-                // would leave no filter and silently return every row.
                 let items: Vec<String> = any
                     .iter()
                     .filter_map(|v| {
@@ -734,19 +744,34 @@ fn build_milvus_filter(
                         }
                     })
                     .collect();
+                if multivalued {
+                    return Some(format!(
+                        "array_contains_any({}, [{}])",
+                        field_name,
+                        items.join(", ")
+                    ));
+                }
                 return Some(format!("{} in [{}]", field_name, items.join(", ")));
             }
             let value = criteria.get("value")?;
             if let Some(s) = value.as_str() {
-                Some(format!("{} == {}", field_name, quote_milvus_string(s)))
-            } else if value.is_number() || value.is_boolean() {
+                if multivalued {
+                    Some(format!(
+                        "array_contains({}, {})",
+                        field_name,
+                        quote_milvus_string(s)
+                    ))
+                } else {
+                    Some(format!("{} == {}", field_name, quote_milvus_string(s)))
+                }
+            } else if !multivalued && (value.is_number() || value.is_boolean()) {
                 Some(format!("{} == {}", field_name, value))
             } else {
-                // Non-scalar exact-match value (a JSON array/object/null) is
+                // Non-scalar exact-match value (a JSON array/object/null), or a
+                // numeric/bool value against the string-array `labels` field, is
                 // malformed input — the canonical model uses `match.any` for
-                // lists. Drop the clause (return None) instead of forwarding
-                // `field == [1,2]` verbatim, matching qdrant/redis/valkey/
-                // vectorsets.
+                // lists. Drop the clause (return None) instead of forwarding a
+                // bad expression, matching qdrant/redis/valkey/vectorsets.
                 None
             }
         }
@@ -1124,6 +1149,27 @@ mod tests {
             build_milvus_filter("color", "match", &json!({"value": "red"})).unwrap(),
             r#"color == "red""#
         );
+    }
+
+    // #88: the multi-valued keyword field `labels` is an Array(VarChar), so it
+    // uses array membership functions instead of scalar `in`/`==`.
+    #[test]
+    fn labels_match_any_uses_array_contains_any() {
+        let expr =
+            build_milvus_filter("labels", "match", &json!({"any": ["red", "blue"]})).unwrap();
+        assert_eq!(expr, r#"array_contains_any(labels, ["red", "blue"])"#);
+    }
+
+    #[test]
+    fn labels_exact_value_uses_array_contains() {
+        let expr = build_milvus_filter("labels", "match", &json!({"value": "red"})).unwrap();
+        assert_eq!(expr, r#"array_contains(labels, "red")"#);
+    }
+
+    #[test]
+    fn labels_numeric_value_dropped() {
+        // A numeric exact-match against the string-array `labels` is malformed.
+        assert!(build_milvus_filter("labels", "match", &json!({"value": 5})).is_none());
     }
 
     // #121: a non-scalar `value` (a JSON array/object/null) is malformed input —

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -14,7 +14,9 @@ use postgres::types::ToSql;
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::{Engine, SearchResults, UploadStats};
-use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
+use vector_db_benchmark::readers::metadata::{
+    is_multivalued_keyword_field, MetadataItem, MetadataValue,
+};
 
 /// Map a dataset schema field type to a Postgres column type. Returns None for
 /// types pgvector can't filter on with a plain scalar column (e.g. geo).
@@ -741,7 +743,19 @@ fn build_pg_clause(entry: &serde_json::Value, builder: &mut FilterBuilder) -> Op
                     } else if let Some(value) = criteria.get("value") {
                         if let Some(s) = value.as_str() {
                             let ph = builder.bind(PgValue::Text(s.to_string()));
-                            parts.push(format!("\"{}\" = {}", field_name, ph));
+                            if is_multivalued_keyword_field(field_name) {
+                                // Multi-valued keyword: the ';'-joined column holds
+                                // a set, so exact-match means "contains this value".
+                                // Test set membership, mirroring the match_any arm
+                                // above (issue #88) — a scalar `=` compares the whole
+                                // joined string and never matches one element.
+                                parts.push(format!(
+                                    "{} = ANY(string_to_array(\"{}\", ';'))",
+                                    ph, field_name
+                                ));
+                            } else {
+                                parts.push(format!("\"{}\" = {}", field_name, ph));
+                            }
                         } else if let Some(b) = value.as_bool() {
                             let ph = builder.bind(PgValue::Bool(b));
                             parts.push(format!("\"{}\" = {}", field_name, ph));
@@ -935,6 +949,21 @@ mod tests {
                 "blue".to_string()
             ])]
         );
+    }
+
+    #[test]
+    fn labels_exact_match_uses_set_membership() {
+        // #88: exact-match on the multi-valued `labels` column means "contains
+        // this value" — test set membership, not whole-string equality. A
+        // single-valued keyword (`name`) keeps scalar `=`.
+        let cond = json!({"and": [{"labels": {"match": {"value": "red"}}}]});
+        let (sql, vals) = parse(&cond).unwrap();
+        assert_eq!(sql, "($3 = ANY(string_to_array(\"labels\", ';')))");
+        assert_eq!(vals, vec![PgValue::Text("red".to_string())]);
+
+        let (sql_name, _) =
+            parse(&json!({"and": [{"name": {"match": {"value": "red"}}}]})).unwrap();
+        assert_eq!(sql_name, "(\"name\" = $3)");
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -401,8 +401,16 @@ impl WeaviateEngine {
 /// FILTERABLE index, so it must be enabled explicitly. `indexSearchable` is
 /// only valid on text-backed properties, so it is set only for those.
 fn weaviate_property(field_name: &str, field_type: &str) -> Option<serde_json::Value> {
+    use vector_db_benchmark::readers::metadata::is_multivalued_keyword_field;
+    // A multi-valued keyword field (`labels`) is a `text[]` array property so
+    // `ContainsAny` matches individual elements; a scalar `text` could only
+    // compare the whole value (issue #88). `field` tokenization (below) still
+    // applies, giving whole-value equality per array element.
+    let multivalued =
+        matches!(field_type, "keyword" | "text") && is_multivalued_keyword_field(field_name);
     let wv_type = match field_type {
         "int" => "int",
+        "keyword" | "text" if multivalued => "text[]",
         "keyword" | "text" => "text",
         "float" => "number",
         "geo" => "geoCoordinates",
@@ -1748,6 +1756,18 @@ mod tests {
         assert_eq!(p["tokenization"], "field");
         assert_eq!(p["indexSearchable"], true);
         assert!(p.get("indexInverted").is_none(), "p={}", p);
+    }
+
+    // #88: the multi-valued keyword field `labels` is a `text[]` array property
+    // (with `field` tokenization for whole-value element equality), so
+    // `ContainsAny`/`Equal` filters match individual elements. A scalar `text`
+    // could only compare the whole value.
+    #[test]
+    fn labels_property_is_text_array() {
+        let p = weaviate_property("labels", "keyword").unwrap();
+        assert_eq!(p["dataType"], json!(["text[]"]));
+        assert_eq!(p["indexFilterable"], true);
+        assert_eq!(p["tokenization"], "field");
     }
 
     #[test]

--- a/src/readers/metadata.rs
+++ b/src/readers/metadata.rs
@@ -8,6 +8,17 @@ pub struct MetadataItem {
     pub fields: Vec<(String, MetadataValue)>,
 }
 
+/// Whether a schema field holds a MULTI-VALUED keyword array rather than a
+/// scalar keyword. By convention (matching [`parse_metadata_from_json`], which
+/// only builds [`MetadataValue::Labels`] for a field literally named `labels`)
+/// the sole multi-valued keyword field is `labels`. Engines with typed columns
+/// (Milvus, Weaviate, pgvector) consult this at schema-creation time to declare
+/// an array column and apply array contains-any semantics, so a query like
+/// `match_any ["a","b"]` matches a doc whose `labels` is `["a","c"]`.
+pub fn is_multivalued_keyword_field(field_name: &str) -> bool {
+    field_name == "labels"
+}
+
 #[derive(Clone, Debug)]
 pub enum MetadataValue {
     String(String),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -31,6 +31,27 @@ const COLORS: [&str; 4] = ["red", "green", "blue", "dark blue"];
 /// The `match_any` set every query filters on (COLORS indices 0 and 2).
 pub const MATCH_ANY_COLORS: [&str; 2] = ["red", "blue"];
 
+/// Vocabulary for the MULTI-VALUED keyword field `labels` (issue #88). Each doc
+/// carries a 2-element array; the `match_any` filter must match a doc that
+/// shares ANY element with the query set — impossible if the engine stored the
+/// array as one joined scalar, so recall discriminates the fix from the bug.
+const LABEL_VOCAB: [&str; 4] = ["red", "green", "blue", "yellow"];
+/// The `labels` `match_any` set every labels-query filters on.
+pub const MATCH_ANY_LABELS: [&str; 2] = ["red", "blue"];
+
+/// Two DISTINCT tags per doc: `VOCAB[id%4]` and `VOCAB[(id%4+2)%4]`. With the
+/// query set {red, blue}, docs with `id%4 ∈ {0,2}` match (their pair is
+/// {red,blue} or {blue,red}); `id%4 ∈ {1,3}` (green/yellow) do not.
+fn labels_for(id: usize) -> Vec<&'static str> {
+    let a = id % 4;
+    vec![LABEL_VOCAB[a], LABEL_VOCAB[(a + 2) % 4]]
+}
+
+fn matches_labels_filter(id: usize) -> bool {
+    let l = labels_for(id);
+    MATCH_ANY_LABELS.iter().any(|q| l.contains(q))
+}
+
 const N_DOCS: usize = 400;
 const N_QUERIES: usize = 10;
 const TOP: usize = 10;
@@ -254,6 +275,98 @@ fn write_match_any_project_metric(
         dataset_name: dataset_name.to_string(),
         top: TOP,
         matching_docs: (0..N_DOCS).filter(|id| matches_filter(*id)).count(),
+    }
+}
+
+/// Like [`write_match_any_project`], but the `match_any` filter is on a
+/// MULTI-VALUED keyword field (`labels`, a per-doc 2-element array) instead of a
+/// scalar `color`. Proves contains-any array semantics end-to-end: an engine
+/// that stores the array as a joined scalar (the pre-#88 Milvus/Weaviate bug)
+/// tests whole-value equality and scores ~0 recall. `metric` follows the engine
+/// (L2 for most; cosine for VectorSets).
+pub fn write_match_any_labels_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+    metric: GtMetric,
+) -> MatchAnyProject {
+    let mut rng = StdRng::seed_from_u64(0xB0BA);
+    let gen_vec =
+        |rng: &mut StdRng| -> Vec<f32> { (0..dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect() };
+    let vectors: Vec<Vec<f32>> = (0..N_DOCS).map(|_| gen_vec(&mut rng)).collect();
+    let queries: Vec<Vec<f32>> = (0..N_QUERIES).map(|_| gen_vec(&mut rng)).collect();
+
+    // Ground truth over ONLY the docs whose labels array intersects the set.
+    let filtered_gt = |q: &[f32]| -> Vec<i64> {
+        let mut scored: Vec<(i64, f64)> = (0..N_DOCS)
+            .filter(|id| matches_labels_filter(*id))
+            .map(|id| (id as i64, metric.dist(q, &vectors[id])))
+            .collect();
+        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        scored.iter().take(TOP).map(|(id, _)| *id).collect()
+    };
+
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().to_path_buf();
+    std::mem::forget(tmp);
+
+    let ds_dir = root.join("datasets").join(dataset_name);
+    fs::create_dir_all(&ds_dir).unwrap();
+    fs::create_dir_all(root.join("experiments/configurations")).unwrap();
+    fs::create_dir_all(root.join("results")).unwrap();
+
+    write_npy_vectors(ds_dir.join("vectors.npy").to_str().unwrap(), &vectors).unwrap();
+
+    // Per-document metadata -> payloads.jsonl (multi-valued keyword `labels`).
+    let payloads: String = (0..N_DOCS)
+        .map(|id| serde_json::json!({ "labels": labels_for(id) }).to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(ds_dir.join("payloads.jsonl"), payloads).unwrap();
+
+    let any_vals: Vec<serde_json::Value> = MATCH_ANY_LABELS
+        .iter()
+        .map(|c| serde_json::json!(c))
+        .collect();
+    let tests: String = queries
+        .iter()
+        .map(|q| {
+            serde_json::json!({
+                "query": q.iter().map(|x| *x as f64).collect::<Vec<_>>(),
+                "conditions": { "and": [ { "labels": { "match": { "any": any_vals } } } ] },
+                "closest_ids": filtered_gt(q),
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(ds_dir.join("tests.jsonl"), tests).unwrap();
+
+    let datasets_json = serde_json::json!([{
+        "name": dataset_name,
+        "type": "tar",
+        "path": format!("{}/", dataset_name),
+        "distance": metric.name(),
+        "vector_size": dim,
+        "vector_count": N_DOCS,
+        "schema": { "labels": "keyword" },
+    }]);
+    fs::write(
+        root.join("datasets/datasets.json"),
+        serde_json::to_string_pretty(&datasets_json).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        root.join("experiments/configurations/test.json"),
+        engine_configs_json,
+    )
+    .unwrap();
+
+    MatchAnyProject {
+        root,
+        dataset_name: dataset_name.to_string(),
+        top: TOP,
+        matching_docs: (0..N_DOCS).filter(|id| matches_labels_filter(*id)).count(),
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -31,20 +31,25 @@ const COLORS: [&str; 4] = ["red", "green", "blue", "dark blue"];
 /// The `match_any` set every query filters on (COLORS indices 0 and 2).
 pub const MATCH_ANY_COLORS: [&str; 2] = ["red", "blue"];
 
-/// Vocabulary for the MULTI-VALUED keyword field `labels` (issue #88). Each doc
-/// carries a 2-element array; the `match_any` filter must match a doc that
-/// shares ANY element with the query set — impossible if the engine stored the
-/// array as one joined scalar, so recall discriminates the fix from the bug.
-const LABEL_VOCAB: [&str; 4] = ["red", "green", "blue", "yellow"];
-/// The `labels` `match_any` set every labels-query filters on.
+/// The `match_any` set every labels-query filters on, for the MULTI-VALUED
+/// keyword field `labels` (issue #88). Each doc carries a 2-element array; the
+/// filter must match a doc that shares ANY element with this set — impossible if
+/// the engine stored the array as one joined scalar, so recall discriminates the
+/// fix from the bug. See [`labels_for`] for the ANY-vs-ALL discrimination.
 pub const MATCH_ANY_LABELS: [&str; 2] = ["red", "blue"];
 
-/// Two DISTINCT tags per doc: `VOCAB[id%4]` and `VOCAB[(id%4+2)%4]`. With the
-/// query set {red, blue}, docs with `id%4 ∈ {0,2}` match (their pair is
-/// {red,blue} or {blue,red}); `id%4 ∈ {1,3}` (green/yellow) do not.
+/// Each MATCHING doc carries exactly ONE query label (`red` XOR `blue`) plus a
+/// non-query tag; non-matching docs carry neither. With the query set
+/// {red, blue}, `id%4 ∈ {0,2}` match; `{1,3}` do not. Because no matching doc
+/// holds BOTH query labels, the fixture distinguishes three behaviors:
+/// contains-ANY (correct → 200 docs), contains-ALL (→ 0 docs, recall 0), and
+/// the joined-scalar bug (whole-string `"red;green" == "red"` → 0, recall 0).
 fn labels_for(id: usize) -> Vec<&'static str> {
-    let a = id % 4;
-    vec![LABEL_VOCAB[a], LABEL_VOCAB[(a + 2) % 4]]
+    match id % 4 {
+        0 => vec!["red", "green"],    // matches via `red` only
+        2 => vec!["blue", "yellow"],  // matches via `blue` only
+        _ => vec!["green", "yellow"], // no query label
+    }
 }
 
 fn matches_labels_filter(id: usize) -> bool {

--- a/tests/integration_milvus.rs
+++ b/tests/integration_milvus.rs
@@ -453,3 +453,52 @@ fn test_binary_milvus_match_any() {
     println!("milvus match_any recall={:.3}", recall);
     assert!(recall >= 0.9, "milvus match_any recall {:.3} < 0.9", recall);
 }
+
+/// End-to-end `match_any` on a MULTI-VALUED keyword field (`labels`, #88).
+/// Milvus stores it as an Array(VarChar) and filters with
+/// `array_contains_any`; before the fix it was a comma-joined VarChar tested
+/// with whole-string `in`, which cannot match a single element (recall ~0).
+#[test]
+fn test_binary_milvus_match_any_labels() {
+    wait_for_milvus();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "milvus-mal", "engine": "milvus",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100, "index_params": {"M": 16, "efConstruction": 200}}
+    }]);
+    let proj = common::write_match_any_labels_project(
+        "match-any-labels-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+        common::GtMetric::L2,
+    );
+    assert!(
+        proj.matching_docs >= proj.top,
+        "fixture must have >= top matching docs (got {})",
+        proj.matching_docs
+    );
+
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "milvus-mal",
+            "match-any-labels-test",
+            "127.0.0.1",
+            &[
+                ("MILVUS_PORT", "19531"),
+                ("MILVUS_COLLECTION_NAME", "bench_matchany_labels"),
+            ],
+        ),
+        "milvus match_any labels run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, "milvus-mal");
+    println!("milvus match_any labels recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "milvus multi-valued labels match_any recall {:.3} < 0.9",
+        recall
+    );
+}

--- a/tests/integration_pgvector.rs
+++ b/tests/integration_pgvector.rs
@@ -651,3 +651,64 @@ fn test_pgvector_match_any_overlap_matches_multivalue() {
     conn.execute("DROP TABLE IF EXISTS ma_overlap_test", &[])
         .unwrap();
 }
+
+/// Direct-SQL correctness for the EXACT-MATCH clause on a multi-valued keyword
+/// field (#88). `build_pg_clause` emits `$1 = ANY(string_to_array(col, ';'))`
+/// for a `match.value` on `labels`; this must match a row whose ';'-joined set
+/// CONTAINS the value — the case a scalar `col = $1` (the pre-fix behaviour)
+/// silently drops. Complements the unit test that pins the SQL shape.
+#[test]
+fn test_pgvector_exact_match_labels_set_membership() {
+    wait_for_postgres();
+    let mut conn = connect();
+    conn.execute("DROP TABLE IF EXISTS ma_exact_test", &[])
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE ma_exact_test (id INT PRIMARY KEY, labels TEXT)",
+        &[],
+    )
+    .unwrap();
+    // id 1: multi-valued 'red;green' (contains 'red'); id 2: 'red' (scalar);
+    // id 3: 'blue' (no).
+    conn.execute(
+        "INSERT INTO ma_exact_test VALUES (1,'red;green'),(2,'red'),(3,'blue')",
+        &[],
+    )
+    .unwrap();
+
+    // Exactly the clause build_pg_clause emits for match.value "red" on labels.
+    let member: Vec<i32> = conn
+        .query(
+            "SELECT id FROM ma_exact_test \
+             WHERE $1 = ANY(string_to_array(\"labels\", ';')) ORDER BY id",
+            &[&"red"],
+        )
+        .unwrap()
+        .iter()
+        .map(|r| r.get::<_, i32>(0))
+        .collect();
+    assert_eq!(
+        member,
+        vec![1, 2],
+        "set-membership must match the multi-valued 'red;green' (via red) and scalar 'red'"
+    );
+
+    // Sanity: the pre-fix scalar `=` misses the multi-valued row.
+    let scalar_eq: Vec<i32> = conn
+        .query(
+            "SELECT id FROM ma_exact_test WHERE \"labels\" = $1 ORDER BY id",
+            &[&"red"],
+        )
+        .unwrap()
+        .iter()
+        .map(|r| r.get::<_, i32>(0))
+        .collect();
+    assert_eq!(
+        scalar_eq,
+        vec![2],
+        "scalar = drops the multi-valued row (confirms the test discriminates)"
+    );
+
+    conn.execute("DROP TABLE IF EXISTS ma_exact_test", &[])
+        .unwrap();
+}

--- a/tests/integration_pgvector.rs
+++ b/tests/integration_pgvector.rs
@@ -541,6 +541,52 @@ fn test_binary_pgvector_match_any() {
     );
 }
 
+/// End-to-end `match_any` on a MULTI-VALUED keyword field (`labels`, #88). The
+/// ';'-joined TEXT column is filtered with array-overlap (`match_any`) and set
+/// membership (exact-match); this exercises the full binary path against a live
+/// Postgres, complementing the direct-SQL overlap test.
+#[test]
+fn test_binary_pgvector_match_any_labels() {
+    wait_for_postgres();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "pg-mal", "engine": "pgvector",
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_labels_project(
+        "match-any-labels-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+        common::GtMetric::L2,
+    );
+    assert!(
+        proj.matching_docs >= proj.top,
+        "fixture must have >= top matching docs (got {})",
+        proj.matching_docs
+    );
+
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "pg-mal",
+            "match-any-labels-test",
+            "127.0.0.1",
+            &[("PGVECTOR_PORT", "5433")],
+        ),
+        "pgvector match_any labels run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, "pg-mal");
+    println!("pgvector match_any labels recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "pgvector multi-valued labels match_any recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// Direct-SQL correctness for the keyword contains-any clause the `match_any`
 /// filter builder emits. Multi-valued keyword payloads are stored as a
 /// ';'-joined TEXT scalar, so the array-overlap must match a row that contains

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -692,6 +692,58 @@ fn test_binary_qdrant_match_any() {
     assert!(recall >= 0.9, "qdrant match_any recall {:.3} < 0.9", recall);
 }
 
+/// Control for the multi-valued `labels` fixture (#88). Qdrant already stores
+/// `labels` as a native list payload and matches per element, so it must clear
+/// 0.9 recall. If this fails alongside the Milvus/Weaviate/pgvector labels
+/// tests, the fixture (not an engine fix) is at fault.
+#[test]
+fn test_binary_qdrant_match_any_labels() {
+    wait_for_qdrant();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "qdrant-mal", "engine": "qdrant",
+        "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 128}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_labels_project(
+        "match-any-labels-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+        common::GtMetric::L2,
+    );
+    assert!(
+        proj.matching_docs >= proj.top,
+        "fixture must have >= top matching docs (got {})",
+        proj.matching_docs
+    );
+
+    let grpc = QDRANT_GRPC_PORT.to_string();
+    let rest = QDRANT_REST_PORT.to_string();
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "qdrant-mal",
+            "match-any-labels-test",
+            "localhost",
+            &[
+                ("QDRANT_GRPC_PORT", grpc.as_str()),
+                ("QDRANT_REST_PORT", rest.as_str()),
+            ],
+        ),
+        "qdrant match_any labels run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, "qdrant-mal");
+    println!("qdrant match_any labels recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "qdrant multi-valued labels match_any recall {:.3} < 0.9",
+        recall
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Quantization coverage: SCALAR (int8), BINARY, and PRODUCT quantization all
 // run end-to-end through the real CLI against live qdrant on the SAME

--- a/tests/integration_weaviate.rs
+++ b/tests/integration_weaviate.rs
@@ -471,6 +471,13 @@ fn test_weaviate_full_cycle() {
 /// filter translated into the gRPC `Filters` message. A fresh project (its own
 /// results dir) and class name per call keep the two runs independent.
 fn run_weaviate_match_any(use_graphql: bool) -> (String, f64) {
+    run_weaviate_match_any_impl(use_graphql, false)
+}
+
+/// Shared runner. `labels=true` filters on a MULTI-VALUED keyword field
+/// (`labels`, a `text[]` array property) instead of scalar `color`, exercising
+/// per-element `ContainsAny`/`Equal` semantics over the array (issue #88).
+fn run_weaviate_match_any_impl(use_graphql: bool, labels: bool) -> (String, f64) {
     let dim = 8;
     let configs = serde_json::json!([{
         "name": "weaviate-ma", "engine": "weaviate",
@@ -478,13 +485,18 @@ fn run_weaviate_match_any(use_graphql: bool) -> (String, f64) {
         "search_params": [{"parallel": 1, "vectorIndexConfig": {"ef": 400}}],
         "upload_params": {"parallel": 1, "batch_size": 100}
     }]);
-    let ds_name = if use_graphql {
-        "match-any-graphql"
-    } else {
-        "match-any-grpc"
+    let ds_name = match (labels, use_graphql) {
+        (false, false) => "match-any-grpc",
+        (false, true) => "match-any-graphql",
+        (true, false) => "match-any-labels-grpc",
+        (true, true) => "match-any-labels-graphql",
     };
-    let proj =
-        common::write_match_any_project(ds_name, &serde_json::to_string(&configs).unwrap(), dim);
+    let cfg_json = serde_json::to_string(&configs).unwrap();
+    let proj = if labels {
+        common::write_match_any_labels_project(ds_name, &cfg_json, dim, common::GtMetric::L2)
+    } else {
+        common::write_match_any_project(ds_name, &cfg_json, dim)
+    };
     assert!(
         proj.matching_docs >= proj.top,
         "fixture must have >= top matching docs (got {})",
@@ -492,10 +504,11 @@ fn run_weaviate_match_any(use_graphql: bool) -> (String, f64) {
     );
 
     let port = std::env::var("WEAVIATE_HTTP_PORT").unwrap_or_else(|_| WEAVIATE_PORT.to_string());
-    let class_name = if use_graphql {
-        "BenchMatchanyGql"
-    } else {
-        "BenchMatchanyGrpc"
+    let class_name = match (labels, use_graphql) {
+        (false, false) => "BenchMatchanyGrpc",
+        (false, true) => "BenchMatchanyGql",
+        (true, false) => "BenchMatchanyLabelsGrpc",
+        (true, true) => "BenchMatchanyLabelsGql",
     };
     // Run directly (not common::run_binary) so we always surface the engine's
     // stdout/stderr — the filtered search's per-query errors print to stderr and
@@ -586,6 +599,42 @@ fn test_binary_weaviate_match_any() {
     assert!(
         (grpc_recall - gql_recall).abs() < 1e-6,
         "gRPC vs GraphQL recall differ: {:.6} vs {:.6}",
+        grpc_recall,
+        gql_recall
+    );
+}
+
+/// End-to-end `match_any` on a MULTI-VALUED keyword field (`labels`, #88).
+/// `labels` is declared as a `text[]` array property and each doc stores an
+/// array; the OR-of-`Equal` filter matches per element (Weaviate's `Equal` on
+/// an array property is contains). Before the fix `labels` was a scalar `text`
+/// property, which rejected the array insert / could not match one element.
+/// Runs both transports and asserts each clears 0.9 and they agree.
+#[test]
+fn test_binary_weaviate_match_any_labels() {
+    wait_for_weaviate();
+
+    let (grpc_transport, grpc_recall) = run_weaviate_match_any_impl(false, true);
+    let (_gql_transport, gql_recall) = run_weaviate_match_any_impl(true, true);
+
+    println!(
+        "weaviate labels match_any [{}] grpc_recall={:.4} gql_recall={:.4}",
+        grpc_transport, grpc_recall, gql_recall
+    );
+
+    assert!(
+        grpc_recall >= 0.9,
+        "weaviate labels match_any gRPC recall {:.4} < 0.9",
+        grpc_recall
+    );
+    assert!(
+        gql_recall >= 0.9,
+        "weaviate labels match_any GraphQL recall {:.4} < 0.9",
+        gql_recall
+    );
+    assert!(
+        (grpc_recall - gql_recall).abs() < 1e-6,
+        "gRPC vs GraphQL labels recall differ: {:.6} vs {:.6}",
         grpc_recall,
         gql_recall
     );


### PR DESCRIPTION
Fixes #88.

## Problem

The multi-valued keyword field `labels` (a per-doc array, e.g. the shipped `arxiv-titles-384-angular-filters` dataset) was stored as a single **joined scalar** by several engines, so `match_any ["a","b"]` could never match a doc whose `labels` were `["a","c"]`:

- **Milvus** — labels joined into one `VarChar`, so `field in [...]` tested whole-string membership (PR #82 was held on this).
- **Weaviate** — declared as a scalar `text` property while storage sent an array (unverified/broken).
- **pgvector** — `match_any` was already correct (array-overlap via `string_to_array`, PR #81), but the exact-match `{value}` arm still compared the whole joined string.

## Fix — real array representation + contains-any semantics

| Engine | Storage | match_any | exact-match |
|---|---|---|---|
| Milvus | `Array(VarChar)`, native JSON array | `array_contains_any(labels, [...])` | `array_contains(labels, x)` |
| Weaviate | `text[]` (storage already sent an array) | OR-of-`Equal` (per-element on array prop) | `Equal` (contains) |
| pgvector | `;`-joined `TEXT` (unchanged) | `string_to_array(col,';') && $1::text[]` (unchanged) | **new:** `$1 = ANY(string_to_array(col,';'))` |

The multi-valued convention — matching the reader, which only builds `MetadataValue::Labels` for a field literally named `labels` — is centralized in `readers::metadata::is_multivalued_keyword_field`. Single-valued keyword fields are unaffected.

## Coverage

**Unit:** Milvus `array_contains_any`/`array_contains` + numeric-value drop; Weaviate `text[]` property; pgvector labels set-membership exact-match. (542 unit tests pass.)

**Integration (live CI):** a new `write_match_any_labels_project` fixture gives each doc a distinct 2-tag array where `match_any {red,blue}` selects a 50% subset — **a joined-scalar store scores ~0 recall**, so the test discriminates the fix from the bug. End-to-end match_any-on-`labels` tests added for **Milvus**, **Weaviate** (both gRPC and GraphQL), **pgvector**, and **Qdrant as a known-good control** (so a fixture bug is distinguishable from an engine bug). The live Milvus/Weaviate suites are what validate the actual `Array`/`text[]` array-query syntax.

`cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)