### PR TITLE
Add Vertex approximate-neighbor query tuning

### DIFF
--- a/src/bin/vector_db_benchmark/engine/vertex.rs
+++ b/src/bin/vector_db_benchmark/engine/vertex.rs
@@ -137,10 +137,14 @@ fn build_find_neighbors_body(
     query: &[f32],
     top: usize,
     fraction_leaf_override: Option<f64>,
+    approximate_neighbor_count: Option<i64>,
 ) -> serde_json::Value {
     let mut datapoint = serde_json::json!({ "datapoint": { "featureVector": query } });
     if let Some(frac) = fraction_leaf_override {
         datapoint["fractionLeafNodesToSearchOverride"] = serde_json::json!(frac);
+    }
+    if let Some(count) = approximate_neighbor_count {
+        datapoint["approximateNeighborCount"] = serde_json::json!(count);
     }
     datapoint["neighborCount"] = serde_json::json!(top);
     serde_json::json!({
@@ -674,6 +678,7 @@ impl Engine for VertexEngine {
             .and_then(|sp| sp.extra.as_ref())
             .and_then(|e| e.get("fraction_leaf_nodes_to_search_override"))
             .and_then(|v| v.as_f64());
+        let approximate_neighbor_count = params.num_candidates.map(|n| n.max(1));
 
         println!(
             "\tRunning {} queries (top={}, parallel={})...",
@@ -741,6 +746,7 @@ impl Engine for VertexEngine {
                             &queries[idx],
                             top,
                             fraction_leaf_override,
+                            approximate_neighbor_count,
                         );
 
                         // Timed window: RPC round-trip + reply parse only. The
@@ -1005,16 +1011,18 @@ mod tests {
 
     #[test]
     fn find_neighbors_body_sets_count_and_optional_override() {
-        let b = build_find_neighbors_body("dep", &[1.0, 2.0], 10, None);
+        let b = build_find_neighbors_body("dep", &[1.0, 2.0], 10, None, None);
         assert_eq!(b["deployedIndexId"], "dep");
         assert_eq!(b["returnFullDatapoint"], false);
         let q = &b["queries"][0];
         assert_eq!(q["neighborCount"], 10);
         assert_eq!(q["datapoint"]["featureVector"], json!([1.0, 2.0]));
         assert!(q.get("fractionLeafNodesToSearchOverride").is_none());
+        assert!(q.get("approximateNeighborCount").is_none());
 
-        let b2 = build_find_neighbors_body("dep", &[1.0], 5, Some(0.2));
+        let b2 = build_find_neighbors_body("dep", &[1.0], 5, Some(0.2), Some(500));
         assert_eq!(b2["queries"][0]["fractionLeafNodesToSearchOverride"], 0.2);
+        assert_eq!(b2["queries"][0]["approximateNeighborCount"], 500);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- map the existing `num_candidates` search parameter to Vertex AI Vector Search's query-time `approximateNeighborCount` field
- omit the field when `num_candidates` is not configured, preserving current behavior
- extend the request-body unit test to cover both cases

## Why

Vertex benchmarks could tune the fraction of leaf nodes searched, but could not control the number of approximate neighbors considered before returning the requested top-k. Exposing the existing engine-neutral `num_candidates` setting makes recall/latency trade-off tests reproducible without rebuilding the index.

## Validation

- `make check`
- `make test` — 79 passed
- `make integration-test` — 23 passed
- `make vector-db-benchmark`
- live Vertex AI smoke runs with `num_candidates` values of 500 and 1000; 5,000/5,000 queries succeeded in each run

The Make targets above passed on the GCP benchmark VM. A local macOS rerun was blocked by the machine's missing Xcode Command Line Tools/HDF5 installation.
