### PR TITLE
docs: client resources & concurrency model (answers #52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ Render a QPS-vs-precision trade-off plot (SVG, no dependencies) from existing `*
 vector-db-benchmark --plot tradeoff.svg --engines '*' --datasets glove-100-angular
 ```
 
+## Client resources & concurrency
+
+**Concurrency model.** A search config's `parallel: N` (and the `--parallels` filter) runs **N OS threads that share a single in-memory copy** of the dataset and query set — not N processes. Raising `parallel` from 1 to 100 adds ~N worker threads and N engine connections (on the order of tens to low-hundreds of MB), **not** N× the dataset. Each worker accumulates only its own small latency/quality samples; nothing per-query is retained beyond scalar metrics.
+
+**Peak client memory ≈ raw dataset size, during upload.** The client loads the whole dataset into RAM for the upload phase — roughly `vector_count × dim × 4 bytes` (e.g. `cohere-768-1M` ≈ 1M × 768 × 4 ≈ 3 GB, plus reader/allocator overhead) — then **frees it before the search phase**. Search holds only the (far smaller) query set plus the per-thread sample buffers, so search-phase memory is largely independent of `parallel`. A client with RAM ≥ ~2× the raw dataset size runs comfortably; increasing search concurrency does not materially change client memory.
+
+> If you saw the client machine hang/OOM specifically when the client count rose (e.g. to 100) — as reported for the original **Python** `vector-db-benchmark`, which used a process-per-client model that copied the dataset into every worker process — this Rust implementation does not reproduce that: workers are threads sharing one copy, and the uploaded vectors are released before searching. Size the client for the upload peak above, not for the client count.
+
 ## Mixed Benchmarks (Update + Search)
 
 The `--update-search-ratio` flag enables mixed workload benchmarks that interleave vector updates with searches. This measures how search performance is affected by concurrent write operations.


### PR DESCRIPTION
Documents the client-side resource/concurrency model and answers #52.

## Context (#52)

A user reported the client machine (8 vCPU / 32 GB) hanging at the `parallel=100` search step on `cohere-768-1M`, suspecting OOM, and asked whether that's expected and what client size to use.

## Finding

The **Rust** implementation does not reproduce that hang:
- `parallel: N` runs **N OS threads sharing a single in-memory copy** of the dataset/queries — not N processes. Raising it 1→100 adds ~N threads + N connections (tens–low-hundreds of MB), not N× the dataset.
- Peak client RAM ≈ **raw dataset size, during upload** (`vector_count × dim × 4`; cohere-768-1M ≈ 3 GB), and it is **freed before the search phase** (`read_vectors` returns owned data scoped to `upload()`).
- Search holds only the (small) query set + per-thread scalar sample buffers, so search memory is largely independent of `parallel`.

The reported symptom is characteristic of the **original Python** `vector-db-benchmark`, whose process-per-client model copied the dataset into every worker process → OOM on a 32 GB client.

## Change

Adds a "Client resources & concurrency" section to the README with the model above and client-sizing guidance (RAM ≥ ~2× raw dataset size). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)