### PR TITLE
Add fixed-rate open-loop search mode

### DIFF
--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -77,6 +77,23 @@ pub struct Args {
     #[arg(long, default_value = "-1")]
     pub queries: i64,
 
+    /// Fixed offered query rate. 0 keeps the existing closed-loop behavior.
+    /// Open-loop mode is currently supported by Redis and Vertex.
+    #[arg(long, default_value = "0.0")]
+    pub target_qps: f64,
+
+    /// Measured open-loop duration in seconds. Required with --target-qps.
+    #[arg(long, default_value = "0.0")]
+    pub search_duration: f64,
+
+    /// Warm-up duration before each measured open-loop search configuration.
+    #[arg(long, default_value = "0.0")]
+    pub warmup_seconds: f64,
+
+    /// Drop an open-loop request when dispatch is this many milliseconds late.
+    #[arg(long, default_value = "1000.0")]
+    pub max_lateness_ms: f64,
+
     /// Repeat each measured search config this many times and report the
     /// best-RPS run (warm best-of, matching v0's REPETITIONS). The first run is
     /// often cold (OS page cache / index warm-up); best-of discards it. Set 1 to
@@ -148,6 +165,24 @@ mod tests {
         assert!(parse(&["--exit-on-error"]).exit_on_error, "bare → true");
         assert!(!parse(&["--exit-on-error", "false"]).exit_on_error);
         assert!(!parse(&["--exit-on-error=false"]).exit_on_error);
+    }
+
+    #[test]
+    fn parses_open_loop_options() {
+        let args = parse(&[
+            "--target-qps",
+            "1500",
+            "--search-duration",
+            "300",
+            "--warmup-seconds",
+            "10",
+            "--max-lateness-ms",
+            "250",
+        ]);
+        assert_eq!(args.target_qps, 1500.0);
+        assert_eq!(args.search_duration, 300.0);
+        assert_eq!(args.warmup_seconds, 10.0);
+        assert_eq!(args.max_lateness_ms, 250.0);
     }
 
     // `--describe datasets|engines` is what the docker-build smoke test exercises;

--- a/src/bin/vector_db_benchmark/config.rs
+++ b/src/bin/vector_db_benchmark/config.rs
@@ -59,6 +59,12 @@ pub struct SearchParams {
     pub search_params: Option<InnerSearchParams>,
     pub top: Option<i64>,
     pub num_candidates: Option<i64>,
+    /// Fixed offered rate for an open-loop run. None keeps closed-loop behavior.
+    pub target_qps: Option<f64>,
+    /// Open-loop measurement duration. Queries recycle when the dataset is shorter.
+    pub duration_seconds: Option<f64>,
+    /// Requests dispatched later than this are dropped and counted.
+    pub max_lateness_ms: Option<f64>,
     /// Calibration: name of the search param to tune (e.g., "ef")
     pub calibration_param: Option<String>,
     /// Calibration: target precision to achieve

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -24,6 +24,7 @@ mod weaviate_grpc;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
+use std::time::{Duration, Instant};
 
 pub use dragonfly::DragonflyEngine;
 pub use elasticsearch::ElasticsearchEngine;
@@ -98,6 +99,17 @@ pub struct SearchResults {
     pub system_cpu_pct: Option<f64>,
     pub client_saturated: bool,
     pub saturation_reason: String,
+    // Open-loop offered-load coverage. None/empty in the original closed-loop mode.
+    pub target_qps: Option<f64>,
+    pub offered_queries: Option<usize>,
+    pub dropped_queries: usize,
+    pub late_queries: usize,
+    pub schedule_delay_p50_time: Option<f64>,
+    pub schedule_delay_p95_time: Option<f64>,
+    pub schedule_delay_p99_time: Option<f64>,
+    pub end_to_end_p50_time: Option<f64>,
+    pub end_to_end_p95_time: Option<f64>,
+    pub end_to_end_p99_time: Option<f64>,
     // Mixed benchmark update metrics (None when search-only)
     pub update_count: Option<usize>,
     pub update_rps: Option<f64>,
@@ -107,6 +119,100 @@ pub struct SearchResults {
     pub update_p99_time: Option<f64>,
     pub update_latencies: Option<Vec<f64>>,
     pub update_search_ratio: Option<String>,
+}
+
+/// Deterministic arrival schedule for fixed-rate, open-loop search.
+#[derive(Debug, Clone, Copy)]
+pub struct OpenLoopPlan {
+    pub target_qps: f64,
+    pub total_requests: usize,
+    pub max_lateness: Duration,
+    late_threshold: Duration,
+}
+
+impl OpenLoopPlan {
+    /// Build a plan from search parameters. Returns None for legacy closed-loop runs.
+    pub fn from_params(params: &SearchParams) -> Result<Option<Self>, String> {
+        let Some(target_qps) = params.target_qps else {
+            return Ok(None);
+        };
+        let duration_seconds = params
+            .duration_seconds
+            .ok_or("open-loop search requires duration_seconds (use --search-duration)")?;
+        let max_lateness_ms = params.max_lateness_ms.unwrap_or(1000.0);
+        if !target_qps.is_finite() || target_qps <= 0.0 {
+            return Err("target_qps must be finite and greater than zero".to_string());
+        }
+        if !duration_seconds.is_finite() || duration_seconds <= 0.0 {
+            return Err("duration_seconds must be finite and greater than zero".to_string());
+        }
+        if !max_lateness_ms.is_finite() || max_lateness_ms < 0.0 {
+            return Err("max_lateness_ms must be finite and non-negative".to_string());
+        }
+        let total_f = (target_qps * duration_seconds).round();
+        if !total_f.is_finite() || total_f < 1.0 || total_f > usize::MAX as f64 {
+            return Err("target_qps * duration_seconds is outside the supported range".to_string());
+        }
+        // A request is reported as late after two arrival intervals, with a 1 ms
+        // floor to avoid treating normal scheduler jitter as overload.
+        let late_threshold = Duration::from_secs_f64((2.0 / target_qps).max(0.001));
+        Ok(Some(Self {
+            target_qps,
+            total_requests: total_f as usize,
+            max_lateness: Duration::from_secs_f64(max_lateness_ms / 1000.0),
+            late_threshold,
+        }))
+    }
+
+    pub fn scheduled_at(&self, start: Instant, ordinal: usize) -> Instant {
+        start + Duration::from_secs_f64(ordinal as f64 / self.target_qps)
+    }
+
+    /// Wait until this request's independent arrival time and return dispatch delay.
+    pub fn wait_for_slot(&self, start: Instant, ordinal: usize) -> Duration {
+        let scheduled = self.scheduled_at(start, ordinal);
+        let now = Instant::now();
+        if now < scheduled {
+            std::thread::sleep(scheduled.duration_since(now));
+        }
+        Instant::now().saturating_duration_since(scheduled)
+    }
+
+    pub fn is_late(&self, delay: Duration) -> bool {
+        delay > self.late_threshold
+    }
+}
+
+/// Add open-loop queueing/arrival metrics without changing closed-loop statistics.
+pub fn attach_open_loop_metrics(
+    results: &mut SearchResults,
+    plan: OpenLoopPlan,
+    schedule_delays: &[f64],
+    end_to_end_latencies: &[f64],
+    dropped_queries: usize,
+    late_queries: usize,
+) {
+    let percentiles = |values: &[f64]| -> (f64, f64, f64) {
+        let mut sorted = values.to_vec();
+        sorted.sort_by(|a, b| a.total_cmp(b));
+        (
+            percentile_linear(&sorted, 0.50),
+            percentile_linear(&sorted, 0.95),
+            percentile_linear(&sorted, 0.99),
+        )
+    };
+    let (sd50, sd95, sd99) = percentiles(schedule_delays);
+    let (e2e50, e2e95, e2e99) = percentiles(end_to_end_latencies);
+    results.target_qps = Some(plan.target_qps);
+    results.offered_queries = Some(plan.total_requests);
+    results.dropped_queries = dropped_queries;
+    results.late_queries = late_queries;
+    results.schedule_delay_p50_time = Some(sd50);
+    results.schedule_delay_p95_time = Some(sd95);
+    results.schedule_delay_p99_time = Some(sd99);
+    results.end_to_end_p50_time = Some(e2e50);
+    results.end_to_end_p95_time = Some(e2e95);
+    results.end_to_end_p99_time = Some(e2e99);
 }
 
 /// `numpy.percentile` with linear interpolation — the method v0 uses
@@ -319,7 +425,8 @@ pub fn create_engine(engine_config: &EngineConfig, host: &str) -> Result<Box<dyn
 
 #[cfg(test)]
 mod stats_tests {
-    use super::compute_search_stats;
+    use super::{attach_open_loop_metrics, compute_search_stats, OpenLoopPlan};
+    use crate::config::SearchParams;
 
     #[test]
     fn empty_times_errors() {
@@ -393,5 +500,55 @@ mod stats_tests {
         assert!((r.p95_time - 95.05).abs() < 1e-9, "p95={}", r.p95_time);
         assert!((r.p50_time - 50.5).abs() < 1e-9, "p50={}", r.p50_time);
         assert!(r.p99_time < 100.0, "p99={} must be below max", r.p99_time);
+    }
+
+    #[test]
+    fn open_loop_plan_validates_and_counts_arrivals() {
+        let params: SearchParams = serde_json::from_value(serde_json::json!({
+            "parallel": 32,
+            "target_qps": 1500.0,
+            "duration_seconds": 2.0,
+            "max_lateness_ms": 250.0
+        }))
+        .unwrap();
+        let plan = OpenLoopPlan::from_params(&params).unwrap().unwrap();
+        assert_eq!(plan.total_requests, 3000);
+        assert_eq!(plan.target_qps, 1500.0);
+        assert_eq!(plan.max_lateness.as_millis(), 250);
+
+        let missing_duration: SearchParams = serde_json::from_value(serde_json::json!({
+            "target_qps": 100.0
+        }))
+        .unwrap();
+        assert!(OpenLoopPlan::from_params(&missing_duration).is_err());
+    }
+
+    #[test]
+    fn open_loop_metrics_preserve_service_latency_and_add_queueing() {
+        let params: SearchParams = serde_json::from_value(serde_json::json!({
+            "target_qps": 10.0,
+            "duration_seconds": 1.0
+        }))
+        .unwrap();
+        let plan = OpenLoopPlan::from_params(&params).unwrap().unwrap();
+        let ones = vec![1.0, 1.0];
+        let mut results =
+            compute_search_stats(&[0.010, 0.020], &ones, &ones, &ones, &ones, 1.0, 10, 2, 2)
+                .unwrap();
+        attach_open_loop_metrics(
+            &mut results,
+            plan,
+            &[0.001, 0.003, 0.5],
+            &[0.011, 0.023],
+            1,
+            1,
+        );
+        assert_eq!(results.target_qps, Some(10.0));
+        assert_eq!(results.offered_queries, Some(10));
+        assert_eq!(results.dropped_queries, 1);
+        assert_eq!(results.late_queries, 1);
+        assert_eq!(results.p50_time, 0.015);
+        assert!(results.schedule_delay_p95_time.unwrap() > 0.4);
+        assert_eq!(results.end_to_end_p50_time, Some(0.017));
     }
 }

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -5,7 +5,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
@@ -17,7 +17,9 @@ use redis::Connection;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{Engine, SearchResults, UpdateSearchRatio, UploadStats};
+use crate::engine::{
+    attach_open_loop_metrics, Engine, OpenLoopPlan, SearchResults, UpdateSearchRatio, UploadStats,
+};
 use crate::metrics::compute_metrics;
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, parse_ft_search_response};
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
@@ -1523,6 +1525,9 @@ impl Engine for RedisEngine {
         let query_path = dataset.get_path()?;
         println!("\tReading queries from {}...", query_path.display());
         let (queries, neighbors, conditions) = dataset.read_queries()?;
+        if queries.is_empty() {
+            return Err("dataset contains no search queries".to_string());
+        }
 
         // Parse all conditions up front (before timing begins)
         let parsed_filters: Vec<Option<ParsedFilter>> = conditions
@@ -1534,11 +1539,14 @@ impl Engine for RedisEngine {
         // When not set, use per-query ground truth count (matches Python v0 behavior
         // where top defaults to len(query.expected_result) per query).
         let explicit_top: Option<usize> = params.top.map(|t| t as usize);
-        let num_to_run = if num_queries > 0 {
-            (num_queries as usize).min(queries.len())
-        } else {
-            queries.len()
-        };
+        let open_loop = OpenLoopPlan::from_params(params)?;
+        let num_to_run = open_loop.map(|p| p.total_requests).unwrap_or_else(|| {
+            if num_queries > 0 {
+                (num_queries as usize).min(queries.len())
+            } else {
+                queries.len()
+            }
+        });
 
         // Precompute all client-side request construction BEFORE the timed
         // region so the per-query timed window wraps ONLY the RPC round-trip +
@@ -1567,13 +1575,24 @@ impl Engine for RedisEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
-        let start_time = Instant::now();
+        // Give workers time to establish their connections before the first
+        // independent arrival; setup is outside the measured open-loop window.
+        let start_time = if open_loop.is_some() {
+            Instant::now() + Duration::from_millis(500)
+        } else {
+            Instant::now()
+        };
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut recs: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut mrs: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut nds: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut schedule_delays: Vec<f64> = Vec::new();
+        let mut end_to_end_latencies: Vec<f64> = Vec::new();
+        let mut dropped_queries = 0usize;
+        let mut late_queries = 0usize;
+        let query_count = queries.len();
 
         std::thread::scope(|s| {
             let mut handles = Vec::with_capacity(parallel);
@@ -1596,15 +1615,19 @@ impl Engine for RedisEngine {
                     let mut r = Vec::new();
                     let mut mr = Vec::new();
                     let mut nd = Vec::new();
+                    let mut sd = Vec::new();
+                    let mut e2e = Vec::new();
+                    let mut dropped = 0usize;
+                    let mut late = 0usize;
                     let mut pb_pending: u64 = 0;
 
                     let client = match redis::Client::open(redis_url.as_str()) {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => return (t, p, r, mr, nd, sd, e2e, dropped, late),
                     };
                     let mut conn = match client.get_connection() {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => return (t, p, r, mr, nd, sd, e2e, dropped, late),
                     };
 
                     loop {
@@ -1612,11 +1635,33 @@ impl Engine for RedisEngine {
                         if idx >= num_to_run {
                             break;
                         }
+                        let query_pos = idx % query_count;
+
+                        let scheduled_at = open_loop.map(|plan| {
+                            let delay = plan.wait_for_slot(start_time, idx);
+                            sd.push(delay.as_secs_f64());
+                            if plan.is_late(delay) {
+                                late += 1;
+                            }
+                            (
+                                plan.scheduled_at(start_time, idx),
+                                delay > plan.max_lateness,
+                            )
+                        });
+                        if scheduled_at.map(|(_, drop)| drop).unwrap_or(false) {
+                            dropped += 1;
+                            pb_pending += 1;
+                            if pb_pending >= 256 {
+                                pb.inc(pb_pending);
+                                pb_pending = 0;
+                            }
+                            continue;
+                        }
 
                         // Per-query top: use explicit top if set, otherwise
                         // use ground truth count (matches Python v0 behavior)
                         let top = explicit_top.unwrap_or_else(|| {
-                            let n = neighbors[idx].len();
+                            let n = neighbors[query_pos].len();
                             if n > 0 {
                                 n
                             } else {
@@ -1629,16 +1674,17 @@ impl Engine for RedisEngine {
                         let query_start = Instant::now();
                         let results = ft_search_knn(
                             &mut conn,
-                            &encoded_queries[idx],
-                            &query_strs[idx],
+                            &encoded_queries[query_pos],
+                            &query_strs[query_pos],
                             top,
                             ef,
                             &algorithm,
                             &hybrid_policy,
                             query_timeout,
-                            parsed_filters[idx].as_ref(),
+                            parsed_filters[query_pos].as_ref(),
                         );
                         let query_time = query_start.elapsed().as_secs_f64();
+                        let completion = Instant::now();
 
                         // Record latency + quality only for successful queries. A
                         // failed query is surfaced and counted (as num_to_run minus
@@ -1648,12 +1694,19 @@ impl Engine for RedisEngine {
                             Ok(result_ids) => {
                                 let ordered_ids: Vec<i64> =
                                     result_ids.iter().map(|(id, _)| *id).collect();
-                                let m = compute_metrics(&ordered_ids, &neighbors[idx], top);
+                                let m = compute_metrics(&ordered_ids, &neighbors[query_pos], top);
                                 t.push(query_time);
                                 p.push(m.precision);
                                 r.push(m.recall);
                                 mr.push(m.mrr);
                                 nd.push(m.ndcg);
+                                if let Some((scheduled, _)) = scheduled_at {
+                                    e2e.push(
+                                        completion
+                                            .saturating_duration_since(scheduled)
+                                            .as_secs_f64(),
+                                    );
+                                }
                             }
                             Err(e) => {
                                 eprintln!("Search query {} failed: {}", idx, e);
@@ -1670,17 +1723,21 @@ impl Engine for RedisEngine {
                     if pb_pending > 0 {
                         pb.inc(pb_pending);
                     }
-                    (t, p, r, mr, nd)
+                    (t, p, r, mr, nd, sd, e2e, dropped, late)
                 }));
             }
 
             for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+                let (t, p, r, mr, nd, sd, e2e, dropped, late) = h.join().unwrap();
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrs.extend(mr);
                 nds.extend(nd);
+                schedule_delays.extend(sd);
+                end_to_end_latencies.extend(e2e);
+                dropped_queries += dropped;
+                late_queries += late;
             }
         });
 
@@ -1701,9 +1758,30 @@ impl Engine for RedisEngine {
         )?;
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
-        crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrs, &nds, total_time, top, parallel, num_to_run,
-        )
+        let attempted_queries = num_to_run.saturating_sub(dropped_queries);
+        let mut results = crate::engine::compute_search_stats(
+            &times,
+            &precs,
+            &recs,
+            &mrs,
+            &nds,
+            total_time,
+            top,
+            parallel,
+            attempted_queries,
+        )?;
+        // In open-loop mode, drops are distinct from attempted request failures.
+        if let Some(plan) = open_loop {
+            attach_open_loop_metrics(
+                &mut results,
+                plan,
+                &schedule_delays,
+                &end_to_end_latencies,
+                dropped_queries,
+                late_queries,
+            );
+        }
+        Ok(results)
     }
 
     fn search_mixed(

--- a/src/bin/vector_db_benchmark/engine/vertex.rs
+++ b/src/bin/vector_db_benchmark/engine/vertex.rs
@@ -21,14 +21,14 @@
 //! start of each phase (and once before the timed search region).
 
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{Engine, SearchResults, UploadStats};
+use crate::engine::{attach_open_loop_metrics, Engine, OpenLoopPlan, SearchResults, UploadStats};
 
 const DEFAULT_REGION: &str = "us-central1";
 const DEFAULT_MACHINE_TYPE: &str = "e2-standard-16";
@@ -170,6 +170,29 @@ fn parse_find_neighbors_response(resp: &serde_json::Value) -> Vec<i64> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn execute_find_neighbors(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    token: &str,
+    body: &serde_json::Value,
+) -> Result<Vec<i64>, String> {
+    let resp = client
+        .post(url)
+        .bearer_auth(token)
+        .json(body)
+        .send()
+        .map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "{}: {}",
+            resp.status(),
+            resp.text().unwrap_or_default()
+        ));
+    }
+    let json: serde_json::Value = resp.json().map_err(|e| e.to_string())?;
+    Ok(parse_find_neighbors_response(&json))
 }
 
 /// Inspect a long-running-operation reply: `Ok(Some(response))` when done,
@@ -650,20 +673,26 @@ impl Engine for VertexEngine {
         let query_path = dataset.get_path()?;
         println!("\tReading queries from {}...", query_path.display());
         let (queries, neighbors, _conditions) = dataset.read_queries()?;
+        if queries.is_empty() {
+            return Err("dataset contains no search queries".to_string());
+        }
 
         let explicit_top: Option<usize> = params.top.map(|t| t as usize);
-        let num_to_run = if num_queries > 0 {
-            (num_queries as usize).min(queries.len())
-        } else {
-            queries.len()
-        };
+        let open_loop = OpenLoopPlan::from_params(params)?;
+        let num_to_run = open_loop.map(|p| p.total_requests).unwrap_or_else(|| {
+            if num_queries > 0 {
+                (num_queries as usize).min(queries.len())
+            } else {
+                queries.len()
+            }
+        });
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
 
-        if neighbors.len() < num_to_run {
+        if neighbors.len() < queries.len() {
             return Err(format!(
-                "dataset misaligned: {} neighbor lists for {} queries to run",
+                "dataset misaligned: {} neighbor lists for {} dataset queries",
                 neighbors.len(),
-                num_to_run
+                queries.len()
             ));
         }
 
@@ -695,7 +724,9 @@ impl Engine for VertexEngine {
         let workers = parallel.min(num_to_run.max(1));
         let query_idx = Arc::new(AtomicUsize::new(0));
         let pb = self.create_progress_bar(num_to_run);
-        let total_start = Instant::now();
+        let closed_loop_start = Instant::now();
+        let open_loop_start = Arc::new(OnceLock::<Instant>::new());
+        let worker_ready = Arc::new(Barrier::new(workers + 1));
 
         let queries = &queries;
         let neighbors = &neighbors;
@@ -707,18 +738,29 @@ impl Engine for VertexEngine {
         let mut recalls: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut mrrs: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcgs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut schedule_delays: Vec<f64> = Vec::new();
+        let mut end_to_end_latencies: Vec<f64> = Vec::new();
+        let mut dropped_queries = 0usize;
+        let mut late_queries = 0usize;
 
         std::thread::scope(|s| {
             let mut handles = Vec::with_capacity(workers);
-            for _ in 0..workers {
+            for worker_id in 0..workers {
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
+                let open_loop_start = Arc::clone(&open_loop_start);
+                let worker_ready = Arc::clone(&worker_ready);
                 handles.push(s.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
                     let mut mr = Vec::new();
                     let mut nd = Vec::new();
+                    let mut sd = Vec::new();
+                    let mut e2e = Vec::new();
+                    let mut dropped = 0usize;
+                    let mut late = 0usize;
+                    let mut pb_pending: u64 = 0;
 
                     let client = match reqwest::blocking::Client::builder()
                         .timeout(Duration::from_secs(60))
@@ -727,8 +769,39 @@ impl Engine for VertexEngine {
                         Ok(c) => c,
                         Err(e) => {
                             eprintln!("Vertex worker client build failed: {}", e);
-                            return (t, p, r, mr, nd);
+                            if open_loop.is_some() {
+                                worker_ready.wait();
+                            }
+                            return (t, p, r, mr, nd, sd, e2e, dropped, late);
                         }
+                    };
+
+                    // reqwest establishes TCP/TLS lazily on first use. Prime each
+                    // persistent worker connection before starting the shared
+                    // arrival clock so setup cannot masquerade as queueing delay.
+                    if open_loop.is_some() {
+                        let prime_pos = worker_id % queries.len();
+                        let prime_body = build_find_neighbors_body(
+                            deployed_index_id,
+                            &queries[prime_pos],
+                            top,
+                            fraction_leaf_override,
+                        );
+                        if let Err(e) = execute_find_neighbors(&client, url, token, &prime_body) {
+                            eprintln!("Vertex worker connection prime failed: {}", e);
+                        }
+                        worker_ready.wait();
+                    }
+
+                    let schedule_start = if open_loop.is_some() {
+                        loop {
+                            if let Some(start) = open_loop_start.get() {
+                                break *start;
+                            }
+                            std::thread::yield_now();
+                        }
+                    } else {
+                        closed_loop_start
                     };
 
                     loop {
@@ -736,41 +809,48 @@ impl Engine for VertexEngine {
                         if idx >= num_to_run {
                             break;
                         }
+                        let query_pos = idx % queries.len();
                         let body = build_find_neighbors_body(
                             deployed_index_id,
-                            &queries[idx],
+                            &queries[query_pos],
                             top,
                             fraction_leaf_override,
                         );
+
+                        let scheduled_at = open_loop.map(|plan| {
+                            let delay = plan.wait_for_slot(schedule_start, idx);
+                            sd.push(delay.as_secs_f64());
+                            if plan.is_late(delay) {
+                                late += 1;
+                            }
+                            (
+                                plan.scheduled_at(schedule_start, idx),
+                                delay > plan.max_lateness,
+                            )
+                        });
+                        if scheduled_at.map(|(_, drop)| drop).unwrap_or(false) {
+                            dropped += 1;
+                            pb_pending += 1;
+                            if pb_pending >= 256 {
+                                pb.inc(pb_pending);
+                                pb_pending = 0;
+                            }
+                            continue;
+                        }
 
                         // Timed window: RPC round-trip + reply parse only. The
                         // request body is built above (client-side work), matching
                         // the other engines' boundary.
                         let start = Instant::now();
-                        let outcome: Result<Vec<i64>, String> = (|| {
-                            let resp = client
-                                .post(url)
-                                .bearer_auth(token)
-                                .json(&body)
-                                .send()
-                                .map_err(|e| e.to_string())?;
-                            if !resp.status().is_success() {
-                                return Err(format!(
-                                    "{}: {}",
-                                    resp.status(),
-                                    resp.text().unwrap_or_default()
-                                ));
-                            }
-                            let json: serde_json::Value = resp.json().map_err(|e| e.to_string())?;
-                            Ok(parse_find_neighbors_response(&json))
-                        })();
+                        let outcome = execute_find_neighbors(&client, url, token, &body);
                         let elapsed = start.elapsed().as_secs_f64();
+                        let completion = Instant::now();
 
                         match outcome {
                             Ok(result_ids) => {
                                 let m = crate::metrics::compute_metrics(
                                     &result_ids,
-                                    &neighbors[idx],
+                                    &neighbors[query_pos],
                                     top,
                                 );
                                 t.push(elapsed);
@@ -778,37 +858,64 @@ impl Engine for VertexEngine {
                                 r.push(m.recall);
                                 mr.push(m.mrr);
                                 nd.push(m.ndcg);
+                                if let Some((scheduled, _)) = scheduled_at {
+                                    e2e.push(
+                                        completion
+                                            .saturating_duration_since(scheduled)
+                                            .as_secs_f64(),
+                                    );
+                                }
                             }
                             Err(e) => eprintln!("Search query {} failed: {}", idx, e),
                         }
-                        pb.inc(1);
+                        pb_pending += 1;
+                        if pb_pending >= 256 {
+                            pb.inc(pb_pending);
+                            pb_pending = 0;
+                        }
                     }
-                    (t, p, r, mr, nd)
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
+                    }
+                    (t, p, r, mr, nd, sd, e2e, dropped, late)
                 }));
             }
+            if open_loop.is_some() {
+                worker_ready.wait();
+                let _ = open_loop_start.set(Instant::now() + Duration::from_millis(100));
+            }
             for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+                let (t, p, r, mr, nd, sd, e2e, dropped, late) = h.join().unwrap();
                 latencies.extend(t);
                 precisions.extend(p);
                 recalls.extend(r);
                 mrrs.extend(mr);
                 ndcgs.extend(nd);
+                schedule_delays.extend(sd);
+                end_to_end_latencies.extend(e2e);
+                dropped_queries += dropped;
+                late_queries += late;
             }
         });
 
         pb.finish_and_clear();
+        let total_start = open_loop_start.get().copied().unwrap_or(closed_loop_start);
         let total_time = total_start.elapsed().as_secs_f64();
 
         let succeeded = latencies.len();
         if succeeded == 0 {
             return Err("No searches completed (all queries failed)".to_string());
         }
-        let failed = num_to_run - succeeded;
+        let attempted_queries = num_to_run.saturating_sub(dropped_queries);
+        let failed = attempted_queries - succeeded;
         if failed > 0 {
-            eprintln!("WARNING: {} of {} queries failed", failed, num_to_run);
+            eprintln!(
+                "WARNING: {} of {} attempted queries failed",
+                failed, attempted_queries
+            );
         }
 
-        crate::engine::compute_search_stats(
+        let mut results = crate::engine::compute_search_stats(
             &latencies,
             &precisions,
             &recalls,
@@ -817,8 +924,19 @@ impl Engine for VertexEngine {
             total_time,
             top,
             parallel,
-            num_to_run,
-        )
+            attempted_queries,
+        )?;
+        if let Some(plan) = open_loop {
+            attach_open_loop_metrics(
+                &mut results,
+                plan,
+                &schedule_delays,
+                &end_to_end_latencies,
+                dropped_queries,
+                late_queries,
+            );
+        }
+        Ok(results)
     }
 
     fn delete(&mut self) -> Result<(), String> {

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -30,6 +30,31 @@ fn results_dir() -> PathBuf {
 pub fn run(args: &Args) -> Result<(), String> {
     println!("vector-db-benchmark v{}", env!("CARGO_PKG_VERSION"));
 
+    if args.target_qps != 0.0 {
+        if !args.target_qps.is_finite() || args.target_qps <= 0.0 {
+            return Err("--target-qps must be finite and greater than zero".to_string());
+        }
+        if !args.search_duration.is_finite() || args.search_duration <= 0.0 {
+            return Err(
+                "--search-duration is required and must be greater than zero with --target-qps"
+                    .to_string(),
+            );
+        }
+        if !args.warmup_seconds.is_finite() || args.warmup_seconds < 0.0 {
+            return Err("--warmup-seconds must be finite and non-negative".to_string());
+        }
+        if !args.max_lateness_ms.is_finite() || args.max_lateness_ms < 0.0 {
+            return Err("--max-lateness-ms must be finite and non-negative".to_string());
+        }
+        if args.skip_vector_index || !args.update_search_ratio.is_empty() {
+            return Err(
+                "--target-qps currently supports search-only vector benchmarks".to_string(),
+            );
+        }
+    } else if args.search_duration != 0.0 || args.warmup_seconds != 0.0 {
+        return Err("--search-duration/--warmup-seconds require --target-qps".to_string());
+    }
+
     let dataset_configs = read_dataset_configs()?;
     let engine_configs = read_engine_configs()?;
 
@@ -77,6 +102,22 @@ pub fn run(args: &Args) -> Result<(), String> {
             args.engines.join(", "),
             supported_engines
         ));
+    }
+
+    if args.target_qps > 0.0 {
+        let unsupported: Vec<_> = engines
+            .iter()
+            .filter_map(|(name, config)| {
+                let engine_type = config.engine.as_deref().unwrap_or("unknown");
+                (!matches!(engine_type, "redis" | "vertex")).then_some(name.as_str())
+            })
+            .collect();
+        if !unsupported.is_empty() {
+            return Err(format!(
+                "--target-qps currently supports Redis and Vertex only; unsupported: {}",
+                unsupported.join(", ")
+            ));
+        }
     }
 
     // --skip-vector-index: deduplicate engine configs by engine type.
@@ -433,7 +474,14 @@ fn run_single_experiment(
                     None
                 };
 
-                let effective_params = calibrated_params.as_ref().unwrap_or(search_params);
+                let base_params = calibrated_params.as_ref().unwrap_or(search_params);
+                let mut runtime_params = base_params.clone();
+                if args.target_qps > 0.0 {
+                    runtime_params.target_qps = Some(args.target_qps);
+                    runtime_params.duration_seconds = Some(args.search_duration);
+                    runtime_params.max_lateness_ms = Some(args.max_lateness_ms);
+                }
+                let effective_params = &runtime_params;
                 let effective_ef = if skip_vector_index {
                     "n/a".to_string()
                 } else {
@@ -455,6 +503,18 @@ fn run_single_experiment(
                         "\tRunning search {}: ef={}, parallel={}",
                         search_id, effective_ef, parallel
                     );
+                }
+
+                if args.target_qps > 0.0 && args.warmup_seconds > 0.0 {
+                    let mut warmup_params = effective_params.clone();
+                    warmup_params.duration_seconds = Some(args.warmup_seconds);
+                    println!(
+                        "\tOpen-loop warm-up: {:.1} QPS for {:.1}s",
+                        args.target_qps, args.warmup_seconds
+                    );
+                    engine
+                        .search(dataset, &warmup_params, args.queries)
+                        .map_err(|e| format!("open-loop warm-up failed: {}", e))?;
                 }
 
                 // Run the measured search `repetitions` times and keep the
@@ -535,6 +595,22 @@ fn run_single_experiment(
                                 results.requested_queries,
                                 results.num_queries,
                             );
+                        }
+                        if let Some(target_qps) = results.target_qps {
+                            println!(
+                                "\t  offered {:.1} QPS; dropped {}; late {}; schedule p95 {:.3} ms; end-to-end p95 {:.3} ms",
+                                target_qps,
+                                results.dropped_queries,
+                                results.late_queries,
+                                results.schedule_delay_p95_time.unwrap_or_default() * 1000.0,
+                                results.end_to_end_p95_time.unwrap_or_default() * 1000.0,
+                            );
+                            if results.dropped_queries > 0 {
+                                eprintln!(
+                                    "\t⚠ WARNING: {} offered requests were dropped after exceeding the dispatch-lateness limit",
+                                    results.dropped_queries
+                                );
+                            }
                         }
                         // Flag client-side saturation: when the benchmark client is
                         // the bottleneck the QPS/latency above are not clean
@@ -721,6 +797,9 @@ fn save_search_results(
             "parallel": search_params.parallel.unwrap_or(1),
             "top": results.top,
             "search_params": search_params.search_params,
+            "target_qps": search_params.target_qps,
+            "duration_seconds": search_params.duration_seconds,
+            "max_lateness_ms": search_params.max_lateness_ms,
         },
         "results": {
             "total_time": results.total_time,
@@ -743,6 +822,16 @@ fn save_search_results(
             "system_cpu_pct": results.system_cpu_pct,
             "client_saturated": results.client_saturated,
             "saturation_reason": results.saturation_reason,
+            "target_qps": results.target_qps,
+            "offered_queries": results.offered_queries,
+            "dropped_queries": results.dropped_queries,
+            "late_queries": results.late_queries,
+            "schedule_delay_p50_time": results.schedule_delay_p50_time,
+            "schedule_delay_p95_time": results.schedule_delay_p95_time,
+            "schedule_delay_p99_time": results.schedule_delay_p99_time,
+            "end_to_end_p50_time": results.end_to_end_p50_time,
+            "end_to_end_p95_time": results.end_to_end_p95_time,
+            "end_to_end_p99_time": results.end_to_end_p99_time,
             "mean_precisions": results.mean_precision,
             "mean_recall": results.mean_recall,
             "mean_mrr": results.mean_mrr,

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -1530,6 +1530,110 @@ fn test_binary_redis_end_to_end() {
 }
 
 #[test]
+fn test_binary_redis_open_loop_fixed_qps() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 16;
+    let count = 100;
+    let top = 5;
+    let (_, vectors) = generate_test_vectors(count, dim);
+    let queries: Vec<Vec<f32>> = vectors[..10].to_vec();
+    let neighbors: Vec<Vec<i64>> = queries
+        .iter()
+        .map(|q| brute_force_neighbors(q, &vectors, top))
+        .collect();
+    let engine_config = serde_json::json!([{
+        "name": "test-redis-open-loop",
+        "engine": "redis",
+        "algorithm": "hnsw",
+        "collection_params": {
+            "hnsw_config": { "M": 16, "EF_CONSTRUCTION": 128 }
+        },
+        "search_params": [{
+            "parallel": 4,
+            "search_params": { "ef": 256 },
+            "top": top
+        }],
+        "upload_params": {
+            "data_type": "FLOAT32",
+            "parallel": 1,
+            "batch_size": 64
+        }
+    }]);
+    let project_root = create_test_project(
+        "test-open-loop",
+        &serde_json::to_string_pretty(&engine_config).unwrap(),
+        &vectors,
+        &queries,
+        &neighbors,
+        "l2",
+        dim,
+    );
+
+    let output = Command::new(binary_path())
+        .args([
+            "--engines",
+            "test-redis-open-loop",
+            "--datasets",
+            "test-open-loop",
+            "--host",
+            "localhost",
+            "--target-qps",
+            "100",
+            "--search-duration",
+            "0.4",
+            "--max-lateness-ms",
+            "1000",
+            "--repetitions",
+            "1",
+        ])
+        .env("REDIS_PORT", TEST_PORT.to_string())
+        .current_dir(&project_root)
+        .output()
+        .expect("Failed to run open-loop benchmark");
+    assert!(
+        output.status.success(),
+        "open-loop binary failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let results_dir = project_root.join("results");
+    assert_eq!(
+        read_search_result_field(&results_dir, "test-redis-open-loop", "target_qps"),
+        Some(serde_json::json!(100.0))
+    );
+    assert_eq!(
+        read_search_result_field(&results_dir, "test-redis-open-loop", "offered_queries"),
+        Some(serde_json::json!(40))
+    );
+    assert_eq!(
+        read_search_result_field(&results_dir, "test-redis-open-loop", "succeeded_queries"),
+        Some(serde_json::json!(40))
+    );
+    assert_eq!(
+        read_search_result_field(&results_dir, "test-redis-open-loop", "dropped_queries"),
+        Some(serde_json::json!(0))
+    );
+    assert!(read_search_result_field(
+        &results_dir,
+        "test-redis-open-loop",
+        "schedule_delay_p95_time"
+    )
+    .and_then(|v| v.as_f64())
+    .is_some());
+    assert!(
+        read_search_result_field(&results_dir, "test-redis-open-loop", "end_to_end_p95_time")
+            .and_then(|v| v.as_f64())
+            .is_some()
+    );
+
+    fs::remove_dir_all(&project_root).ok();
+}
+
+#[test]
 fn test_binary_vectorsets_end_to_end() {
     wait_for_redis();
     let mut conn = get_test_connection();


### PR DESCRIPTION
## Summary

- add an open-loop fixed-rate search mode with `--target-qps`, `--search-duration`, warm-up, and a configurable lateness/drop threshold
- report offered/completed/failed/dropped/late request accounting plus schedule-delay and end-to-end latency percentiles
- support Redis and Vertex while preserving the existing closed-loop behavior
- prime persistent Vertex worker connections before the shared arrival clock starts

## Why

The existing concurrency-driven loop measures maximum closed-loop throughput, but it cannot apply the same offered QPS to two engines. This change adds a deterministic independent arrival schedule so latency, completion rate, failures, drops, and generator queueing can be compared at a fixed load.

## Validation

- `make check`
- `make test` (79 passed)
- `make vector-db-benchmark`
- `make integration-test` (24 passed, including the new fixed-QPS Redis test)

## Live validation

- Glove 1M / 100-dim at 1,500 offered QPS, concurrency 32, five minutes: Redis and Vertex each completed 450,000/450,000 requests with zero drops.
- Recall@10 at 2,500 offered QPS, concurrency 32, five minutes: Redis and Vertex each completed 750,000/750,000 requests with zero failures and zero drops; neither load-generator run was CPU-saturated.