### PR TITLE
fix(#151): --engines-file no-op, Vertex upload 401 retry, repetitions in duration mode

### DIFF
--- a/src/bin/vector_db_benchmark/config.rs
+++ b/src/bin/vector_db_benchmark/config.rs
@@ -142,12 +142,30 @@ pub fn read_dataset_configs() -> Result<HashMap<String, DatasetConfig>, String> 
 }
 
 /// Read all engine configurations from experiments/configurations/*.json
-pub fn read_engine_configs() -> Result<HashMap<String, EngineConfig>, String> {
-    let configs_dir = project_root().join("experiments/configurations");
-    let pattern = configs_dir.join("*.json");
-
+/// Read engine configs. When `engines_file` is `Some`, ONLY that JSON file is
+/// read (the `--engines-file` flag); otherwise every
+/// `experiments/configurations/*.json` is globbed. A `--engines-file` that is
+/// missing or malformed is a hard error (the previous glob-only behavior
+/// silently ignored the flag, so `--engines-file x.json` failed with a
+/// confusing "no engines match" — see issue #151).
+pub fn read_engine_configs(
+    engines_file: Option<&str>,
+) -> Result<HashMap<String, EngineConfig>, String> {
     let mut all_configs = HashMap::new();
 
+    if let Some(file) = engines_file {
+        let content = fs::read_to_string(file)
+            .map_err(|e| format!("failed to read --engines-file {}: {}", file, e))?;
+        let configs: Vec<EngineConfig> = serde_json::from_str(&content)
+            .map_err(|e| format!("invalid JSON in --engines-file {}: {}", file, e))?;
+        for config in configs {
+            all_configs.insert(config.name.clone(), config);
+        }
+        return Ok(all_configs);
+    }
+
+    let configs_dir = project_root().join("experiments/configurations");
+    let pattern = configs_dir.join("*.json");
     for path in glob::glob(pattern.to_str().unwrap())
         .map_err(|e| e.to_string())?
         .flatten()
@@ -336,7 +354,7 @@ pub fn describe_datasets(verbose: bool) -> Result<(), String> {
 
 /// Describe available engines
 pub fn describe_engines(verbose: bool) -> Result<(), String> {
-    let configs = read_engine_configs()?;
+    let configs = read_engine_configs(None)?;
     println!("Available engines ({}):", configs.len());
     for (name, config) in configs.iter() {
         if verbose {
@@ -361,6 +379,26 @@ mod tests {
         assert!(matches_pattern("redis", "redis"));
         assert!(matches_pattern("anything-at-all", "*"));
         assert!(!matches_pattern("redis", "qdrant"));
+    }
+
+    // #151: `--engines-file` must actually read the given file (it was a silent
+    // no-op). A missing/malformed file is a hard error, not a fallback to glob.
+    #[test]
+    fn engines_file_is_read_and_errors_are_hard() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        use std::io::Write;
+        write!(
+            f,
+            r#"[{{"name":"my-cfg","engine":"redis","search_params":[{{"parallel":1}}]}}]"#
+        )
+        .unwrap();
+        f.flush().unwrap();
+        let configs = read_engine_configs(Some(f.path().to_str().unwrap())).unwrap();
+        assert!(configs.contains_key("my-cfg"));
+        assert_eq!(configs["my-cfg"].engine.as_deref(), Some("redis"));
+
+        // Missing file → hard error (not a silent fall-through to the glob).
+        assert!(read_engine_configs(Some("/no/such/file.json")).is_err());
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/vertex.rs
+++ b/src/bin/vector_db_benchmark/engine/vertex.rs
@@ -1047,9 +1047,34 @@ impl Engine for VertexEngine {
                             schema,
                         );
                         let mut quota_retries = 0usize;
+                        let mut auth_retries = 0usize;
                         loop {
                             match client.post(url).bearer_auth(&token).json(&body).send() {
                                 Ok(r) if r.status().is_success() => break,
+                                // A transient 401 (e.g. a token that expired or was
+                                // invalidated early) must NOT abort the whole upload
+                                // and leave a partially-populated index (#151):
+                                // re-mint the token and retry the (idempotent) batch.
+                                Ok(r)
+                                    if r.status() == reqwest::StatusCode::UNAUTHORIZED
+                                        && auth_retries < 5 =>
+                                {
+                                    auth_retries += 1;
+                                    match engine.access_token() {
+                                        Ok(t) => {
+                                            token = t;
+                                            token_at = Instant::now();
+                                        }
+                                        Err(e) => {
+                                            *error.lock().unwrap() = Some(e);
+                                            break;
+                                        }
+                                    }
+                                    eprintln!(
+                                        "Vertex upsert got 401; refreshed token, retrying batch {} (attempt {}/5)",
+                                        idx, auth_retries
+                                    );
+                                }
                                 Ok(r)
                                     if r.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
                                         && quota_retries < 30 =>

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -64,7 +64,7 @@ pub fn run(args: &Args) -> Result<(), String> {
     }
 
     let dataset_configs = read_dataset_configs()?;
-    let engine_configs = read_engine_configs()?;
+    let engine_configs = read_engine_configs(args.engines_file.as_deref())?;
 
     // Filter datasets by pattern
     let datasets: Vec<_> = dataset_configs
@@ -548,7 +548,20 @@ fn run_single_experiment(
                 // is often cold (OS page cache / index warm-up), and best-of
                 // discards it, so published QPS is a warm figure comparable to
                 // the Python tool. --repetitions 1 disables it.
-                let repetitions = args.repetitions.max(1);
+                // Best-of-N is meaningless in --search-duration (closed/open-loop
+                // timed) mode — it just triples runtime for an upward-biased max.
+                // Force a single rep there, warning if the user set >1 (#151).
+                let repetitions = if args.search_duration > 0.0 {
+                    if args.repetitions > 1 {
+                        eprintln!(
+                            "note: --repetitions {} ignored (using 1) in --search-duration mode",
+                            args.repetitions
+                        );
+                    }
+                    1
+                } else {
+                    args.repetitions.max(1)
+                };
                 let mut best: Option<crate::engine::SearchResults> = None;
                 let mut last_err: Option<String> = None;
 


### PR DESCRIPTION
Addresses the localized, validatable must-fixes from **#151** (full Redis-vs-Vertex end-to-end run). Ordered as in the issue.

## #3 — `--engines-file` was a silent no-op ✅ validated
`read_engine_configs()` globbed `experiments/configurations/*.json` and ignored the flag, so `--engines-file x.json --engines my-cfg` failed with "no engines match" (it was listing built-in engine *types*). Now `read_engine_configs(engines_file)` reads **only** that file when given; a missing/malformed file is a **hard error**, not a fall-through. End-to-end verified (the file's config runs, then attempts a real connection) + unit test.

## #1 — Vertex upload treated a transient 401 as fatal ✅
A 401 mid-stream aborted the whole upload, leaving a *partially-populated* index → silently-wrong recall. Now a 401 re-mints the access token and retries the (idempotent) batch, bounded, mirroring the existing 429/`Retry-After` path. Combined with the existing per-worker 45-min proactive refresh, this also covers **#2** (token expiry) for long uploads.

## #6 — `--repetitions` in `--search-duration` mode ✅
Best-of-N is meaningless in timed (closed/open-loop) mode — it triples runtime for an upward-biased max. Force 1 there, warning if the user set >1.

## Deferred (noted on the issue, each its own follow-up)
- **#4** Redis M×EFC index-name collision — the correct fix (per-config index name) is right but the integration tests hardcode `"idx"` and it needs Redis/Valkey/Dragonfly Docker validation; deserves a careful dedicated PR.
- **#5** per-search wall-clock watchdog (generic harness change), **#7** Vertex `indexSyncTime` post-upload wait, **#8** streaming percentiles (large refactor). **#9** (async op polling) is already implemented.

## Tests
489 unit tests pass; `clippy --all-targets -D warnings` + `fmt --check` clean on the CI toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)