### PR TITLE
Add Vertex gRPC and duration-bounded benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bzip2 = "0.5"
 postgres = "0.19"
 pgvector = { version = "0.4", features = ["postgres"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time"] }
-tonic = "0.12"
+tonic = { version = "0.12", features = ["tls-native-roots"] }
 prost = "0.13"
 prost-types = "0.13"
 qdrant-client = "1.17"

--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -77,6 +77,23 @@ pub struct Args {
     #[arg(long, default_value = "-1")]
     pub queries: i64,
 
+    /// Fixed offered query rate. 0 keeps the existing closed-loop behavior.
+    /// Open-loop mode is currently supported by Redis and Vertex.
+    #[arg(long, default_value = "0.0")]
+    pub target_qps: f64,
+
+    /// Measured open-loop duration in seconds. Required with --target-qps.
+    #[arg(long, default_value = "0.0")]
+    pub search_duration: f64,
+
+    /// Warm-up duration before each measured open-loop search configuration.
+    #[arg(long, default_value = "0.0")]
+    pub warmup_seconds: f64,
+
+    /// Drop an open-loop request when dispatch is this many milliseconds late.
+    #[arg(long, default_value = "1000.0")]
+    pub max_lateness_ms: f64,
+
     /// Repeat each measured search config this many times and report the
     /// best-RPS run (warm best-of, matching v0's REPETITIONS). The first run is
     /// often cold (OS page cache / index warm-up); best-of discards it. Set 1 to
@@ -148,6 +165,24 @@ mod tests {
         assert!(parse(&["--exit-on-error"]).exit_on_error, "bare → true");
         assert!(!parse(&["--exit-on-error", "false"]).exit_on_error);
         assert!(!parse(&["--exit-on-error=false"]).exit_on_error);
+    }
+
+    #[test]
+    fn parses_open_loop_options() {
+        let args = parse(&[
+            "--target-qps",
+            "1500",
+            "--search-duration",
+            "300",
+            "--warmup-seconds",
+            "10",
+            "--max-lateness-ms",
+            "250",
+        ]);
+        assert_eq!(args.target_qps, 1500.0);
+        assert_eq!(args.search_duration, 300.0);
+        assert_eq!(args.warmup_seconds, 10.0);
+        assert_eq!(args.max_lateness_ms, 250.0);
     }
 
     // `--describe datasets|engines` is what the docker-build smoke test exercises;

--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -38,6 +38,10 @@ pub struct Args {
     #[arg(long, default_value = "false")]
     pub skip_search: bool,
 
+    /// Keep the configured index and uploaded data after the experiment
+    #[arg(long, default_value = "false")]
+    pub keep_data: bool,
+
     /// Skip if results already exist (accepts an optional value, e.g.
     /// `--skip-if-exists false`; bare `--skip-if-exists` means true)
     #[arg(
@@ -82,7 +86,8 @@ pub struct Args {
     #[arg(long, default_value = "0.0")]
     pub target_qps: f64,
 
-    /// Measured open-loop duration in seconds. Required with --target-qps.
+    /// Measured search duration in seconds. With --target-qps this is open-loop;
+    /// without it Redis and Vertex run unrestricted closed-loop for this long.
     #[arg(long, default_value = "0.0")]
     pub search_duration: f64,
 

--- a/src/bin/vector_db_benchmark/config.rs
+++ b/src/bin/vector_db_benchmark/config.rs
@@ -59,6 +59,12 @@ pub struct SearchParams {
     pub search_params: Option<InnerSearchParams>,
     pub top: Option<i64>,
     pub num_candidates: Option<i64>,
+    /// Fixed offered rate for an open-loop run. None keeps closed-loop behavior.
+    pub target_qps: Option<f64>,
+    /// Open-loop measurement duration. Queries recycle when the dataset is shorter.
+    pub duration_seconds: Option<f64>,
+    /// Requests dispatched later than this are dropped and counted.
+    pub max_lateness_ms: Option<f64>,
     /// Calibration: name of the search param to tune (e.g., "ef")
     pub calibration_param: Option<String>,
     /// Calibration: target precision to achieve

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -24,6 +24,7 @@ mod weaviate_grpc;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
+use std::time::{Duration, Instant};
 
 pub use dragonfly::DragonflyEngine;
 pub use elasticsearch::ElasticsearchEngine;
@@ -98,6 +99,17 @@ pub struct SearchResults {
     pub system_cpu_pct: Option<f64>,
     pub client_saturated: bool,
     pub saturation_reason: String,
+    // Open-loop offered-load coverage. None/empty in the original closed-loop mode.
+    pub target_qps: Option<f64>,
+    pub offered_queries: Option<usize>,
+    pub dropped_queries: usize,
+    pub late_queries: usize,
+    pub schedule_delay_p50_time: Option<f64>,
+    pub schedule_delay_p95_time: Option<f64>,
+    pub schedule_delay_p99_time: Option<f64>,
+    pub end_to_end_p50_time: Option<f64>,
+    pub end_to_end_p95_time: Option<f64>,
+    pub end_to_end_p99_time: Option<f64>,
     // Mixed benchmark update metrics (None when search-only)
     pub update_count: Option<usize>,
     pub update_rps: Option<f64>,
@@ -107,6 +119,100 @@ pub struct SearchResults {
     pub update_p99_time: Option<f64>,
     pub update_latencies: Option<Vec<f64>>,
     pub update_search_ratio: Option<String>,
+}
+
+/// Deterministic arrival schedule for fixed-rate, open-loop search.
+#[derive(Debug, Clone, Copy)]
+pub struct OpenLoopPlan {
+    pub target_qps: f64,
+    pub total_requests: usize,
+    pub max_lateness: Duration,
+    late_threshold: Duration,
+}
+
+impl OpenLoopPlan {
+    /// Build a plan from search parameters. Returns None for legacy closed-loop runs.
+    pub fn from_params(params: &SearchParams) -> Result<Option<Self>, String> {
+        let Some(target_qps) = params.target_qps else {
+            return Ok(None);
+        };
+        let duration_seconds = params
+            .duration_seconds
+            .ok_or("open-loop search requires duration_seconds (use --search-duration)")?;
+        let max_lateness_ms = params.max_lateness_ms.unwrap_or(1000.0);
+        if !target_qps.is_finite() || target_qps <= 0.0 {
+            return Err("target_qps must be finite and greater than zero".to_string());
+        }
+        if !duration_seconds.is_finite() || duration_seconds <= 0.0 {
+            return Err("duration_seconds must be finite and greater than zero".to_string());
+        }
+        if !max_lateness_ms.is_finite() || max_lateness_ms < 0.0 {
+            return Err("max_lateness_ms must be finite and non-negative".to_string());
+        }
+        let total_f = (target_qps * duration_seconds).round();
+        if !total_f.is_finite() || total_f < 1.0 || total_f > usize::MAX as f64 {
+            return Err("target_qps * duration_seconds is outside the supported range".to_string());
+        }
+        // A request is reported as late after two arrival intervals, with a 1 ms
+        // floor to avoid treating normal scheduler jitter as overload.
+        let late_threshold = Duration::from_secs_f64((2.0 / target_qps).max(0.001));
+        Ok(Some(Self {
+            target_qps,
+            total_requests: total_f as usize,
+            max_lateness: Duration::from_secs_f64(max_lateness_ms / 1000.0),
+            late_threshold,
+        }))
+    }
+
+    pub fn scheduled_at(&self, start: Instant, ordinal: usize) -> Instant {
+        start + Duration::from_secs_f64(ordinal as f64 / self.target_qps)
+    }
+
+    /// Wait until this request's independent arrival time and return dispatch delay.
+    pub fn wait_for_slot(&self, start: Instant, ordinal: usize) -> Duration {
+        let scheduled = self.scheduled_at(start, ordinal);
+        let now = Instant::now();
+        if now < scheduled {
+            std::thread::sleep(scheduled.duration_since(now));
+        }
+        Instant::now().saturating_duration_since(scheduled)
+    }
+
+    pub fn is_late(&self, delay: Duration) -> bool {
+        delay > self.late_threshold
+    }
+}
+
+/// Add open-loop queueing/arrival metrics without changing closed-loop statistics.
+pub fn attach_open_loop_metrics(
+    results: &mut SearchResults,
+    plan: OpenLoopPlan,
+    schedule_delays: &[f64],
+    end_to_end_latencies: &[f64],
+    dropped_queries: usize,
+    late_queries: usize,
+) {
+    let percentiles = |values: &[f64]| -> (f64, f64, f64) {
+        let mut sorted = values.to_vec();
+        sorted.sort_by(|a, b| a.total_cmp(b));
+        (
+            percentile_linear(&sorted, 0.50),
+            percentile_linear(&sorted, 0.95),
+            percentile_linear(&sorted, 0.99),
+        )
+    };
+    let (sd50, sd95, sd99) = percentiles(schedule_delays);
+    let (e2e50, e2e95, e2e99) = percentiles(end_to_end_latencies);
+    results.target_qps = Some(plan.target_qps);
+    results.offered_queries = Some(plan.total_requests);
+    results.dropped_queries = dropped_queries;
+    results.late_queries = late_queries;
+    results.schedule_delay_p50_time = Some(sd50);
+    results.schedule_delay_p95_time = Some(sd95);
+    results.schedule_delay_p99_time = Some(sd99);
+    results.end_to_end_p50_time = Some(e2e50);
+    results.end_to_end_p95_time = Some(e2e95);
+    results.end_to_end_p99_time = Some(e2e99);
 }
 
 /// `numpy.percentile` with linear interpolation — the method v0 uses
@@ -319,7 +425,8 @@ pub fn create_engine(engine_config: &EngineConfig, host: &str) -> Result<Box<dyn
 
 #[cfg(test)]
 mod stats_tests {
-    use super::compute_search_stats;
+    use super::{attach_open_loop_metrics, compute_search_stats, OpenLoopPlan};
+    use crate::config::SearchParams;
 
     #[test]
     fn empty_times_errors() {
@@ -393,5 +500,55 @@ mod stats_tests {
         assert!((r.p95_time - 95.05).abs() < 1e-9, "p95={}", r.p95_time);
         assert!((r.p50_time - 50.5).abs() < 1e-9, "p50={}", r.p50_time);
         assert!(r.p99_time < 100.0, "p99={} must be below max", r.p99_time);
+    }
+
+    #[test]
+    fn open_loop_plan_validates_and_counts_arrivals() {
+        let params: SearchParams = serde_json::from_value(serde_json::json!({
+            "parallel": 32,
+            "target_qps": 1500.0,
+            "duration_seconds": 2.0,
+            "max_lateness_ms": 250.0
+        }))
+        .unwrap();
+        let plan = OpenLoopPlan::from_params(&params).unwrap().unwrap();
+        assert_eq!(plan.total_requests, 3000);
+        assert_eq!(plan.target_qps, 1500.0);
+        assert_eq!(plan.max_lateness.as_millis(), 250);
+
+        let missing_duration: SearchParams = serde_json::from_value(serde_json::json!({
+            "target_qps": 100.0
+        }))
+        .unwrap();
+        assert!(OpenLoopPlan::from_params(&missing_duration).is_err());
+    }
+
+    #[test]
+    fn open_loop_metrics_preserve_service_latency_and_add_queueing() {
+        let params: SearchParams = serde_json::from_value(serde_json::json!({
+            "target_qps": 10.0,
+            "duration_seconds": 1.0
+        }))
+        .unwrap();
+        let plan = OpenLoopPlan::from_params(&params).unwrap().unwrap();
+        let ones = vec![1.0, 1.0];
+        let mut results =
+            compute_search_stats(&[0.010, 0.020], &ones, &ones, &ones, &ones, 1.0, 10, 2, 2)
+                .unwrap();
+        attach_open_loop_metrics(
+            &mut results,
+            plan,
+            &[0.001, 0.003, 0.5],
+            &[0.011, 0.023],
+            1,
+            1,
+        );
+        assert_eq!(results.target_qps, Some(10.0));
+        assert_eq!(results.offered_queries, Some(10));
+        assert_eq!(results.dropped_queries, 1);
+        assert_eq!(results.late_queries, 1);
+        assert_eq!(results.p50_time, 0.015);
+        assert!(results.schedule_delay_p95_time.unwrap() > 0.4);
+        assert_eq!(results.end_to_end_p50_time, Some(0.017));
     }
 }

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -19,6 +19,7 @@ mod turbopuffer;
 mod valkey;
 mod vectorsets;
 mod vertex;
+mod vertex_grpc;
 mod weaviate;
 mod weaviate_grpc;
 
@@ -181,6 +182,22 @@ impl OpenLoopPlan {
     pub fn is_late(&self, delay: Duration) -> bool {
         delay > self.late_threshold
     }
+}
+
+/// Return the duration for an unrestricted closed-loop run, if requested.
+pub fn closed_loop_duration(params: &SearchParams) -> Result<Option<Duration>, String> {
+    if params.target_qps.is_some() {
+        return Ok(None);
+    }
+    let Some(seconds) = params.duration_seconds else {
+        return Ok(None);
+    };
+    if !seconds.is_finite() || seconds <= 0.0 {
+        return Err(
+            "closed-loop duration_seconds must be finite and greater than zero".to_string(),
+        );
+    }
+    Ok(Some(Duration::from_secs_f64(seconds)))
 }
 
 /// Add open-loop queueing/arrival metrics without changing closed-loop statistics.

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -5,7 +5,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
@@ -17,7 +17,9 @@ use redis::Connection;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{Engine, SearchResults, UpdateSearchRatio, UploadStats};
+use crate::engine::{
+    attach_open_loop_metrics, Engine, OpenLoopPlan, SearchResults, UpdateSearchRatio, UploadStats,
+};
 use crate::metrics::compute_metrics;
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, parse_ft_search_response};
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
@@ -1523,6 +1525,9 @@ impl Engine for RedisEngine {
         let query_path = dataset.get_path()?;
         println!("\tReading queries from {}...", query_path.display());
         let (queries, neighbors, conditions) = dataset.read_queries()?;
+        if queries.is_empty() {
+            return Err("dataset contains no search queries".to_string());
+        }
 
         // Parse all conditions up front (before timing begins)
         let parsed_filters: Vec<Option<ParsedFilter>> = conditions
@@ -1534,11 +1539,14 @@ impl Engine for RedisEngine {
         // When not set, use per-query ground truth count (matches Python v0 behavior
         // where top defaults to len(query.expected_result) per query).
         let explicit_top: Option<usize> = params.top.map(|t| t as usize);
-        let num_to_run = if num_queries > 0 {
-            (num_queries as usize).min(queries.len())
-        } else {
-            queries.len()
-        };
+        let open_loop = OpenLoopPlan::from_params(params)?;
+        let num_to_run = open_loop.map(|p| p.total_requests).unwrap_or_else(|| {
+            if num_queries > 0 {
+                (num_queries as usize).min(queries.len())
+            } else {
+                queries.len()
+            }
+        });
 
         // Precompute all client-side request construction BEFORE the timed
         // region so the per-query timed window wraps ONLY the RPC round-trip +
@@ -1567,13 +1575,24 @@ impl Engine for RedisEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
-        let start_time = Instant::now();
+        // Give workers time to establish their connections before the first
+        // independent arrival; setup is outside the measured open-loop window.
+        let start_time = if open_loop.is_some() {
+            Instant::now() + Duration::from_millis(500)
+        } else {
+            Instant::now()
+        };
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut recs: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut mrs: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut nds: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut schedule_delays: Vec<f64> = Vec::new();
+        let mut end_to_end_latencies: Vec<f64> = Vec::new();
+        let mut dropped_queries = 0usize;
+        let mut late_queries = 0usize;
+        let query_count = queries.len();
 
         std::thread::scope(|s| {
             let mut handles = Vec::with_capacity(parallel);
@@ -1596,15 +1615,19 @@ impl Engine for RedisEngine {
                     let mut r = Vec::new();
                     let mut mr = Vec::new();
                     let mut nd = Vec::new();
+                    let mut sd = Vec::new();
+                    let mut e2e = Vec::new();
+                    let mut dropped = 0usize;
+                    let mut late = 0usize;
                     let mut pb_pending: u64 = 0;
 
                     let client = match redis::Client::open(redis_url.as_str()) {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => return (t, p, r, mr, nd, sd, e2e, dropped, late),
                     };
                     let mut conn = match client.get_connection() {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => return (t, p, r, mr, nd, sd, e2e, dropped, late),
                     };
 
                     loop {
@@ -1612,11 +1635,33 @@ impl Engine for RedisEngine {
                         if idx >= num_to_run {
                             break;
                         }
+                        let query_pos = idx % query_count;
+
+                        let scheduled_at = open_loop.map(|plan| {
+                            let delay = plan.wait_for_slot(start_time, idx);
+                            sd.push(delay.as_secs_f64());
+                            if plan.is_late(delay) {
+                                late += 1;
+                            }
+                            (
+                                plan.scheduled_at(start_time, idx),
+                                delay > plan.max_lateness,
+                            )
+                        });
+                        if scheduled_at.map(|(_, drop)| drop).unwrap_or(false) {
+                            dropped += 1;
+                            pb_pending += 1;
+                            if pb_pending >= 256 {
+                                pb.inc(pb_pending);
+                                pb_pending = 0;
+                            }
+                            continue;
+                        }
 
                         // Per-query top: use explicit top if set, otherwise
                         // use ground truth count (matches Python v0 behavior)
                         let top = explicit_top.unwrap_or_else(|| {
-                            let n = neighbors[idx].len();
+                            let n = neighbors[query_pos].len();
                             if n > 0 {
                                 n
                             } else {
@@ -1629,16 +1674,17 @@ impl Engine for RedisEngine {
                         let query_start = Instant::now();
                         let results = ft_search_knn(
                             &mut conn,
-                            &encoded_queries[idx],
-                            &query_strs[idx],
+                            &encoded_queries[query_pos],
+                            &query_strs[query_pos],
                             top,
                             ef,
                             &algorithm,
                             &hybrid_policy,
                             query_timeout,
-                            parsed_filters[idx].as_ref(),
+                            parsed_filters[query_pos].as_ref(),
                         );
                         let query_time = query_start.elapsed().as_secs_f64();
+                        let completion = Instant::now();
 
                         // Record latency + quality only for successful queries. A
                         // failed query is surfaced and counted (as num_to_run minus
@@ -1648,12 +1694,19 @@ impl Engine for RedisEngine {
                             Ok(result_ids) => {
                                 let ordered_ids: Vec<i64> =
                                     result_ids.iter().map(|(id, _)| *id).collect();
-                                let m = compute_metrics(&ordered_ids, &neighbors[idx], top);
+                                let m = compute_metrics(&ordered_ids, &neighbors[query_pos], top);
                                 t.push(query_time);
                                 p.push(m.precision);
                                 r.push(m.recall);
                                 mr.push(m.mrr);
                                 nd.push(m.ndcg);
+                                if let Some((scheduled, _)) = scheduled_at {
+                                    e2e.push(
+                                        completion
+                                            .saturating_duration_since(scheduled)
+                                            .as_secs_f64(),
+                                    );
+                                }
                             }
                             Err(e) => {
                                 eprintln!("Search query {} failed: {}", idx, e);
@@ -1670,17 +1723,21 @@ impl Engine for RedisEngine {
                     if pb_pending > 0 {
                         pb.inc(pb_pending);
                     }
-                    (t, p, r, mr, nd)
+                    (t, p, r, mr, nd, sd, e2e, dropped, late)
                 }));
             }
 
             for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+                let (t, p, r, mr, nd, sd, e2e, dropped, late) = h.join().unwrap();
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrs.extend(mr);
                 nds.extend(nd);
+                schedule_delays.extend(sd);
+                end_to_end_latencies.extend(e2e);
+                dropped_queries += dropped;
+                late_queries += late;
             }
         });
 
@@ -1701,9 +1758,30 @@ impl Engine for RedisEngine {
         )?;
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
-        crate::engine::compute_search_stats(
-            &times, &precs, &recs, &mrs, &nds, total_time, top, parallel, num_to_run,
-        )
+        let attempted_queries = num_to_run.saturating_sub(dropped_queries);
+        let mut results = crate::engine::compute_search_stats(
+            &times,
+            &precs,
+            &recs,
+            &mrs,
+            &nds,
+            total_time,
+            top,
+            parallel,
+            attempted_queries,
+        )?;
+        // In open-loop mode, drops are distinct from attempted request failures.
+        if let Some(plan) = open_loop {
+            attach_open_loop_metrics(
+                &mut results,
+                plan,
+                &schedule_delays,
+                &end_to_end_latencies,
+                dropped_queries,
+                late_queries,
+            );
+        }
+        Ok(results)
     }
 
     fn search_mixed(

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -18,11 +18,16 @@ use redis::Connection;
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::{
-    attach_open_loop_metrics, Engine, OpenLoopPlan, SearchResults, UpdateSearchRatio, UploadStats,
+    attach_open_loop_metrics, closed_loop_duration, Engine, OpenLoopPlan, SearchResults,
+    UpdateSearchRatio, UploadStats,
 };
 use crate::metrics::compute_metrics;
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, parse_ft_search_response};
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
+
+fn configured_index_name() -> String {
+    std::env::var("REDIS_INDEX_NAME").unwrap_or_else(|_| "idx".to_string())
+}
 
 /// Redis engine configuration
 #[derive(Clone)]
@@ -118,7 +123,7 @@ impl RedisEngine {
 
         // Drop existing index if any
         let _ = redis::cmd("FT.DROPINDEX")
-            .arg("idx")
+            .arg(configured_index_name())
             .arg("DD")
             .query::<()>(conn);
 
@@ -127,7 +132,7 @@ impl RedisEngine {
 
         // Build FT.CREATE command
         let mut cmd = redis::cmd("FT.CREATE");
-        cmd.arg("idx")
+        cmd.arg(configured_index_name())
             .arg("ON")
             .arg("HASH")
             .arg("PREFIX")
@@ -309,7 +314,7 @@ impl RedisEngine {
 
         loop {
             let info: redis::Value = redis::cmd("FT.INFO")
-                .arg("idx")
+                .arg(configured_index_name())
                 .query(&mut conn)
                 .map_err(|e| format!("FT.INFO error: {}", e))?;
 
@@ -1153,7 +1158,7 @@ fn ft_search_filter_only(
     let (filter_expr, params) = filter;
 
     let mut cmd = redis::cmd("FT.SEARCH");
-    cmd.arg("idx")
+    cmd.arg(configured_index_name())
         .arg(filter_expr.as_str())
         .arg("LIMIT")
         .arg(0)
@@ -1254,7 +1259,7 @@ fn ft_search_knn(
 ) -> Result<Vec<(i64, f64)>, String> {
     // Build FT.SEARCH command
     let mut cmd = redis::cmd("FT.SEARCH");
-    cmd.arg("idx")
+    cmd.arg(configured_index_name())
         .arg(query_str)
         .arg("SORTBY")
         .arg("vector_score")
@@ -1540,13 +1545,18 @@ impl Engine for RedisEngine {
         // where top defaults to len(query.expected_result) per query).
         let explicit_top: Option<usize> = params.top.map(|t| t as usize);
         let open_loop = OpenLoopPlan::from_params(params)?;
-        let num_to_run = open_loop.map(|p| p.total_requests).unwrap_or_else(|| {
-            if num_queries > 0 {
-                (num_queries as usize).min(queries.len())
-            } else {
-                queries.len()
-            }
-        });
+        let closed_loop_duration = closed_loop_duration(params)?;
+        let num_to_run = if closed_loop_duration.is_some() {
+            usize::MAX
+        } else {
+            open_loop.map(|p| p.total_requests).unwrap_or_else(|| {
+                if num_queries > 0 {
+                    (num_queries as usize).min(queries.len())
+                } else {
+                    queries.len()
+                }
+            })
+        };
 
         // Precompute all client-side request construction BEFORE the timed
         // region so the per-query timed window wraps ONLY the RPC round-trip +
@@ -1574,7 +1584,11 @@ impl Engine for RedisEngine {
         // (only its own monotonicity matters, not ordering against other memory).
         let query_idx = Arc::new(AtomicUsize::new(0));
 
-        let pb = self.create_progress_bar(num_to_run);
+        let pb = self.create_progress_bar(if closed_loop_duration.is_some() {
+            0
+        } else {
+            num_to_run
+        });
         // Give workers time to establish their connections before the first
         // independent arrival; setup is outside the measured open-loop window.
         let start_time = if open_loop.is_some() {
@@ -1583,11 +1597,16 @@ impl Engine for RedisEngine {
             Instant::now()
         };
 
-        let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
-        let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
-        let mut recs: Vec<f64> = Vec::with_capacity(num_to_run);
-        let mut mrs: Vec<f64> = Vec::with_capacity(num_to_run);
-        let mut nds: Vec<f64> = Vec::with_capacity(num_to_run);
+        let sample_capacity = if closed_loop_duration.is_some() {
+            queries.len()
+        } else {
+            num_to_run
+        };
+        let mut times: Vec<f64> = Vec::with_capacity(sample_capacity);
+        let mut precs: Vec<f64> = Vec::with_capacity(sample_capacity);
+        let mut recs: Vec<f64> = Vec::with_capacity(sample_capacity);
+        let mut mrs: Vec<f64> = Vec::with_capacity(sample_capacity);
+        let mut nds: Vec<f64> = Vec::with_capacity(sample_capacity);
         let mut schedule_delays: Vec<f64> = Vec::new();
         let mut end_to_end_latencies: Vec<f64> = Vec::new();
         let mut dropped_queries = 0usize;
@@ -1631,6 +1650,12 @@ impl Engine for RedisEngine {
                     };
 
                     loop {
+                        if closed_loop_duration
+                            .map(|duration| Instant::now() >= start_time + duration)
+                            .unwrap_or(false)
+                        {
+                            break;
+                        }
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
                         if idx >= num_to_run {
                             break;
@@ -1758,7 +1783,10 @@ impl Engine for RedisEngine {
         )?;
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
-        let attempted_queries = num_to_run.saturating_sub(dropped_queries);
+        let attempted_queries = query_idx
+            .load(Ordering::Relaxed)
+            .min(num_to_run)
+            .saturating_sub(dropped_queries);
         let mut results = crate::engine::compute_search_stats(
             &times,
             &precs,
@@ -2052,7 +2080,7 @@ impl Engine for RedisEngine {
     fn delete(&mut self) -> Result<(), String> {
         let mut conn = self.get_connection()?;
         let _ = redis::cmd("FT.DROPINDEX")
-            .arg("idx")
+            .arg(configured_index_name())
             .arg("DD")
             .query::<()>(&mut conn);
         Ok(())
@@ -2067,7 +2095,7 @@ impl Engine for RedisEngine {
 
         // Get FT.INFO for index stats
         let ft_info: Option<serde_json::Value> = redis::cmd("FT.INFO")
-            .arg("idx")
+            .arg(configured_index_name())
             .query::<redis::Value>(&mut conn)
             .ok()
             .map(|v| redis_value_to_json(&v));
@@ -2084,7 +2112,7 @@ impl Engine for RedisEngine {
         // Vector index stats (HNSW M/EF, num_docs, index memory, ...). Errors on
         // the BEFORE snapshot (index not yet created) → index_info: null.
         let ft_info = redis::cmd("FT.INFO")
-            .arg("idx")
+            .arg(configured_index_name())
             .query::<redis::Value>(&mut conn)
             .ok()
             .map(|v| redis_value_to_json(&v));

--- a/src/bin/vector_db_benchmark/engine/vertex.rs
+++ b/src/bin/vector_db_benchmark/engine/vertex.rs
@@ -28,7 +28,11 @@ use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{attach_open_loop_metrics, Engine, OpenLoopPlan, SearchResults, UploadStats};
+use crate::engine::vertex_grpc::{VertexGrpcRequest, VertexGrpcWorker};
+use crate::engine::{
+    attach_open_loop_metrics, closed_loop_duration, Engine, OpenLoopPlan, SearchResults,
+    UploadStats,
+};
 
 const DEFAULT_REGION: &str = "us-central1";
 const DEFAULT_MACHINE_TYPE: &str = "e2-standard-16";
@@ -36,6 +40,31 @@ const DEFAULT_DISPLAY_NAME: &str = "vdb_benchmark";
 const DEFAULT_APPROX_NEIGHBORS: i64 = 150;
 const DEFAULT_LEAF_EMBEDDING_COUNT: i64 = 500;
 const DEFAULT_LEAF_SEARCH_PERCENT: i64 = 7;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum VertexQueryTransport {
+    Rest,
+    PublicGrpc,
+    PrivateGrpc,
+}
+
+impl VertexQueryTransport {
+    fn from_env() -> Result<Self, String> {
+        match std::env::var("VERTEX_QUERY_TRANSPORT")
+            .unwrap_or_else(|_| "rest".to_string())
+            .to_ascii_lowercase()
+            .replace('_', "-")
+            .as_str()
+        {
+            "rest" => Ok(Self::Rest),
+            "grpc" | "public-grpc" => Ok(Self::PublicGrpc),
+            "private-grpc" | "psc-grpc" => Ok(Self::PrivateGrpc),
+            value => Err(format!(
+                "unsupported VERTEX_QUERY_TRANSPORT={value}; use rest, public-grpc, or private-grpc"
+            )),
+        }
+    }
+}
 
 /// The three env vars that point the engine at an ALREADY-deployed index, in
 /// which case `configure` skips create+deploy and `delete` skips teardown (so
@@ -137,10 +166,14 @@ fn build_find_neighbors_body(
     query: &[f32],
     top: usize,
     fraction_leaf_override: Option<f64>,
+    approximate_neighbor_count: Option<i64>,
 ) -> serde_json::Value {
     let mut datapoint = serde_json::json!({ "datapoint": { "featureVector": query } });
     if let Some(frac) = fraction_leaf_override {
         datapoint["fractionLeafNodesToSearchOverride"] = serde_json::json!(frac);
+    }
+    if let Some(count) = approximate_neighbor_count {
+        datapoint["approximateNeighborCount"] = serde_json::json!(count);
     }
     datapoint["neighborCount"] = serde_json::json!(top);
     serde_json::json!({
@@ -195,6 +228,97 @@ fn execute_find_neighbors(
     Ok(parse_find_neighbors_response(&json))
 }
 
+enum VertexWorkerRequest {
+    Rest(serde_json::Value),
+    Grpc(VertexGrpcRequest),
+}
+
+enum VertexWorker {
+    Rest {
+        client: reqwest::blocking::Client,
+        url: String,
+        token: String,
+    },
+    Grpc(VertexGrpcWorker),
+}
+
+struct VertexWorkerConfig<'a> {
+    transport: VertexQueryTransport,
+    public_domain: &'a str,
+    private_address: Option<&'a str>,
+    token: &'a str,
+    index_endpoint: &'a str,
+    deployed_index_id: &'a str,
+}
+
+impl VertexWorker {
+    fn new(config: VertexWorkerConfig<'_>) -> Result<Self, String> {
+        match config.transport {
+            VertexQueryTransport::Rest => {
+                let client = reqwest::blocking::Client::builder()
+                    .timeout(Duration::from_secs(60))
+                    .build()
+                    .map_err(|e| format!("Vertex REST worker client build failed: {e}"))?;
+                Ok(Self::Rest {
+                    client,
+                    url: format!(
+                        "https://{}/v1/{}:findNeighbors",
+                        config.public_domain, config.index_endpoint
+                    ),
+                    token: config.token.to_string(),
+                })
+            }
+            VertexQueryTransport::PublicGrpc => Ok(Self::Grpc(VertexGrpcWorker::public(
+                config.public_domain,
+                config.token,
+                config.index_endpoint,
+                config.deployed_index_id,
+            )?)),
+            VertexQueryTransport::PrivateGrpc => Ok(Self::Grpc(VertexGrpcWorker::private(
+                config
+                    .private_address
+                    .ok_or("VERTEX_GRPC_ADDRESS is required for private-grpc transport")?,
+                config.deployed_index_id,
+            )?)),
+        }
+    }
+
+    fn request(
+        &self,
+        deployed_index_id: &str,
+        vector: &[f32],
+        top: usize,
+        fraction_leaf_override: Option<f64>,
+        approximate_neighbor_count: Option<i64>,
+    ) -> VertexWorkerRequest {
+        match self {
+            Self::Rest { .. } => VertexWorkerRequest::Rest(build_find_neighbors_body(
+                deployed_index_id,
+                vector,
+                top,
+                fraction_leaf_override,
+                approximate_neighbor_count,
+            )),
+            Self::Grpc(worker) => VertexWorkerRequest::Grpc(worker.request(
+                vector,
+                top,
+                fraction_leaf_override,
+                approximate_neighbor_count,
+            )),
+        }
+    }
+
+    fn execute(&mut self, request: VertexWorkerRequest) -> Result<Vec<i64>, String> {
+        match (self, request) {
+            (Self::Rest { client, url, token }, VertexWorkerRequest::Rest(body)) => {
+                execute_find_neighbors(client, url, token, &body)
+            }
+            (Self::Grpc(worker), VertexWorkerRequest::Grpc(message)) => worker.execute(message),
+            _ => Err("Vertex worker/request transport mismatch".to_string()),
+        }
+    }
+}
+
 /// Inspect a long-running-operation reply: `Ok(Some(response))` when done,
 /// `Ok(None)` while still running, `Err` when the operation reported an error.
 fn parse_lro(resp: &serde_json::Value) -> Result<Option<serde_json::Value>, String> {
@@ -229,6 +353,8 @@ pub struct VertexEngine {
     leaf_embedding_count: i64,
     leaf_search_percent: i64,
     shard_size: Option<String>,
+    query_transport: VertexQueryTransport,
+    grpc_address: Option<String>,
     // Populated during configure().
     index_name: String,
     index_endpoint_name: String,
@@ -298,6 +424,10 @@ impl VertexEngine {
             ),
             leaf_search_percent: env_i64("VERTEX_LEAF_SEARCH_PERCENT", DEFAULT_LEAF_SEARCH_PERCENT),
             shard_size: std::env::var("VERTEX_SHARD_SIZE")
+                .ok()
+                .filter(|s| !s.trim().is_empty()),
+            query_transport: VertexQueryTransport::from_env()?,
+            grpc_address: std::env::var("VERTEX_GRPC_ADDRESS")
                 .ok()
                 .filter(|s| !s.trim().is_empty()),
             index_name: String::new(),
@@ -523,20 +653,32 @@ impl Engine for VertexEngine {
             self.poll_operation(&op_name, self.deploy_timeout, "index deployment")?;
         }
 
-        // Resolve the public endpoint domain used by findNeighbors.
+        // Resolve the public endpoint domain used by REST/public gRPC. Private
+        // gRPC connects directly to the PSC/VPC match address instead.
         let token = self.access_token()?;
         let ep = self.get_json(
             &format!("{}/{}", self.base_url(), self.index_endpoint_name),
             &token,
         )?;
-        self.public_endpoint_domain = ep
-            .get("publicEndpointDomainName")
-            .and_then(|d| d.as_str())
-            .ok_or(
-                "index endpoint has no publicEndpointDomainName (is a public endpoint enabled?)",
-            )?
-            .to_string();
-        println!("Vertex endpoint ready at {}", self.public_endpoint_domain);
+        if self.query_transport == VertexQueryTransport::PrivateGrpc {
+            let address = self
+                .grpc_address
+                .as_deref()
+                .ok_or("VERTEX_GRPC_ADDRESS is required for private-grpc transport")?;
+            println!("Vertex private gRPC endpoint ready at {address}");
+        } else {
+            self.public_endpoint_domain = ep
+                .get("publicEndpointDomainName")
+                .and_then(|d| d.as_str())
+                .ok_or(
+                    "index endpoint has no publicEndpointDomainName (is a public endpoint enabled?)",
+                )?
+                .to_string();
+            println!(
+                "Vertex {:?} endpoint ready at {}",
+                self.query_transport, self.public_endpoint_domain
+            );
+        }
         Ok(())
     }
 
@@ -619,20 +761,55 @@ impl Engine for VertexEngine {
                         }
                         let (start, end) = batches[idx];
                         let body = build_upsert_body(&ids[start..end], &vectors[start..end]);
-                        match client.post(url).bearer_auth(&token).json(&body).send() {
-                            Ok(r) if r.status().is_success() => {}
-                            Ok(r) => {
-                                *error.lock().unwrap() = Some(format!(
-                                    "{}: {}",
-                                    r.status(),
-                                    r.text().unwrap_or_default()
-                                ));
-                                break;
+                        let mut quota_retries = 0usize;
+                        loop {
+                            match client.post(url).bearer_auth(&token).json(&body).send() {
+                                Ok(r) if r.status().is_success() => break,
+                                Ok(r)
+                                    if r.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+                                        && quota_retries < 30 =>
+                                {
+                                    quota_retries += 1;
+                                    let retry_after = r
+                                        .headers()
+                                        .get(reqwest::header::RETRY_AFTER)
+                                        .and_then(|value| value.to_str().ok())
+                                        .and_then(|value| value.parse::<u64>().ok())
+                                        .unwrap_or(60);
+                                    eprintln!(
+                                        "Vertex stream-update quota reached; retrying batch {} in {}s (attempt {}/30)",
+                                        idx, retry_after, quota_retries
+                                    );
+                                    std::thread::sleep(Duration::from_secs(retry_after));
+                                    if token_at.elapsed() > TOKEN_REFRESH_AFTER {
+                                        match engine.access_token() {
+                                            Ok(t) => {
+                                                token = t;
+                                                token_at = Instant::now();
+                                            }
+                                            Err(e) => {
+                                                *error.lock().unwrap() = Some(e);
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                                Ok(r) => {
+                                    *error.lock().unwrap() = Some(format!(
+                                        "{}: {}",
+                                        r.status(),
+                                        r.text().unwrap_or_default()
+                                    ));
+                                    break;
+                                }
+                                Err(e) => {
+                                    *error.lock().unwrap() = Some(e.to_string());
+                                    break;
+                                }
                             }
-                            Err(e) => {
-                                *error.lock().unwrap() = Some(e.to_string());
-                                break;
-                            }
+                        }
+                        if error.lock().unwrap().is_some() {
+                            break;
                         }
                         pb.inc((end - start) as u64);
                     }
@@ -668,6 +845,35 @@ impl Engine for VertexEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        self.distance_measure = vertex_distance_measure(dataset.distance()).to_string();
+
+        if self.index_name.is_empty()
+            || self.index_endpoint_name.is_empty()
+            || self.deployed_index_id.is_empty()
+        {
+            let (index, endpoint, deployed) = reuse_index_ids().ok_or(
+                "Vertex search with --skip-upload requires VERTEX_INDEX, VERTEX_INDEX_ENDPOINT, and VERTEX_DEPLOYED_INDEX_ID",
+            )?;
+            self.index_name = index;
+            self.index_endpoint_name = endpoint;
+            self.deployed_index_id = deployed;
+        }
+
+        if self.public_endpoint_domain.is_empty()
+            && self.query_transport != VertexQueryTransport::PrivateGrpc
+        {
+            let token = self.access_token()?;
+            let ep = self.get_json(
+                &format!("{}/{}", self.base_url(), self.index_endpoint_name),
+                &token,
+            )?;
+            self.public_endpoint_domain = ep
+                .get("publicEndpointDomainName")
+                .and_then(|d| d.as_str())
+                .ok_or("index endpoint has no publicEndpointDomainName")?
+                .to_string();
+        }
+
         let parallel = params.parallel.unwrap_or(1).max(1) as usize;
 
         let query_path = dataset.get_path()?;
@@ -679,13 +885,18 @@ impl Engine for VertexEngine {
 
         let explicit_top: Option<usize> = params.top.map(|t| t as usize);
         let open_loop = OpenLoopPlan::from_params(params)?;
-        let num_to_run = open_loop.map(|p| p.total_requests).unwrap_or_else(|| {
-            if num_queries > 0 {
-                (num_queries as usize).min(queries.len())
-            } else {
-                queries.len()
-            }
-        });
+        let closed_loop_duration = closed_loop_duration(params)?;
+        let num_to_run = if closed_loop_duration.is_some() {
+            usize::MAX
+        } else {
+            open_loop.map(|p| p.total_requests).unwrap_or_else(|| {
+                if num_queries > 0 {
+                    (num_queries as usize).min(queries.len())
+                } else {
+                    queries.len()
+                }
+            })
+        };
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
 
         if neighbors.len() < queries.len() {
@@ -703,41 +914,60 @@ impl Engine for VertexEngine {
             .and_then(|sp| sp.extra.as_ref())
             .and_then(|e| e.get("fraction_leaf_nodes_to_search_override"))
             .and_then(|v| v.as_f64());
+        let approximate_neighbor_count = params.num_candidates.map(|n| n.max(1));
 
-        println!(
-            "\tRunning {} queries (top={}, parallel={})...",
-            HumanCount(num_to_run as u64),
-            top,
-            parallel
-        );
+        if let Some(duration) = closed_loop_duration {
+            println!(
+                "\tRunning unrestricted closed-loop for {:.1}s (top={}, parallel={})...",
+                duration.as_secs_f64(),
+                top,
+                parallel
+            );
+        } else {
+            println!(
+                "\tRunning {} queries (top={}, parallel={})...",
+                HumanCount(num_to_run as u64),
+                top,
+                parallel
+            );
+        }
 
         // One access token for the whole timed region (avoids a gcloud shell-out
         // in the hot loop). Each worker builds its own blocking client so no
         // connection pool is shared across threads.
         let token = self.access_token()?;
-        let url = format!(
-            "https://{}/v1/{}:findNeighbors",
-            self.public_endpoint_domain, self.index_endpoint_name
-        );
         let deployed_index_id = self.deployed_index_id.as_str();
+        let query_transport = self.query_transport;
+        let public_endpoint_domain = self.public_endpoint_domain.as_str();
+        let private_address = self.grpc_address.as_deref();
+        let index_endpoint_name = self.index_endpoint_name.as_str();
 
         let workers = parallel.min(num_to_run.max(1));
         let query_idx = Arc::new(AtomicUsize::new(0));
-        let pb = self.create_progress_bar(num_to_run);
+        let pb = self.create_progress_bar(if closed_loop_duration.is_some() {
+            0
+        } else {
+            num_to_run
+        });
         let closed_loop_start = Instant::now();
         let open_loop_start = Arc::new(OnceLock::<Instant>::new());
         let worker_ready = Arc::new(Barrier::new(workers + 1));
+        let timed_mode = open_loop.is_some() || closed_loop_duration.is_some();
 
         let queries = &queries;
         let neighbors = &neighbors;
-        let url = url.as_str();
         let token = token.as_str();
 
-        let mut latencies: Vec<f64> = Vec::with_capacity(num_to_run);
-        let mut precisions: Vec<f64> = Vec::with_capacity(num_to_run);
-        let mut recalls: Vec<f64> = Vec::with_capacity(num_to_run);
-        let mut mrrs: Vec<f64> = Vec::with_capacity(num_to_run);
-        let mut ndcgs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let sample_capacity = if closed_loop_duration.is_some() {
+            queries.len()
+        } else {
+            num_to_run
+        };
+        let mut latencies: Vec<f64> = Vec::with_capacity(sample_capacity);
+        let mut precisions: Vec<f64> = Vec::with_capacity(sample_capacity);
+        let mut recalls: Vec<f64> = Vec::with_capacity(sample_capacity);
+        let mut mrrs: Vec<f64> = Vec::with_capacity(sample_capacity);
+        let mut ndcgs: Vec<f64> = Vec::with_capacity(sample_capacity);
         let mut schedule_delays: Vec<f64> = Vec::new();
         let mut end_to_end_latencies: Vec<f64> = Vec::new();
         let mut dropped_queries = 0usize;
@@ -762,38 +992,40 @@ impl Engine for VertexEngine {
                     let mut late = 0usize;
                     let mut pb_pending: u64 = 0;
 
-                    let client = match reqwest::blocking::Client::builder()
-                        .timeout(Duration::from_secs(60))
-                        .build()
-                    {
+                    let mut client = match VertexWorker::new(VertexWorkerConfig {
+                        transport: query_transport,
+                        public_domain: public_endpoint_domain,
+                        private_address,
+                        token,
+                        index_endpoint: index_endpoint_name,
+                        deployed_index_id,
+                    }) {
                         Ok(c) => c,
                         Err(e) => {
                             eprintln!("Vertex worker client build failed: {}", e);
-                            if open_loop.is_some() {
+                            if timed_mode {
                                 worker_ready.wait();
                             }
                             return (t, p, r, mr, nd, sd, e2e, dropped, late);
                         }
                     };
 
-                    // reqwest establishes TCP/TLS lazily on first use. Prime each
-                    // persistent worker connection before starting the shared
-                    // arrival clock so setup cannot masquerade as queueing delay.
-                    if open_loop.is_some() {
+                    if timed_mode {
                         let prime_pos = worker_id % queries.len();
-                        let prime_body = build_find_neighbors_body(
+                        let prime_request = client.request(
                             deployed_index_id,
                             &queries[prime_pos],
                             top,
                             fraction_leaf_override,
+                            approximate_neighbor_count,
                         );
-                        if let Err(e) = execute_find_neighbors(&client, url, token, &prime_body) {
+                        if let Err(e) = client.execute(prime_request) {
                             eprintln!("Vertex worker connection prime failed: {}", e);
                         }
                         worker_ready.wait();
                     }
 
-                    let schedule_start = if open_loop.is_some() {
+                    let schedule_start = if timed_mode {
                         loop {
                             if let Some(start) = open_loop_start.get() {
                                 break *start;
@@ -805,16 +1037,23 @@ impl Engine for VertexEngine {
                     };
 
                     loop {
+                        if closed_loop_duration
+                            .map(|duration| Instant::now() >= schedule_start + duration)
+                            .unwrap_or(false)
+                        {
+                            break;
+                        }
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
                         if idx >= num_to_run {
                             break;
                         }
                         let query_pos = idx % queries.len();
-                        let body = build_find_neighbors_body(
+                        let request = client.request(
                             deployed_index_id,
                             &queries[query_pos],
                             top,
                             fraction_leaf_override,
+                            approximate_neighbor_count,
                         );
 
                         let scheduled_at = open_loop.map(|plan| {
@@ -842,7 +1081,7 @@ impl Engine for VertexEngine {
                         // request body is built above (client-side work), matching
                         // the other engines' boundary.
                         let start = Instant::now();
-                        let outcome = execute_find_neighbors(&client, url, token, &body);
+                        let outcome = client.execute(request);
                         let elapsed = start.elapsed().as_secs_f64();
                         let completion = Instant::now();
 
@@ -880,9 +1119,14 @@ impl Engine for VertexEngine {
                     (t, p, r, mr, nd, sd, e2e, dropped, late)
                 }));
             }
-            if open_loop.is_some() {
+            if timed_mode {
                 worker_ready.wait();
-                let _ = open_loop_start.set(Instant::now() + Duration::from_millis(100));
+                let measurement_start = if open_loop.is_some() {
+                    Instant::now() + Duration::from_millis(100)
+                } else {
+                    Instant::now()
+                };
+                let _ = open_loop_start.set(measurement_start);
             }
             for h in handles {
                 let (t, p, r, mr, nd, sd, e2e, dropped, late) = h.join().unwrap();
@@ -906,8 +1150,11 @@ impl Engine for VertexEngine {
         if succeeded == 0 {
             return Err("No searches completed (all queries failed)".to_string());
         }
-        let attempted_queries = num_to_run.saturating_sub(dropped_queries);
-        let failed = attempted_queries - succeeded;
+        let attempted_queries = query_idx
+            .load(Ordering::Relaxed)
+            .min(num_to_run)
+            .saturating_sub(dropped_queries);
+        let failed = attempted_queries.saturating_sub(succeeded);
         if failed > 0 {
             eprintln!(
                 "WARNING: {} of {} attempted queries failed",
@@ -1123,7 +1370,7 @@ mod tests {
 
     #[test]
     fn find_neighbors_body_sets_count_and_optional_override() {
-        let b = build_find_neighbors_body("dep", &[1.0, 2.0], 10, None);
+        let b = build_find_neighbors_body("dep", &[1.0, 2.0], 10, None, None);
         assert_eq!(b["deployedIndexId"], "dep");
         assert_eq!(b["returnFullDatapoint"], false);
         let q = &b["queries"][0];
@@ -1131,7 +1378,7 @@ mod tests {
         assert_eq!(q["datapoint"]["featureVector"], json!([1.0, 2.0]));
         assert!(q.get("fractionLeafNodesToSearchOverride").is_none());
 
-        let b2 = build_find_neighbors_body("dep", &[1.0], 5, Some(0.2));
+        let b2 = build_find_neighbors_body("dep", &[1.0], 5, Some(0.2), Some(500));
         assert_eq!(b2["queries"][0]["fractionLeafNodesToSearchOverride"], 0.2);
     }
 

--- a/src/bin/vector_db_benchmark/engine/vertex.rs
+++ b/src/bin/vector_db_benchmark/engine/vertex.rs
@@ -21,14 +21,14 @@
 //! start of each phase (and once before the timed search region).
 
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{Engine, SearchResults, UploadStats};
+use crate::engine::{attach_open_loop_metrics, Engine, OpenLoopPlan, SearchResults, UploadStats};
 
 const DEFAULT_REGION: &str = "us-central1";
 const DEFAULT_MACHINE_TYPE: &str = "e2-standard-16";
@@ -170,6 +170,29 @@ fn parse_find_neighbors_response(resp: &serde_json::Value) -> Vec<i64> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn execute_find_neighbors(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    token: &str,
+    body: &serde_json::Value,
+) -> Result<Vec<i64>, String> {
+    let resp = client
+        .post(url)
+        .bearer_auth(token)
+        .json(body)
+        .send()
+        .map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "{}: {}",
+            resp.status(),
+            resp.text().unwrap_or_default()
+        ));
+    }
+    let json: serde_json::Value = resp.json().map_err(|e| e.to_string())?;
+    Ok(parse_find_neighbors_response(&json))
 }
 
 /// Inspect a long-running-operation reply: `Ok(Some(response))` when done,
@@ -650,20 +673,26 @@ impl Engine for VertexEngine {
         let query_path = dataset.get_path()?;
         println!("\tReading queries from {}...", query_path.display());
         let (queries, neighbors, _conditions) = dataset.read_queries()?;
+        if queries.is_empty() {
+            return Err("dataset contains no search queries".to_string());
+        }
 
         let explicit_top: Option<usize> = params.top.map(|t| t as usize);
-        let num_to_run = if num_queries > 0 {
-            (num_queries as usize).min(queries.len())
-        } else {
-            queries.len()
-        };
+        let open_loop = OpenLoopPlan::from_params(params)?;
+        let num_to_run = open_loop.map(|p| p.total_requests).unwrap_or_else(|| {
+            if num_queries > 0 {
+                (num_queries as usize).min(queries.len())
+            } else {
+                queries.len()
+            }
+        });
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
 
-        if neighbors.len() < num_to_run {
+        if neighbors.len() < queries.len() {
             return Err(format!(
-                "dataset misaligned: {} neighbor lists for {} queries to run",
+                "dataset misaligned: {} neighbor lists for {} dataset queries",
                 neighbors.len(),
-                num_to_run
+                queries.len()
             ));
         }
 
@@ -695,7 +724,9 @@ impl Engine for VertexEngine {
         let workers = parallel.min(num_to_run.max(1));
         let query_idx = Arc::new(AtomicUsize::new(0));
         let pb = self.create_progress_bar(num_to_run);
-        let total_start = Instant::now();
+        let closed_loop_start = Instant::now();
+        let open_loop_start = Arc::new(OnceLock::<Instant>::new());
+        let worker_ready = Arc::new(Barrier::new(workers + 1));
 
         let queries = &queries;
         let neighbors = &neighbors;
@@ -707,18 +738,29 @@ impl Engine for VertexEngine {
         let mut recalls: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut mrrs: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcgs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut schedule_delays: Vec<f64> = Vec::new();
+        let mut end_to_end_latencies: Vec<f64> = Vec::new();
+        let mut dropped_queries = 0usize;
+        let mut late_queries = 0usize;
 
         std::thread::scope(|s| {
             let mut handles = Vec::with_capacity(workers);
-            for _ in 0..workers {
+            for worker_id in 0..workers {
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
+                let open_loop_start = Arc::clone(&open_loop_start);
+                let worker_ready = Arc::clone(&worker_ready);
                 handles.push(s.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
                     let mut mr = Vec::new();
                     let mut nd = Vec::new();
+                    let mut sd = Vec::new();
+                    let mut e2e = Vec::new();
+                    let mut dropped = 0usize;
+                    let mut late = 0usize;
+                    let mut pb_pending: u64 = 0;
 
                     let client = match reqwest::blocking::Client::builder()
                         .timeout(Duration::from_secs(60))
@@ -727,8 +769,39 @@ impl Engine for VertexEngine {
                         Ok(c) => c,
                         Err(e) => {
                             eprintln!("Vertex worker client build failed: {}", e);
-                            return (t, p, r, mr, nd);
+                            if open_loop.is_some() {
+                                worker_ready.wait();
+                            }
+                            return (t, p, r, mr, nd, sd, e2e, dropped, late);
                         }
+                    };
+
+                    // reqwest establishes TCP/TLS lazily on first use. Prime each
+                    // persistent worker connection before starting the shared
+                    // arrival clock so setup cannot masquerade as queueing delay.
+                    if open_loop.is_some() {
+                        let prime_pos = worker_id % queries.len();
+                        let prime_body = build_find_neighbors_body(
+                            deployed_index_id,
+                            &queries[prime_pos],
+                            top,
+                            fraction_leaf_override,
+                        );
+                        if let Err(e) = execute_find_neighbors(&client, url, token, &prime_body) {
+                            eprintln!("Vertex worker connection prime failed: {}", e);
+                        }
+                        worker_ready.wait();
+                    }
+
+                    let schedule_start = if open_loop.is_some() {
+                        loop {
+                            if let Some(start) = open_loop_start.get() {
+                                break *start;
+                            }
+                            std::thread::yield_now();
+                        }
+                    } else {
+                        closed_loop_start
                     };
 
                     loop {
@@ -736,41 +809,48 @@ impl Engine for VertexEngine {
                         if idx >= num_to_run {
                             break;
                         }
+                        let query_pos = idx % queries.len();
                         let body = build_find_neighbors_body(
                             deployed_index_id,
-                            &queries[idx],
+                            &queries[query_pos],
                             top,
                             fraction_leaf_override,
                         );
+
+                        let scheduled_at = open_loop.map(|plan| {
+                            let delay = plan.wait_for_slot(schedule_start, idx);
+                            sd.push(delay.as_secs_f64());
+                            if plan.is_late(delay) {
+                                late += 1;
+                            }
+                            (
+                                plan.scheduled_at(schedule_start, idx),
+                                delay > plan.max_lateness,
+                            )
+                        });
+                        if scheduled_at.map(|(_, drop)| drop).unwrap_or(false) {
+                            dropped += 1;
+                            pb_pending += 1;
+                            if pb_pending >= 256 {
+                                pb.inc(pb_pending);
+                                pb_pending = 0;
+                            }
+                            continue;
+                        }
 
                         // Timed window: RPC round-trip + reply parse only. The
                         // request body is built above (client-side work), matching
                         // the other engines' boundary.
                         let start = Instant::now();
-                        let outcome: Result<Vec<i64>, String> = (|| {
-                            let resp = client
-                                .post(url)
-                                .bearer_auth(token)
-                                .json(&body)
-                                .send()
-                                .map_err(|e| e.to_string())?;
-                            if !resp.status().is_success() {
-                                return Err(format!(
-                                    "{}: {}",
-                                    resp.status(),
-                                    resp.text().unwrap_or_default()
-                                ));
-                            }
-                            let json: serde_json::Value = resp.json().map_err(|e| e.to_string())?;
-                            Ok(parse_find_neighbors_response(&json))
-                        })();
+                        let outcome = execute_find_neighbors(&client, url, token, &body);
                         let elapsed = start.elapsed().as_secs_f64();
+                        let completion = Instant::now();
 
                         match outcome {
                             Ok(result_ids) => {
                                 let m = crate::metrics::compute_metrics(
                                     &result_ids,
-                                    &neighbors[idx],
+                                    &neighbors[query_pos],
                                     top,
                                 );
                                 t.push(elapsed);
@@ -778,37 +858,64 @@ impl Engine for VertexEngine {
                                 r.push(m.recall);
                                 mr.push(m.mrr);
                                 nd.push(m.ndcg);
+                                if let Some((scheduled, _)) = scheduled_at {
+                                    e2e.push(
+                                        completion
+                                            .saturating_duration_since(scheduled)
+                                            .as_secs_f64(),
+                                    );
+                                }
                             }
                             Err(e) => eprintln!("Search query {} failed: {}", idx, e),
                         }
-                        pb.inc(1);
+                        pb_pending += 1;
+                        if pb_pending >= 256 {
+                            pb.inc(pb_pending);
+                            pb_pending = 0;
+                        }
                     }
-                    (t, p, r, mr, nd)
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
+                    }
+                    (t, p, r, mr, nd, sd, e2e, dropped, late)
                 }));
             }
+            if open_loop.is_some() {
+                worker_ready.wait();
+                let _ = open_loop_start.set(Instant::now() + Duration::from_millis(100));
+            }
             for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+                let (t, p, r, mr, nd, sd, e2e, dropped, late) = h.join().unwrap();
                 latencies.extend(t);
                 precisions.extend(p);
                 recalls.extend(r);
                 mrrs.extend(mr);
                 ndcgs.extend(nd);
+                schedule_delays.extend(sd);
+                end_to_end_latencies.extend(e2e);
+                dropped_queries += dropped;
+                late_queries += late;
             }
         });
 
         pb.finish_and_clear();
+        let total_start = open_loop_start.get().copied().unwrap_or(closed_loop_start);
         let total_time = total_start.elapsed().as_secs_f64();
 
         let succeeded = latencies.len();
         if succeeded == 0 {
             return Err("No searches completed (all queries failed)".to_string());
         }
-        let failed = num_to_run - succeeded;
+        let attempted_queries = num_to_run.saturating_sub(dropped_queries);
+        let failed = attempted_queries - succeeded;
         if failed > 0 {
-            eprintln!("WARNING: {} of {} queries failed", failed, num_to_run);
+            eprintln!(
+                "WARNING: {} of {} attempted queries failed",
+                failed, attempted_queries
+            );
         }
 
-        crate::engine::compute_search_stats(
+        let mut results = crate::engine::compute_search_stats(
             &latencies,
             &precisions,
             &recalls,
@@ -817,8 +924,19 @@ impl Engine for VertexEngine {
             total_time,
             top,
             parallel,
-            num_to_run,
-        )
+            attempted_queries,
+        )?;
+        if let Some(plan) = open_loop {
+            attach_open_loop_metrics(
+                &mut results,
+                plan,
+                &schedule_delays,
+                &end_to_end_latencies,
+                dropped_queries,
+                late_queries,
+            );
+        }
+        Ok(results)
     }
 
     fn delete(&mut self) -> Result<(), String> {

--- a/src/bin/vector_db_benchmark/engine/vertex_grpc.rs
+++ b/src/bin/vector_db_benchmark/engine/vertex_grpc.rs
@@ -1,0 +1,349 @@
+//! Minimal Vertex AI Vector Search gRPC wire types and synchronous worker.
+//!
+//! Public endpoints expose `google.cloud.aiplatform.v1.MatchService`, while
+//! private VPC/PSC endpoints expose the lower-level
+//! `google.cloud.aiplatform.container.v1.MatchService` on port 10000. Keeping
+//! the small subset used by pure dense KNN here avoids a build-time `protoc`
+//! dependency while remaining wire-compatible with Google's protobufs.
+
+use std::time::Duration;
+
+use tonic::codegen::http::uri::PathAndQuery;
+use tonic::metadata::MetadataValue;
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+use tonic::Request;
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct IndexDatapoint {
+    #[prost(string, tag = "1")]
+    pub datapoint_id: String,
+    #[prost(float, repeated, tag = "2")]
+    pub feature_vector: Vec<f32>,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct PublicQuery {
+    #[prost(message, optional, tag = "1")]
+    pub datapoint: Option<IndexDatapoint>,
+    #[prost(int32, tag = "2")]
+    pub neighbor_count: i32,
+    #[prost(int32, tag = "4")]
+    pub approximate_neighbor_count: i32,
+    #[prost(double, tag = "5")]
+    pub fraction_leaf_nodes_to_search_override: f64,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct PublicFindNeighborsRequest {
+    #[prost(string, tag = "1")]
+    pub index_endpoint: String,
+    #[prost(string, tag = "2")]
+    pub deployed_index_id: String,
+    #[prost(message, repeated, tag = "3")]
+    pub queries: Vec<PublicQuery>,
+    #[prost(bool, tag = "4")]
+    pub return_full_datapoint: bool,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct PublicNeighbor {
+    #[prost(message, optional, tag = "1")]
+    pub datapoint: Option<IndexDatapoint>,
+    #[prost(double, tag = "2")]
+    pub distance: f64,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct PublicNearestNeighbors {
+    #[prost(string, tag = "1")]
+    pub id: String,
+    #[prost(message, repeated, tag = "2")]
+    pub neighbors: Vec<PublicNeighbor>,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct PublicFindNeighborsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub nearest_neighbors: Vec<PublicNearestNeighbors>,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct PrivateMatchRequest {
+    #[prost(string, tag = "1")]
+    pub deployed_index_id: String,
+    #[prost(float, repeated, tag = "2")]
+    pub float_val: Vec<f32>,
+    #[prost(int32, tag = "3")]
+    pub num_neighbors: i32,
+    #[prost(int32, tag = "6")]
+    pub approx_num_neighbors: i32,
+    #[prost(double, tag = "9")]
+    pub fraction_leaf_nodes_to_search_override: f64,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct PrivateNeighbor {
+    #[prost(string, tag = "1")]
+    pub id: String,
+    #[prost(double, tag = "2")]
+    pub distance: f64,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+pub struct PrivateMatchResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub neighbor: Vec<PrivateNeighbor>,
+}
+
+#[derive(Clone)]
+pub enum VertexGrpcRequest {
+    Public(PublicFindNeighborsRequest),
+    Private(PrivateMatchRequest),
+}
+
+enum WorkerKind {
+    Public {
+        channel: Channel,
+        authorization: MetadataValue<tonic::metadata::Ascii>,
+        index_endpoint: String,
+        deployed_index_id: String,
+    },
+    Private {
+        channel: Channel,
+        deployed_index_id: String,
+    },
+}
+
+pub struct VertexGrpcWorker {
+    runtime: tokio::runtime::Runtime,
+    kind: WorkerKind,
+}
+
+impl VertexGrpcWorker {
+    pub fn public(
+        domain: &str,
+        token: &str,
+        index_endpoint: &str,
+        deployed_index_id: &str,
+    ) -> Result<Self, String> {
+        let runtime = runtime()?;
+        let endpoint = Endpoint::from_shared(format!("https://{domain}"))
+            .map_err(|e| format!("invalid Vertex public gRPC endpoint: {e}"))?
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(60))
+            .tcp_nodelay(true)
+            .tls_config(
+                ClientTlsConfig::new()
+                    .with_native_roots()
+                    .domain_name(domain.to_string()),
+            )
+            .map_err(|e| format!("Vertex public gRPC TLS configuration failed: {e}"))?;
+        let channel = runtime
+            .block_on(endpoint.connect())
+            .map_err(|e| format!("Vertex public gRPC connect failed: {e:?}"))?;
+        let authorization = format!("Bearer {token}")
+            .parse()
+            .map_err(|e| format!("invalid Vertex authorization metadata: {e}"))?;
+        Ok(Self {
+            runtime,
+            kind: WorkerKind::Public {
+                channel,
+                authorization,
+                index_endpoint: index_endpoint.to_string(),
+                deployed_index_id: deployed_index_id.to_string(),
+            },
+        })
+    }
+
+    pub fn private(address: &str, deployed_index_id: &str) -> Result<Self, String> {
+        let runtime = runtime()?;
+        let target = if address.starts_with("http://") {
+            address.to_string()
+        } else if address.contains(':') {
+            format!("http://{address}")
+        } else {
+            format!("http://{address}:10000")
+        };
+        let endpoint = Endpoint::from_shared(target)
+            .map_err(|e| format!("invalid Vertex private gRPC endpoint: {e}"))?
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(60))
+            .tcp_nodelay(true);
+        let channel = runtime
+            .block_on(endpoint.connect())
+            .map_err(|e| format!("Vertex private gRPC connect failed: {e}"))?;
+        Ok(Self {
+            runtime,
+            kind: WorkerKind::Private {
+                channel,
+                deployed_index_id: deployed_index_id.to_string(),
+            },
+        })
+    }
+
+    pub fn request(
+        &self,
+        vector: &[f32],
+        top: usize,
+        fraction_leaf_override: Option<f64>,
+        approximate_neighbor_count: Option<i64>,
+    ) -> VertexGrpcRequest {
+        match &self.kind {
+            WorkerKind::Public {
+                index_endpoint,
+                deployed_index_id,
+                ..
+            } => VertexGrpcRequest::Public(PublicFindNeighborsRequest {
+                index_endpoint: index_endpoint.clone(),
+                deployed_index_id: deployed_index_id.clone(),
+                queries: vec![PublicQuery {
+                    datapoint: Some(IndexDatapoint {
+                        datapoint_id: String::new(),
+                        feature_vector: vector.to_vec(),
+                    }),
+                    neighbor_count: top as i32,
+                    approximate_neighbor_count: approximate_neighbor_count.unwrap_or(0) as i32,
+                    fraction_leaf_nodes_to_search_override: fraction_leaf_override.unwrap_or(0.0),
+                }],
+                return_full_datapoint: false,
+            }),
+            WorkerKind::Private {
+                deployed_index_id, ..
+            } => VertexGrpcRequest::Private(PrivateMatchRequest {
+                deployed_index_id: deployed_index_id.clone(),
+                float_val: vector.to_vec(),
+                num_neighbors: top as i32,
+                approx_num_neighbors: approximate_neighbor_count.unwrap_or(0) as i32,
+                fraction_leaf_nodes_to_search_override: fraction_leaf_override.unwrap_or(0.0),
+            }),
+        }
+    }
+
+    pub fn execute(&mut self, request: VertexGrpcRequest) -> Result<Vec<i64>, String> {
+        match (&self.kind, request) {
+            (
+                WorkerKind::Public {
+                    channel,
+                    authorization,
+                    ..
+                },
+                VertexGrpcRequest::Public(message),
+            ) => self.runtime.block_on(public_find_neighbors(
+                channel.clone(),
+                authorization.clone(),
+                message,
+            )),
+            (WorkerKind::Private { channel, .. }, VertexGrpcRequest::Private(message)) => self
+                .runtime
+                .block_on(private_match(channel.clone(), message)),
+            _ => Err("Vertex gRPC worker/request transport mismatch".to_string()),
+        }
+    }
+}
+
+fn runtime() -> Result<tokio::runtime::Runtime, String> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("failed to build Vertex gRPC runtime: {e}"))
+}
+
+async fn public_find_neighbors(
+    channel: Channel,
+    authorization: MetadataValue<tonic::metadata::Ascii>,
+    message: PublicFindNeighborsRequest,
+) -> Result<Vec<i64>, String> {
+    let mut grpc = tonic::client::Grpc::new(channel);
+    grpc.ready()
+        .await
+        .map_err(|e| format!("Vertex public gRPC service was not ready: {e}"))?;
+    let mut request = Request::new(message);
+    request
+        .metadata_mut()
+        .insert("authorization", authorization);
+    let response: tonic::Response<PublicFindNeighborsResponse> = grpc
+        .unary(
+            request,
+            PathAndQuery::from_static("/google.cloud.aiplatform.v1.MatchService/FindNeighbors"),
+            tonic::codec::ProstCodec::default(),
+        )
+        .await
+        .map_err(|e| format!("Vertex public gRPC FindNeighbors failed: {e}"))?;
+    Ok(response
+        .into_inner()
+        .nearest_neighbors
+        .into_iter()
+        .next()
+        .map(|nearest| {
+            nearest
+                .neighbors
+                .into_iter()
+                .filter_map(|neighbor| neighbor.datapoint?.datapoint_id.parse().ok())
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+async fn private_match(channel: Channel, message: PrivateMatchRequest) -> Result<Vec<i64>, String> {
+    let mut grpc = tonic::client::Grpc::new(channel);
+    grpc.ready()
+        .await
+        .map_err(|e| format!("Vertex private gRPC service was not ready: {e}"))?;
+    let response: tonic::Response<PrivateMatchResponse> = grpc
+        .unary(
+            Request::new(message),
+            PathAndQuery::from_static("/google.cloud.aiplatform.container.v1.MatchService/Match"),
+            tonic::codec::ProstCodec::default(),
+        )
+        .await
+        .map_err(|e| format!("Vertex private gRPC Match failed: {e}"))?;
+    Ok(response
+        .into_inner()
+        .neighbor
+        .into_iter()
+        .filter_map(|neighbor| neighbor.id.parse().ok())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    #[test]
+    fn public_request_uses_official_wire_tags() {
+        let message = PublicFindNeighborsRequest {
+            index_endpoint: "projects/p/locations/r/indexEndpoints/e".to_string(),
+            deployed_index_id: "d".to_string(),
+            queries: vec![PublicQuery {
+                datapoint: Some(IndexDatapoint {
+                    datapoint_id: String::new(),
+                    feature_vector: vec![1.0, 2.0],
+                }),
+                neighbor_count: 10,
+                approximate_neighbor_count: 100,
+                fraction_leaf_nodes_to_search_override: 0.07,
+            }],
+            return_full_datapoint: false,
+        };
+        let decoded = PublicFindNeighborsRequest::decode(message.encode_to_vec().as_slice())
+            .expect("request must round-trip");
+        assert_eq!(decoded.queries[0].neighbor_count, 10);
+        assert_eq!(decoded.queries[0].approximate_neighbor_count, 100);
+    }
+
+    #[test]
+    fn private_request_uses_official_wire_tags() {
+        let message = PrivateMatchRequest {
+            deployed_index_id: "d".to_string(),
+            float_val: vec![1.0, 2.0],
+            num_neighbors: 10,
+            approx_num_neighbors: 100,
+            fraction_leaf_nodes_to_search_override: 0.07,
+        };
+        let decoded = PrivateMatchRequest::decode(message.encode_to_vec().as_slice())
+            .expect("request must round-trip");
+        assert_eq!(decoded.num_neighbors, 10);
+        assert_eq!(decoded.approx_num_neighbors, 100);
+    }
+}

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -30,6 +30,31 @@ fn results_dir() -> PathBuf {
 pub fn run(args: &Args) -> Result<(), String> {
     println!("vector-db-benchmark v{}", env!("CARGO_PKG_VERSION"));
 
+    if args.target_qps != 0.0 {
+        if !args.target_qps.is_finite() || args.target_qps <= 0.0 {
+            return Err("--target-qps must be finite and greater than zero".to_string());
+        }
+        if !args.search_duration.is_finite() || args.search_duration <= 0.0 {
+            return Err(
+                "--search-duration is required and must be greater than zero with --target-qps"
+                    .to_string(),
+            );
+        }
+        if !args.warmup_seconds.is_finite() || args.warmup_seconds < 0.0 {
+            return Err("--warmup-seconds must be finite and non-negative".to_string());
+        }
+        if !args.max_lateness_ms.is_finite() || args.max_lateness_ms < 0.0 {
+            return Err("--max-lateness-ms must be finite and non-negative".to_string());
+        }
+        if args.skip_vector_index || !args.update_search_ratio.is_empty() {
+            return Err(
+                "--target-qps currently supports search-only vector benchmarks".to_string(),
+            );
+        }
+    } else if args.search_duration != 0.0 || args.warmup_seconds != 0.0 {
+        return Err("--search-duration/--warmup-seconds require --target-qps".to_string());
+    }
+
     let dataset_configs = read_dataset_configs()?;
     let engine_configs = read_engine_configs()?;
 
@@ -77,6 +102,22 @@ pub fn run(args: &Args) -> Result<(), String> {
             args.engines.join(", "),
             supported_engines
         ));
+    }
+
+    if args.target_qps > 0.0 {
+        let unsupported: Vec<_> = engines
+            .iter()
+            .filter_map(|(name, config)| {
+                let engine_type = config.engine.as_deref().unwrap_or("unknown");
+                (!matches!(engine_type, "redis" | "vertex")).then_some(name.as_str())
+            })
+            .collect();
+        if !unsupported.is_empty() {
+            return Err(format!(
+                "--target-qps currently supports Redis and Vertex only; unsupported: {}",
+                unsupported.join(", ")
+            ));
+        }
     }
 
     // --skip-vector-index: deduplicate engine configs by engine type.
@@ -433,7 +474,14 @@ fn run_single_experiment(
                     None
                 };
 
-                let effective_params = calibrated_params.as_ref().unwrap_or(search_params);
+                let base_params = calibrated_params.as_ref().unwrap_or(search_params);
+                let mut runtime_params = base_params.clone();
+                if args.target_qps > 0.0 {
+                    runtime_params.target_qps = Some(args.target_qps);
+                    runtime_params.duration_seconds = Some(args.search_duration);
+                    runtime_params.max_lateness_ms = Some(args.max_lateness_ms);
+                }
+                let effective_params = &runtime_params;
                 let effective_ef = if skip_vector_index {
                     "n/a".to_string()
                 } else {
@@ -455,6 +503,18 @@ fn run_single_experiment(
                         "\tRunning search {}: ef={}, parallel={}",
                         search_id, effective_ef, parallel
                     );
+                }
+
+                if args.target_qps > 0.0 && args.warmup_seconds > 0.0 {
+                    let mut warmup_params = effective_params.clone();
+                    warmup_params.duration_seconds = Some(args.warmup_seconds);
+                    println!(
+                        "\tOpen-loop warm-up: {:.1} QPS for {:.1}s",
+                        args.target_qps, args.warmup_seconds
+                    );
+                    engine
+                        .search(dataset, &warmup_params, args.queries)
+                        .map_err(|e| format!("open-loop warm-up failed: {}", e))?;
                 }
 
                 // Run the measured search `repetitions` times and keep the
@@ -535,6 +595,22 @@ fn run_single_experiment(
                                 results.requested_queries,
                                 results.num_queries,
                             );
+                        }
+                        if let Some(target_qps) = results.target_qps {
+                            println!(
+                                "\t  offered {:.1} QPS; dropped {}; late {}; schedule p95 {:.3} ms; end-to-end p95 {:.3} ms",
+                                target_qps,
+                                results.dropped_queries,
+                                results.late_queries,
+                                results.schedule_delay_p95_time.unwrap_or_default() * 1000.0,
+                                results.end_to_end_p95_time.unwrap_or_default() * 1000.0,
+                            );
+                            if results.dropped_queries > 0 {
+                                eprintln!(
+                                    "\t⚠ WARNING: {} offered requests were dropped after exceeding the dispatch-lateness limit",
+                                    results.dropped_queries
+                                );
+                            }
                         }
                         // Flag client-side saturation: when the benchmark client is
                         // the bottleneck the QPS/latency above are not clean
@@ -721,6 +797,9 @@ fn save_search_results(
             "parallel": search_params.parallel.unwrap_or(1),
             "top": results.top,
             "search_params": search_params.search_params,
+            "target_qps": search_params.target_qps,
+            "duration_seconds": search_params.duration_seconds,
+            "max_lateness_ms": search_params.max_lateness_ms,
         },
         "results": {
             "total_time": results.total_time,
@@ -743,6 +822,16 @@ fn save_search_results(
             "system_cpu_pct": results.system_cpu_pct,
             "client_saturated": results.client_saturated,
             "saturation_reason": results.saturation_reason,
+            "target_qps": results.target_qps,
+            "offered_queries": results.offered_queries,
+            "dropped_queries": results.dropped_queries,
+            "late_queries": results.late_queries,
+            "schedule_delay_p50_time": results.schedule_delay_p50_time,
+            "schedule_delay_p95_time": results.schedule_delay_p95_time,
+            "schedule_delay_p99_time": results.schedule_delay_p99_time,
+            "end_to_end_p50_time": results.end_to_end_p50_time,
+            "end_to_end_p95_time": results.end_to_end_p95_time,
+            "end_to_end_p99_time": results.end_to_end_p99_time,
             "mean_precisions": results.mean_precision,
             "mean_recall": results.mean_recall,
             "mean_mrr": results.mean_mrr,

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -51,8 +51,13 @@ pub fn run(args: &Args) -> Result<(), String> {
                 "--target-qps currently supports search-only vector benchmarks".to_string(),
             );
         }
-    } else if args.search_duration != 0.0 || args.warmup_seconds != 0.0 {
-        return Err("--search-duration/--warmup-seconds require --target-qps".to_string());
+    } else {
+        if !args.search_duration.is_finite() || args.search_duration < 0.0 {
+            return Err("--search-duration must be finite and non-negative".to_string());
+        }
+        if args.warmup_seconds != 0.0 {
+            return Err("--warmup-seconds requires --target-qps".to_string());
+        }
     }
 
     let dataset_configs = read_dataset_configs()?;
@@ -104,7 +109,7 @@ pub fn run(args: &Args) -> Result<(), String> {
         ));
     }
 
-    if args.target_qps > 0.0 {
+    if args.target_qps > 0.0 || args.search_duration > 0.0 {
         let unsupported: Vec<_> = engines
             .iter()
             .filter_map(|(name, config)| {
@@ -114,7 +119,7 @@ pub fn run(args: &Args) -> Result<(), String> {
             .collect();
         if !unsupported.is_empty() {
             return Err(format!(
-                "--target-qps currently supports Redis and Vertex only; unsupported: {}",
+                "duration-bounded search currently supports Redis and Vertex only; unsupported: {}",
                 unsupported.join(", ")
             ));
         }
@@ -356,8 +361,12 @@ fn run_single_experiment(
                      skipping search (no filter conditions possible)",
                     dataset.config.name
                 );
-                println!("Experiment stage: Cleanup (deleting index and data)");
-                engine.delete()?;
+                if args.keep_data {
+                    println!("Experiment stage: Keep data (cleanup skipped)");
+                } else {
+                    println!("Experiment stage: Cleanup (deleting index and data)");
+                    engine.delete()?;
+                }
                 println!("Experiment stage: Done");
                 return Ok(());
             }
@@ -476,9 +485,11 @@ fn run_single_experiment(
 
                 let base_params = calibrated_params.as_ref().unwrap_or(search_params);
                 let mut runtime_params = base_params.clone();
+                if args.search_duration > 0.0 {
+                    runtime_params.duration_seconds = Some(args.search_duration);
+                }
                 if args.target_qps > 0.0 {
                     runtime_params.target_qps = Some(args.target_qps);
-                    runtime_params.duration_seconds = Some(args.search_duration);
                     runtime_params.max_lateness_ms = Some(args.max_lateness_ms);
                 }
                 let effective_params = &runtime_params;
@@ -680,9 +691,13 @@ fn run_single_experiment(
         )?;
     }
 
-    // Cleanup
-    println!("Experiment stage: Cleanup (deleting index and data)");
-    engine.delete()?;
+    // Cleanup unless the caller wants to reuse the populated index.
+    if args.keep_data {
+        println!("Experiment stage: Keep data (cleanup skipped)");
+    } else {
+        println!("Experiment stage: Cleanup (deleting index and data)");
+        engine.delete()?;
+    }
 
     println!("Experiment stage: Done");
     Ok(())

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -1530,6 +1530,110 @@ fn test_binary_redis_end_to_end() {
 }
 
 #[test]
+fn test_binary_redis_open_loop_fixed_qps() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 16;
+    let count = 100;
+    let top = 5;
+    let (_, vectors) = generate_test_vectors(count, dim);
+    let queries: Vec<Vec<f32>> = vectors[..10].to_vec();
+    let neighbors: Vec<Vec<i64>> = queries
+        .iter()
+        .map(|q| brute_force_neighbors(q, &vectors, top))
+        .collect();
+    let engine_config = serde_json::json!([{
+        "name": "test-redis-open-loop",
+        "engine": "redis",
+        "algorithm": "hnsw",
+        "collection_params": {
+            "hnsw_config": { "M": 16, "EF_CONSTRUCTION": 128 }
+        },
+        "search_params": [{
+            "parallel": 4,
+            "search_params": { "ef": 256 },
+            "top": top
+        }],
+        "upload_params": {
+            "data_type": "FLOAT32",
+            "parallel": 1,
+            "batch_size": 64
+        }
+    }]);
+    let project_root = create_test_project(
+        "test-open-loop",
+        &serde_json::to_string_pretty(&engine_config).unwrap(),
+        &vectors,
+        &queries,
+        &neighbors,
+        "l2",
+        dim,
+    );
+
+    let output = Command::new(binary_path())
+        .args([
+            "--engines",
+            "test-redis-open-loop",
+            "--datasets",
+            "test-open-loop",
+            "--host",
+            "localhost",
+            "--target-qps",
+            "100",
+            "--search-duration",
+            "0.4",
+            "--max-lateness-ms",
+            "1000",
+            "--repetitions",
+            "1",
+        ])
+        .env("REDIS_PORT", TEST_PORT.to_string())
+        .current_dir(&project_root)
+        .output()
+        .expect("Failed to run open-loop benchmark");
+    assert!(
+        output.status.success(),
+        "open-loop binary failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let results_dir = project_root.join("results");
+    assert_eq!(
+        read_search_result_field(&results_dir, "test-redis-open-loop", "target_qps"),
+        Some(serde_json::json!(100.0))
+    );
+    assert_eq!(
+        read_search_result_field(&results_dir, "test-redis-open-loop", "offered_queries"),
+        Some(serde_json::json!(40))
+    );
+    assert_eq!(
+        read_search_result_field(&results_dir, "test-redis-open-loop", "succeeded_queries"),
+        Some(serde_json::json!(40))
+    );
+    assert_eq!(
+        read_search_result_field(&results_dir, "test-redis-open-loop", "dropped_queries"),
+        Some(serde_json::json!(0))
+    );
+    assert!(read_search_result_field(
+        &results_dir,
+        "test-redis-open-loop",
+        "schedule_delay_p95_time"
+    )
+    .and_then(|v| v.as_f64())
+    .is_some());
+    assert!(
+        read_search_result_field(&results_dir, "test-redis-open-loop", "end_to_end_p95_time")
+            .and_then(|v| v.as_f64())
+            .is_some()
+    );
+
+    fs::remove_dir_all(&project_root).ok();
+}
+
+#[test]
 fn test_binary_vectorsets_end_to_end() {
     wait_for_redis();
     let mut conn = get_test_connection();


### PR DESCRIPTION
## Summary

- add Vertex AI Vector Search query transports for REST, public gRPC, and private PSC gRPC
- add duration-bounded unrestricted closed-loop search for Redis and Vertex
- add reusable-resource safeguards, configurable Redis index names, synchronized worker warm-up, and Vertex upload quota retries

## Why

The existing REST-only client included public-network and HTTP overhead in Vertex measurements and the harness could only run a fixed query count or fixed-rate open-loop workload. These changes let benchmarks use Vertex's native private gRPC path and measure maximum sustainable throughput for a fixed duration while preserving preloaded indexes between runs.

## Impact

Set `VERTEX_QUERY_TRANSPORT=private-grpc` with `VERTEX_GRPC_ADDRESS` to benchmark a PSC/VPC endpoint, or use `public-grpc` for a public endpoint. Passing `--search-duration` without `--target-qps` now cycles queries in unrestricted closed loop for Redis and Vertex; `--keep-data` prevents cleanup and `REDIS_INDEX_NAME` selects an existing Redis index.

Vertex uploads now retry HTTP 429 quota responses, and timed workers establish their connections before the shared measurement clock begins.

## Dependency

This is a follow-up to #146 and currently includes that PR's commit. Once #146 merges, GitHub will reduce this PR to the single follow-up commit automatically.

## Validation

- `make check`
- `make vector-db-benchmark`
- `make test` — 79 passed
- `make integration-test` — 24 passed
- five-minute Redis and Vertex Glove-100 benchmark runs using the new duration and private gRPC paths
