### PR TITLE
fix(#151-4): per-config index+key namespacing so Redis/Valkey/Dragonfly M×EFC sweeps don't collide

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,29 @@ Options:
     -h, --help                 Print help
 ```
 
+### Per-config index isolation (Redis / Valkey / Dragonfly)
+
+Each engine config gets its **own** RediSearch index and keyspace, derived from the
+config `name`: index `"<base>:<config>"` (base `idx`) with docs keyed
+`"<config>:<id>"`. This lets an M×EF_CONSTRUCTION **sweep** run all its configs
+against one server and coexist, so you can upload every config once and then
+search each in a later `--skip-upload` pass — each config reads its own graph, and
+memory is reported per-index via `FT.INFO` (issue #151-4).
+
+- `REDIS_INDEX_NAME` / `VALKEY_INDEX_NAME` / `DRAGONFLY_INDEX_NAME` now set the
+  **base namespace**, not the whole index name; the config name is always appended.
+  Set `<VAR>_EXACT=1` to use the base verbatim (single-config "point at an
+  out-of-band index" case — combining it with >1 config for that engine is a
+  startup error).
+- Indexes/keys written by any **pre-#151-4** binary are incompatible — re-upload.
+  `--skip-upload` against a missing/mismatched index now **hard-errors** instead of
+  silently writing a `recall 0.0` file.
+- Two-phase coexistence sweep: `… --keep-data` (upload + search all configs,
+  keep the data), then `… --skip-upload --keep-data --skip-if-exists false`
+  (search each against its own index). Per-config prefixing stores N copies of
+  otherwise-identical sweep docs, so keyspace bytes scale ×N — the intended trade
+  for isolation.
+
 ### Charts
 
 Render a QPS-vs-precision trade-off plot (SVG, no dependencies) from existing `*-summary.json` results — one colored series per engine, filtered by `--engines`/`--datasets`:

--- a/fuzz/dictionaries/resp.dict
+++ b/fuzz/dictionaries/resp.dict
@@ -15,3 +15,9 @@ f_results="results"
 f_id="id"
 f_extra="extra_attributes"
 f_score="vector_score"
+# Per-config prefixed doc keys (#151-4): doc_key_to_id / _opt split on the last
+# ':'. Exercise a normal prefixed key plus pathological colon shapes.
+key_prefixed="$19\x0d\x0aredis-m-16-ef-64:42\x0d\x0a"
+key_double_colon="$2\x0d\x0a::\x0d\x0a"
+key_multi_colon="$5\x0d\x0aa:b:c\x0d\x0a"
+key_empty_tail="$4\x0d\x0acfg:\x0d\x0a"

--- a/src/bin/vector_db_benchmark/engine/dragonfly.rs
+++ b/src/bin/vector_db_benchmark/engine/dragonfly.rs
@@ -39,8 +39,10 @@ use super::redis_utils;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
+use crate::engine::index_naming::{derive_index_name, derive_key_prefix};
 use crate::engine::{Engine, SearchResults, UploadStats};
 use crate::metrics::compute_metrics;
+use vector_db_benchmark::parsers::{doc_key_to_id, doc_key_to_id_opt};
 use vector_db_benchmark::readers::metadata::MetadataItem;
 
 /// Dragonfly engine configuration.
@@ -53,6 +55,12 @@ pub struct DragonflyEngineConfig {
     pub algorithm: String,
     pub batch_size: usize,
     pub parallel: usize,
+    /// Per-config index name (`"<base>:<config>"`, issue #151-4) so a sweep's
+    /// configs address disjoint indexes on one server. Resolved once in `new()`.
+    pub index_name: String,
+    /// Per-config key prefix (`"<config>:"`, issue #151-4). Each config owns a
+    /// disjoint keyspace; teardown is a prefix-scoped SCAN+UNLINK (no DD flag).
+    pub key_prefix: String,
 }
 
 pub struct DragonflyEngine {
@@ -130,6 +138,8 @@ impl DragonflyEngine {
                 algorithm,
                 batch_size,
                 parallel,
+                index_name: derive_index_name("DRAGONFLY_INDEX_NAME", "idx", &engine_config.name),
+                key_prefix: derive_key_prefix(&engine_config.name),
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             commandstats_baseline: None,
@@ -170,22 +180,22 @@ impl DragonflyEngine {
         let distance = dataset.distance();
         let vector_size = dataset.vector_size();
 
-        // Drop existing index if any (ignore "not found"), then flush leftover
-        // keys from previous runs.
-        let _ = redis::cmd("FT.DROPINDEX").arg("idx").query::<()>(conn);
-        let _ = redis::cmd("FLUSHALL").query::<()>(conn);
+        // Drop this config's index + keys ONLY (Dragonfly Search has no DD flag, so
+        // a prefix-scoped SCAN+UNLINK replaces the old keyspace-wide FLUSHALL, which
+        // under #151-4 coexistence would wipe sibling configs' data).
+        redis_utils::drop_index_and_keys(conn, &self.config.index_name, &self.config.key_prefix);
 
         let distance_metric = map_distance_metric(distance);
 
         // Build FT.CREATE: a single VECTOR field `vector`. KNN-only, so no
         // metadata/filter schema fields are declared.
         let mut cmd = redis::cmd("FT.CREATE");
-        cmd.arg("idx")
+        cmd.arg(&self.config.index_name)
             .arg("ON")
             .arg("HASH")
             .arg("PREFIX")
             .arg("1")
-            .arg("");
+            .arg(&self.config.key_prefix);
 
         cmd.arg("SCHEMA");
 
@@ -217,6 +227,7 @@ impl DragonflyEngine {
                 &mut conn,
                 &ids[batch_start..batch_end],
                 &vectors[batch_start..batch_end],
+                &self.config.key_prefix,
             )?;
             pb.inc((batch_end - batch_start) as u64);
         }
@@ -241,6 +252,7 @@ impl DragonflyEngine {
             for _ in 0..num_threads {
                 let host = self.host.clone();
                 let port = self.port;
+                let key_prefix = self.config.key_prefix.clone();
                 let batches = &batches;
                 let batch_idx = Arc::clone(&batch_idx);
                 let error = Arc::clone(&error);
@@ -265,6 +277,7 @@ impl DragonflyEngine {
                             &mut conn,
                             &ids[batch_start..batch_end],
                             &vectors[batch_start..batch_end],
+                            &key_prefix,
                         ) {
                             *error.lock().unwrap() = Some(e);
                             break;
@@ -291,7 +304,7 @@ impl DragonflyEngine {
 
         loop {
             let info: redis::Value = redis::cmd("FT.INFO")
-                .arg("idx")
+                .arg(&self.config.index_name)
                 .query(&mut conn)
                 .map_err(|e| format!("FT.INFO error: {}", e))?;
 
@@ -445,11 +458,12 @@ fn upload_batch_internal(
     conn: &mut Connection,
     ids: &[i64],
     vectors: &[Vec<f32>],
+    key_prefix: &str,
 ) -> Result<(), String> {
     let mut pipe = redis::pipe();
 
     for i in 0..ids.len() {
-        let key = ids[i].to_string();
+        let key = format!("{}{}", key_prefix, ids[i]);
         let vec_bytes = encode_query_vector(&vectors[i]);
         let mut hset_cmd = redis::cmd("HSET");
         hset_cmd.arg(key.as_str()).arg("vector").arg(&vec_bytes[..]);
@@ -503,8 +517,10 @@ fn build_knn_query_str(algorithm: &str) -> String {
 /// `vec_bytes` and `query_str` are precomputed by the caller BEFORE the timed
 /// window; this performs only the arg binding, the `cmd.query` RPC round-trip,
 /// and the reply parse.
+#[allow(clippy::too_many_arguments)]
 fn ft_search_knn(
     conn: &mut Connection,
+    index_name: &str,
     vec_bytes: &[u8],
     query_str: &str,
     top: usize,
@@ -513,7 +529,7 @@ fn ft_search_knn(
     query_timeout: i64,
 ) -> Result<Vec<(i64, f64)>, String> {
     let mut cmd = redis::cmd("FT.SEARCH");
-    cmd.arg("idx")
+    cmd.arg(index_name)
         .arg(query_str)
         .arg("SORTBY")
         .arg("vector_score")
@@ -564,7 +580,11 @@ fn parse_ft_search_resp2(response: &[redis::Value]) -> Vec<(i64, f64)> {
     let mut results = Vec::new();
     let mut i = 1;
     while i < response.len() {
-        let id = value_as_i64(&response[i]);
+        // The reply carries the doc KEY ("<config>:<id>", #151-4); recover the
+        // trailing numeric id. Missing string → 0 (positionally present).
+        let id = value_as_string(&response[i])
+            .map(|s| doc_key_to_id(&s))
+            .unwrap_or(0);
         i += 1;
 
         if i < response.len() {
@@ -600,7 +620,7 @@ fn parse_ft_search_resp3(pairs: &[(redis::Value, redis::Value)]) -> Vec<(i64, f6
         let mut score = 0.0f64;
         for (k, v) in fields {
             match value_as_string(k).as_deref() {
-                Some("id") => id = value_as_string(v).and_then(|s| s.parse().ok()),
+                Some("id") => id = value_as_string(v).and_then(|s| doc_key_to_id_opt(&s)),
                 Some("extra_attributes") => {
                     if let redis::Value::Map(attrs) = v {
                         for (ak, av) in attrs {
@@ -632,6 +652,10 @@ fn value_as_string(v: &redis::Value) -> Option<String> {
 }
 
 /// Parse a RESP value as an i64 doc id (bulk/simple string or integer).
+/// Retained for its unit test; the resp2 hot path now goes through
+/// `doc_key_to_id` (#151-4) to strip the per-config key prefix, so this is
+/// test-only.
+#[cfg(test)]
 fn value_as_i64(v: &redis::Value) -> i64 {
     match v {
         redis::Value::BulkString(data) => String::from_utf8_lossy(data).parse::<i64>().unwrap_or(0),
@@ -809,6 +833,13 @@ impl Engine for DragonflyEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // Index-existence guard (#151-4): on the --skip-upload path a missing or
+        // mismatched index would otherwise write a silent recall-0.0 result file.
+        {
+            let mut conn = self.get_connection()?;
+            redis_utils::ensure_index_exists(&mut conn, &self.config.index_name)?;
+        }
+
         let ef = params
             .search_params
             .as_ref()
@@ -841,6 +872,8 @@ impl Engine for DragonflyEngine {
             queries.iter().map(|q| encode_query_vector(q)).collect();
         let algorithm = self.config.algorithm.clone();
         let query_str = build_knn_query_str(&algorithm);
+        // Resolve the per-config index name once (not per query / per worker).
+        let index_name = self.config.index_name.clone();
 
         // Per-thread sample buffers merged on join — no per-query Mutex<Vec>
         // contention in the timed loop (see redis.rs::search). Metrics are
@@ -865,6 +898,7 @@ impl Engine for DragonflyEngine {
                 let encoded_queries = &encoded_queries;
                 let query_str = query_str.as_str();
                 let algorithm = algorithm.as_str();
+                let index_name = index_name.as_str();
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
 
@@ -901,6 +935,7 @@ impl Engine for DragonflyEngine {
                         let query_start = Instant::now();
                         let results = ft_search_knn(
                             &mut conn,
+                            index_name,
                             &encoded_queries[idx],
                             query_str,
                             top,
@@ -975,25 +1010,38 @@ impl Engine for DragonflyEngine {
 
     fn delete(&mut self) -> Result<(), String> {
         let mut conn = self.get_connection()?;
-        let _ = redis::cmd("FT.DROPINDEX").arg("idx").query::<()>(&mut conn);
-        let _ = redis::cmd("FLUSHALL").query::<()>(&mut conn);
+        // Dragonfly Search has no DD flag: drop this config's index + its keys via
+        // a prefix-scoped SCAN+UNLINK (not a keyspace-wide FLUSHALL, which under
+        // #151-4 coexistence would wipe sibling configs' data).
+        redis_utils::drop_index_and_keys(
+            &mut conn,
+            &self.config.index_name,
+            &self.config.key_prefix,
+        );
         Ok(())
     }
 
     fn get_memory_usage(&mut self) -> Option<serde_json::Value> {
         let mut conn = self.get_connection().ok()?;
 
+        // used_memory is server-wide (SUM of all resident configs under #151-4);
+        // kept only as a secondary/global figure. The per-config figure is the
+        // FT.INFO index size below.
         let info_str: String = redis::cmd("INFO").arg("memory").query(&mut conn).ok()?;
         let used_memory: i64 = parse_used_memory(&info_str);
 
-        let ft_info: Option<serde_json::Value> = redis::cmd("FT.INFO")
-            .arg("idx")
+        let ft_info_raw: Option<redis::Value> = redis::cmd("FT.INFO")
+            .arg(&self.config.index_name)
             .query::<redis::Value>(&mut conn)
-            .ok()
-            .map(|v| redis_value_to_json(&v));
+            .ok();
+        let index_memory_bytes = ft_info_raw
+            .as_ref()
+            .and_then(redis_utils::ft_info_index_memory_bytes);
+        let ft_info = ft_info_raw.as_ref().map(redis_value_to_json);
 
         Some(serde_json::json!({
             "used_memory": [used_memory],
+            "index_memory_bytes": index_memory_bytes,
             "index_info": ft_info,
         }))
     }
@@ -1004,7 +1052,7 @@ impl Engine for DragonflyEngine {
         // Vector index stats. Errors on the BEFORE snapshot (index not yet
         // created) → index_info: null.
         let ft_info = redis::cmd("FT.INFO")
-            .arg("idx")
+            .arg(&self.config.index_name)
             .query::<redis::Value>(&mut conn)
             .ok()
             .map(|v| redis_value_to_json(&v));
@@ -1075,12 +1123,13 @@ mod tests {
 
     #[test]
     fn parse_ft_search_response_resp2_reads_id_score_pairs() {
-        // [count, id, [vector_score, val], id, [vector_score, val]]
+        // [count, key, [vector_score, val], key, [vector_score, val]]. A
+        // per-config-prefixed key ("cfg:42", #151-4) resolves to its trailing id.
         let resp = Value::Array(vec![
             Value::Int(2),
             bulk("7"),
             Value::Array(vec![bulk("vector_score"), bulk("0.5")]),
-            bulk("42"),
+            bulk("cfg:42"),
             Value::Array(vec![bulk("vector_score"), bulk("0.75")]),
         ]);
         let out = parse_ft_search_response(&resp).unwrap();

--- a/src/bin/vector_db_benchmark/engine/index_naming.rs
+++ b/src/bin/vector_db_benchmark/engine/index_naming.rs
@@ -1,0 +1,97 @@
+//! Per-config index-name and key-prefix derivation for the Redis-wire engines
+//! (Redis / Valkey / Dragonfly).
+//!
+//! Issue #151-4: an M×EF_CONSTRUCTION sweep runs several configs of the same
+//! engine against one server. When every config used the literal index name
+//! `idx` with `PREFIX 1 ""`, the configs shared one index and one keyspace, so
+//! an "upload all, then `--skip-upload` search each" flow silently overwrote
+//! each config's graph with the next — collapsing recall and memory to a single
+//! (last-writer-wins) point.
+//!
+//! The fix makes each config address a *disjoint* index + keyspace derived
+//! purely from `engine_config.name`, so N configs coexist on one server.
+
+/// Map any char outside `[A-Za-z0-9_-]` to `_`. Guarantees: (a) the only `:` in
+/// a derived name/prefix is our own separator; (b) no SCAN glob metacharacters
+/// (`* ? [ ] \`) can originate from a config name. Both properties are
+/// load-bearing: the prefix-scoped SCAN+UNLINK teardown treats `<prefix>*` as a
+/// glob, and the doc-key → id recovery splits on the last `:`.
+pub fn sanitize_token(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Per-config index name: `"<base>:<sanitized-config-name>"`.
+///
+/// `base` is the env override (`base_env`) if set, else `default_base` (`"idx"`).
+/// The config suffix is ALWAYS appended so a pinned base cannot re-collapse a
+/// sweep into one shared index.
+///
+/// Exact-pin escape hatch: if `<base_env>_EXACT=1` is set, the base is used
+/// verbatim with NO config suffix (point a single config at an out-of-band
+/// index). Combining exact mode with >1 config for the engine is caught by the
+/// startup collision guard in `experiment::run`.
+pub fn derive_index_name(base_env: &str, default_base: &str, engine_name: &str) -> String {
+    let base = std::env::var(base_env).unwrap_or_else(|_| default_base.to_string());
+    if index_name_exact(base_env) {
+        return base;
+    }
+    format!("{base}:{}", sanitize_token(engine_name))
+}
+
+/// Whether the `<base_env>_EXACT` escape hatch is enabled (value `1`/`true`).
+pub fn index_name_exact(base_env: &str) -> bool {
+    std::env::var(format!("{base_env}_EXACT"))
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Per-config key prefix: `"<sanitized-config-name>:"`. The trailing `:` is the
+/// only `:` in a doc key, so `doc_key_to_id` recovers the id as the tail after
+/// the last `:`. Debug-asserted non-empty (keyspace-hygiene invariant: an empty
+/// prefix would make the scoped teardown a keyspace-wide `*` wipe).
+pub fn derive_key_prefix(engine_name: &str) -> String {
+    let t = sanitize_token(engine_name);
+    debug_assert!(
+        !t.is_empty(),
+        "config name must sanitize to a non-empty token"
+    );
+    format!("{t}:")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_maps_glob_and_colon_metachars() {
+        // Colons, globs and backslashes all collapse to '_'; alnum/-/_ survive.
+        assert_eq!(sanitize_token("redis-m-16_ef-64"), "redis-m-16_ef-64");
+        assert_eq!(sanitize_token("a:b:c"), "a_b_c");
+        assert_eq!(sanitize_token("a*b?c[d]e\\f"), "a_b_c_d_e_f");
+        assert_eq!(sanitize_token("space here"), "space_here");
+    }
+
+    #[test]
+    fn derive_index_name_appends_sanitized_config() {
+        // No env set → default base "idx" + ':' + sanitized name.
+        assert_eq!(
+            derive_index_name("NONEXISTENT_ENV_151_4", "idx", "redis-m-8"),
+            "idx:redis-m-8"
+        );
+    }
+
+    #[test]
+    fn derive_key_prefix_has_single_trailing_colon() {
+        let p = derive_key_prefix("redis-m-8");
+        assert_eq!(p, "redis-m-8:");
+        assert_eq!(p.matches(':').count(), 1);
+    }
+}

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -8,6 +8,7 @@
 
 mod dragonfly;
 mod elasticsearch;
+pub mod index_naming;
 mod milvus;
 mod mongodb_engine;
 mod opensearch;

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -17,6 +17,7 @@ use redis::Connection;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
+use crate::engine::index_naming::{derive_index_name, derive_key_prefix};
 use crate::engine::{
     attach_open_loop_metrics, closed_loop_duration, zero_search_results, Engine, OpenLoopPlan,
     SearchResults, UpdateSearchRatio, UploadStats,
@@ -24,10 +25,6 @@ use crate::engine::{
 use crate::metrics::compute_metrics;
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, parse_ft_search_response};
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
-
-fn configured_index_name() -> String {
-    std::env::var("REDIS_INDEX_NAME").unwrap_or_else(|_| "idx".to_string())
-}
 
 /// Redis engine configuration
 #[derive(Clone)]
@@ -39,6 +36,15 @@ pub struct RedisEngineConfig {
     pub batch_size: usize,
     pub parallel: usize,
     pub skip_vector_index: bool,
+    /// Per-config RediSearch index name (`"<base>:<config>"`, issue #151-4) so a
+    /// sweep's configs address disjoint indexes on one server. Resolved once in
+    /// `new()`; never re-read from the environment inside a timed window.
+    pub index_name: String,
+    /// Per-config key prefix (`"<config>:"`, issue #151-4). Every doc key is
+    /// `"<key_prefix><id>"`, and the index is `PREFIX 1 "<key_prefix>"`, so each
+    /// config owns a disjoint keyspace and its `FT.DROPINDEX ... DD` teardown
+    /// touches only its own docs.
+    pub key_prefix: String,
     /// Schema field names declared as `datetime`. Values for these fields are
     /// ISO-8601 strings in the payload; they are converted to epoch seconds at
     /// HSET time so the NUMERIC index/range filters match. Populated in
@@ -105,6 +111,8 @@ impl RedisEngine {
                 batch_size,
                 parallel,
                 skip_vector_index: engine_config.skip_vector_index,
+                index_name: derive_index_name("REDIS_INDEX_NAME", "idx", &engine_config.name),
+                key_prefix: derive_key_prefix(&engine_config.name),
                 datetime_fields: Arc::new(HashSet::new()),
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
@@ -121,9 +129,11 @@ impl RedisEngine {
         let distance = dataset.distance();
         let vector_size = dataset.vector_size();
 
-        // Drop existing index if any
+        // Drop existing index if any. DD deletes the indexed docs too; because the
+        // index PREFIX is now this config's `<config>:` (not `""`), DD removes only
+        // this config's keys — sibling configs' indexes/keys are untouched (#151-4).
         let _ = redis::cmd("FT.DROPINDEX")
-            .arg(configured_index_name())
+            .arg(&self.config.index_name)
             .arg("DD")
             .query::<()>(conn);
 
@@ -132,12 +142,12 @@ impl RedisEngine {
 
         // Build FT.CREATE command
         let mut cmd = redis::cmd("FT.CREATE");
-        cmd.arg(configured_index_name())
+        cmd.arg(&self.config.index_name)
             .arg("ON")
             .arg("HASH")
             .arg("PREFIX")
             .arg("1")
-            .arg("");
+            .arg(&self.config.key_prefix);
 
         cmd.arg("SCHEMA");
 
@@ -314,7 +324,7 @@ impl RedisEngine {
 
         loop {
             let info: redis::Value = redis::cmd("FT.INFO")
-                .arg(configured_index_name())
+                .arg(&self.config.index_name)
                 .query(&mut conn)
                 .map_err(|e| format!("FT.INFO error: {}", e))?;
 
@@ -443,6 +453,13 @@ impl RedisEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // Index-existence guard (#151-4): hard-error on a missing/mismatched index
+        // instead of writing a silent recall-0.0 file on the --skip-upload path.
+        {
+            let mut conn = self.get_connection()?;
+            redis_utils::ensure_index_exists(&mut conn, &self.config.index_name)?;
+        }
+
         let parallel = params.parallel.unwrap_or(1) as usize;
         let query_timeout: i64 = std::env::var("REDIS_QUERY_TIMEOUT")
             .ok()
@@ -488,7 +505,7 @@ impl RedisEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         // Resolve the index name once (env lookup) instead of per query.
-        let index_name = configured_index_name();
+        let index_name = self.config.index_name.clone();
 
         let pb = self.create_progress_bar(num_to_run);
         let start_time = Instant::now();
@@ -692,7 +709,7 @@ fn upload_batch_internal(
     let mut pipe = redis::pipe();
 
     for i in 0..ids.len() {
-        let key = ids[i].to_string();
+        let key = format!("{}{}", config.key_prefix, ids[i]);
         let vec_bytes = encode_vector(&config.data_type, &vectors[i]);
 
         let mut fields: Vec<(Vec<u8>, Vec<u8>)> = vec![("vector".as_bytes().to_vec(), vec_bytes)];
@@ -1374,7 +1391,7 @@ fn hset_single(
     vector: &[f32],
     metadata: Option<&MetadataItem>,
 ) -> Result<(), String> {
-    let key = id.to_string();
+    let key = format!("{}{}", config.key_prefix, id);
     let vec_bytes = encode_vector(&config.data_type, vector);
 
     let mut cmd = redis::cmd("HSET");
@@ -1562,6 +1579,13 @@ impl Engine for RedisEngine {
             return self.search_filter_only(dataset, params, num_queries);
         }
 
+        // Index-existence guard (#151-4): on the --skip-upload path a missing or
+        // mismatched index would otherwise write a silent recall-0.0 result file.
+        {
+            let mut conn = self.get_connection()?;
+            redis_utils::ensure_index_exists(&mut conn, &self.config.index_name)?;
+        }
+
         let ef = params
             .search_params
             .as_ref()
@@ -1639,7 +1663,7 @@ impl Engine for RedisEngine {
         });
         // Resolve the index name ONCE (env lookup) so it is not re-read from the
         // environment inside the per-query timed window.
-        let index_name = configured_index_name();
+        let index_name = self.config.index_name.clone();
 
         // Barrier-synchronized start so connection setup AND the cold first query
         // fall OUTSIDE the measured window — for open-loop and closed-loop-duration
@@ -1974,6 +1998,12 @@ impl Engine for RedisEngine {
         // the `--skip-upload` path (configure() does not run there). Idempotent.
         self.config.datetime_fields = Arc::new(datetime_fields_from_schema(dataset));
 
+        // Index-existence guard (#151-4): fail loudly on a missing/mismatched index.
+        {
+            let mut conn = self.get_connection()?;
+            redis_utils::ensure_index_exists(&mut conn, &self.config.index_name)?;
+        }
+
         let ef = params
             .search_params
             .as_ref()
@@ -2017,7 +2047,7 @@ impl Engine for RedisEngine {
         let update_idx = Arc::new(AtomicUsize::new(0));
 
         // Resolve the index name once (env lookup) rather than per query.
-        let index_name = configured_index_name();
+        let index_name = self.config.index_name.clone();
 
         let ratio_searches = ratio.searches as usize;
         let ratio_updates = ratio.updates as usize;
@@ -2235,7 +2265,7 @@ impl Engine for RedisEngine {
     fn delete(&mut self) -> Result<(), String> {
         let mut conn = self.get_connection()?;
         let _ = redis::cmd("FT.DROPINDEX")
-            .arg(configured_index_name())
+            .arg(&self.config.index_name)
             .arg("DD")
             .query::<()>(&mut conn);
         Ok(())
@@ -2244,19 +2274,26 @@ impl Engine for RedisEngine {
     fn get_memory_usage(&mut self) -> Option<serde_json::Value> {
         let mut conn = self.get_connection().ok()?;
 
-        // Get used_memory from INFO memory (returns bulk string, parse key:value lines)
+        // Server-wide used_memory is kept only as a SECONDARY/global figure: under
+        // #151-4 coexistence it is the SUM of all resident configs, so it cannot
+        // attribute memory per graph. The per-config figure is the FT.INFO index
+        // size below.
         let info_str: String = redis::cmd("INFO").arg("memory").query(&mut conn).ok()?;
         let used_memory: i64 = parse_used_memory(&info_str);
 
-        // Get FT.INFO for index stats
-        let ft_info: Option<serde_json::Value> = redis::cmd("FT.INFO")
-            .arg(configured_index_name())
+        // Get FT.INFO for this config's index stats + per-index memory.
+        let ft_info_raw: Option<redis::Value> = redis::cmd("FT.INFO")
+            .arg(&self.config.index_name)
             .query::<redis::Value>(&mut conn)
-            .ok()
-            .map(|v| redis_value_to_json(&v));
+            .ok();
+        let index_memory_bytes = ft_info_raw
+            .as_ref()
+            .and_then(redis_utils::ft_info_index_memory_bytes);
+        let ft_info = ft_info_raw.as_ref().map(redis_value_to_json);
 
         Some(serde_json::json!({
             "used_memory": [used_memory],
+            "index_memory_bytes": index_memory_bytes,
             "index_info": ft_info,
         }))
     }
@@ -2267,7 +2304,7 @@ impl Engine for RedisEngine {
         // Vector index stats (HNSW M/EF, num_docs, index memory, ...). Errors on
         // the BEFORE snapshot (index not yet created) → index_info: null.
         let ft_info = redis::cmd("FT.INFO")
-            .arg(configured_index_name())
+            .arg(&self.config.index_name)
             .query::<redis::Value>(&mut conn)
             .ok()
             .map(|v| redis_value_to_json(&v));
@@ -2487,6 +2524,8 @@ mod tests {
             batch_size: 1,
             parallel: 1,
             skip_vector_index: false,
+            index_name: "idx:test".to_string(),
+            key_prefix: "test:".to_string(),
             datetime_fields: Arc::new(dt),
         };
         // datetime field → epoch seconds string
@@ -2659,12 +2698,14 @@ mod tests {
 
     #[test]
     fn parse_ft_search_response_resp2_reads_id_score_pairs() {
-        // RESP2 FT.SEARCH shape: [count, id1, fields1, id2, fields2, ...]
+        // RESP2 FT.SEARCH shape: [count, key1, fields1, key2, fields2, ...]. Doc
+        // ids arrive as the string KEY; a per-config-prefixed key ("cfg:42",
+        // #151-4) resolves to its trailing numeric id.
         let resp = Value::Array(vec![
             Value::Int(2),
             bulk("7"),
             Value::Array(vec![bulk("vector_score"), bulk("0.25")]),
-            Value::Int(42),
+            bulk("cfg:42"),
             Value::Array(vec![bulk("vector_score"), bulk("1.5")]),
         ]);
         let hits = parse_ft_search_response(&resp).unwrap();

--- a/src/bin/vector_db_benchmark/engine/redis_utils.rs
+++ b/src/bin/vector_db_benchmark/engine/redis_utils.rs
@@ -215,6 +215,10 @@ fn value_to_string(v: &redis::Value) -> String {
         redis::Value::SimpleString(s) => s.clone(),
         redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
         redis::Value::Int(n) => n.to_string(),
+        // RESP3 returns FT.INFO numeric size fields (`*_mb`) as Double; render the
+        // bare number so `ft_info_index_memory_bytes` can parse it (else per-config
+        // memory silently degrades to null under `*_PROTOCOL=resp3`).
+        redis::Value::Double(d) => d.to_string(),
         other => format!("{:?}", other),
     }
 }
@@ -355,6 +359,87 @@ fn evaluate(
     }
 }
 
+/// Confirm a search index exists before a search run (issue #151-4). On the
+/// `--skip-upload` path a name/prefix mismatch (old→new upgrade, wrong config,
+/// missing prior upload) would otherwise write a silent `recall 0.0` result
+/// file. `FT.INFO <index_name>` errors when the index is absent → hard error.
+pub fn ensure_index_exists(conn: &mut Connection, index_name: &str) -> Result<(), String> {
+    redis::cmd("FT.INFO")
+        .arg(index_name)
+        .query::<redis::Value>(conn)
+        .map(|_| ())
+        .map_err(|_| {
+            format!(
+                "index '{index_name}' not found — did you upload this config? \
+                 (--skip-upload requires a prior upload with --keep-data)"
+            )
+        })
+}
+
+/// Per-index memory footprint in bytes, summed from every `*_mb` size field of
+/// an `FT.INFO` reply (RESP2 flat array or RESP3 map). Under issue #151-4's
+/// coexistence mode the server-wide `used_memory` is the SUM of all resident
+/// configs, so it cannot attribute memory per graph; this reads the per-index
+/// figure instead. Returns `None` when the reply carries no size fields.
+pub fn ft_info_index_memory_bytes(v: &redis::Value) -> Option<i64> {
+    let pairs: Vec<(String, &redis::Value)> = match v {
+        redis::Value::Map(m) => m.iter().map(|(k, val)| (value_to_string(k), val)).collect(),
+        redis::Value::Array(items) => items
+            .chunks_exact(2)
+            .map(|c| (value_to_string(&c[0]), &c[1]))
+            .collect(),
+        _ => return None,
+    };
+    let mut mb = 0.0f64;
+    let mut found = false;
+    for (k, val) in pairs {
+        if k.ends_with("_mb") {
+            if let Ok(n) = value_to_string(val).parse::<f64>() {
+                mb += n;
+                found = true;
+            }
+        }
+    }
+    found.then_some((mb * 1024.0 * 1024.0) as i64)
+}
+
+/// Non-destructive teardown for a single config's index + keys (issue #151-4),
+/// for engines with no `DD` flag on `FT.DROPINDEX` (Valkey / Dragonfly). Drops
+/// the index, then SCAN+UNLINKs only keys matching `<key_prefix>*`. `key_prefix`
+/// is sanitized (see `index_naming::sanitize_token`) so the SCAN `MATCH` glob
+/// contains no metacharacters — it is a literal prefix. Runs OUTSIDE every timed
+/// window and every `check_commandstats` reset window. UNLINK (async) avoids the
+/// blocking spike a large synchronous `DEL` would cause.
+pub fn drop_index_and_keys(conn: &mut Connection, index_name: &str, key_prefix: &str) {
+    let _ = redis::cmd("FT.DROPINDEX").arg(index_name).query::<()>(conn);
+    let pattern = format!("{key_prefix}*"); // key_prefix is sanitized → no glob metachars
+    let mut cursor: u64 = 0;
+    loop {
+        let (next, keys): (u64, Vec<String>) = match redis::cmd("SCAN")
+            .arg(cursor)
+            .arg("MATCH")
+            .arg(&pattern)
+            .arg("COUNT")
+            .arg(1000)
+            .query(conn)
+        {
+            Ok(v) => v,
+            Err(_) => break,
+        };
+        if !keys.is_empty() {
+            let mut unlink = redis::cmd("UNLINK");
+            for k in &keys {
+                unlink.arg(k);
+            }
+            let _ = unlink.query::<()>(conn);
+        }
+        if next == 0 {
+            break;
+        }
+        cursor = next;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{evaluate, parse_failed_calls, CommandStatsBaseline};
@@ -444,6 +529,41 @@ mod tests {
         let m = parse_failed_calls(info);
         assert_eq!(m.get("FT.CREATE"), Some(&2));
         assert!(!m.contains_key("BAD"));
+    }
+
+    #[test]
+    fn ft_info_memory_sums_mb_fields_from_both_shapes() {
+        use redis::Value;
+        fn bulk(s: &str) -> Value {
+            Value::BulkString(s.as_bytes().to_vec())
+        }
+        // RESP2 flat array: only `*_mb` fields count; num_docs is ignored.
+        let arr = Value::Array(vec![
+            bulk("num_docs"),
+            bulk("100"),
+            bulk("inverted_sz_mb"),
+            bulk("1.0"),
+            bulk("vector_index_sz_mb"),
+            bulk("2.0"),
+        ]);
+        assert_eq!(
+            super::ft_info_index_memory_bytes(&arr),
+            Some(3 * 1024 * 1024)
+        );
+        // RESP3 map: same total.
+        let map = Value::Map(vec![
+            (bulk("inverted_sz_mb"), bulk("1.0")),
+            (bulk("vector_index_sz_mb"), bulk("2.0")),
+        ]);
+        assert_eq!(
+            super::ft_info_index_memory_bytes(&map),
+            Some(3 * 1024 * 1024)
+        );
+        // No size fields → None.
+        assert_eq!(
+            super::ft_info_index_memory_bytes(&Value::Array(vec![bulk("num_docs"), bulk("5")])),
+            None
+        );
     }
 }
 

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -33,8 +33,9 @@ use redis::Connection;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
+use crate::engine::index_naming::{derive_index_name, derive_key_prefix};
 use crate::engine::{Engine, SearchResults, UpdateSearchRatio, UploadStats};
-use vector_db_benchmark::parsers::datetime_to_epoch_secs;
+use vector_db_benchmark::parsers::{datetime_to_epoch_secs, doc_key_to_id, doc_key_to_id_opt};
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
 
 /// Valkey engine configuration
@@ -59,6 +60,12 @@ pub struct ValkeyEngineConfig {
     /// supports single-term full-text matching (any doc containing the term); it
     /// does NOT support phrase / multi-term full-text queries.
     pub text_tag_fields: Arc<HashSet<String>>,
+    /// Per-config index name (`"<base>:<config>"`, issue #151-4) so a sweep's
+    /// configs address disjoint indexes on one server. Resolved once in `new()`.
+    pub index_name: String,
+    /// Per-config key prefix (`"<config>:"`, issue #151-4). Each config owns a
+    /// disjoint keyspace; teardown is a prefix-scoped SCAN+UNLINK (no DD flag).
+    pub key_prefix: String,
 }
 
 pub struct ValkeyEngine {
@@ -126,6 +133,8 @@ impl ValkeyEngine {
                 skip_vector_index: engine_config.skip_vector_index,
                 datetime_fields: Arc::new(HashSet::new()),
                 text_tag_fields: Arc::new(HashSet::new()),
+                index_name: derive_index_name("VALKEY_INDEX_NAME", "idx", &engine_config.name),
+                key_prefix: derive_key_prefix(&engine_config.name),
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             commandstats_baseline: None,
@@ -166,22 +175,22 @@ impl ValkeyEngine {
         let distance = dataset.distance();
         let vector_size = dataset.vector_size();
 
-        // Drop existing index if any (Valkey Search does not support DD flag)
-        let _ = redis::cmd("FT.DROPINDEX").arg("idx").query::<()>(conn);
-        // Flush all keys to clean up data from previous runs
-        let _ = redis::cmd("FLUSHALL").query::<()>(conn);
+        // Drop this config's index + keys ONLY (Valkey Search has no DD flag, so a
+        // prefix-scoped SCAN+UNLINK replaces the old keyspace-wide FLUSHALL). Under
+        // #151-4 coexistence a FLUSHALL would wipe sibling configs' data.
+        redis_utils::drop_index_and_keys(conn, &self.config.index_name, &self.config.key_prefix);
 
         // Map distance metric
         let distance_metric = map_distance_metric(distance);
 
         // Build FT.CREATE command
         let mut cmd = redis::cmd("FT.CREATE");
-        cmd.arg("idx")
+        cmd.arg(&self.config.index_name)
             .arg("ON")
             .arg("HASH")
             .arg("PREFIX")
             .arg("1")
-            .arg("");
+            .arg(&self.config.key_prefix);
 
         cmd.arg("SCHEMA");
 
@@ -350,7 +359,7 @@ impl ValkeyEngine {
 
         loop {
             let info: redis::Value = redis::cmd("FT.INFO")
-                .arg("idx")
+                .arg(&self.config.index_name)
                 .query(&mut conn)
                 .map_err(|e| format!("FT.INFO error: {}", e))?;
 
@@ -479,6 +488,12 @@ impl ValkeyEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // Index-existence guard (#151-4): hard-error on a missing/mismatched index.
+        {
+            let mut conn = self.get_connection()?;
+            redis_utils::ensure_index_exists(&mut conn, &self.config.index_name)?;
+        }
+
         let parallel = params.parallel.unwrap_or(1) as usize;
         let query_timeout: i64 = std::env::var("VALKEY_QUERY_TIMEOUT")
             .ok()
@@ -525,6 +540,9 @@ impl ValkeyEngine {
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
 
+        // Resolve the per-config index name once (not per query / per worker).
+        let index_name = self.config.index_name.clone();
+
         std::thread::scope(|s| {
             let mut handles = Vec::with_capacity(parallel);
             for _ in 0..parallel {
@@ -535,6 +553,7 @@ impl ValkeyEngine {
                 let neighbors = &neighbors;
                 let errors = Arc::clone(&errors);
                 let query_idx = Arc::clone(&query_idx);
+                let index_name = index_name.as_str();
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -585,6 +604,7 @@ impl ValkeyEngine {
                         let query_start = Instant::now();
                         let result = ft_search_filter_only(
                             &mut conn,
+                            index_name,
                             top,
                             query_timeout,
                             parsed_filters[idx].as_ref().unwrap(),
@@ -712,7 +732,7 @@ fn upload_batch_internal(
     let mut pipe_bytes: usize = 0;
 
     for i in 0..ids.len() {
-        let key = ids[i].to_string();
+        let key = format!("{}{}", config.key_prefix, ids[i]);
         let vec_bytes: Vec<u8> = match config.data_type.as_str() {
             "FLOAT64" => vectors[i]
                 .iter()
@@ -1202,6 +1222,7 @@ fn build_condition(
 /// Execute filter-only FT.SEARCH (no KNN vector query).
 fn ft_search_filter_only(
     conn: &mut Connection,
+    index_name: &str,
     top: usize,
     query_timeout: i64,
     filter: &ParsedFilter,
@@ -1209,7 +1230,7 @@ fn ft_search_filter_only(
     let (filter_expr, params) = filter;
 
     let mut cmd = redis::cmd("FT.SEARCH");
-    cmd.arg("idx")
+    cmd.arg(index_name)
         .arg(filter_expr.as_str())
         .arg("LIMIT")
         .arg(0)
@@ -1282,6 +1303,7 @@ fn encode_query_vector(query_vector: &[f32]) -> Vec<u8> {
 #[allow(clippy::too_many_arguments)]
 fn ft_search_knn(
     conn: &mut Connection,
+    index_name: &str,
     vec_bytes: &[u8],
     query_str: &str,
     top: usize,
@@ -1293,7 +1315,7 @@ fn ft_search_knn(
 ) -> Result<Vec<(i64, f64)>, String> {
     // Valkey Search: DIALECT 2 only, no SORTBY on computed fields
     let mut cmd = redis::cmd("FT.SEARCH");
-    cmd.arg("idx")
+    cmd.arg(index_name)
         .arg(query_str)
         .arg("LIMIT")
         .arg(0)
@@ -1358,7 +1380,11 @@ fn parse_ft_search_resp2(response: &[redis::Value]) -> Vec<(i64, f64)> {
     let mut results = Vec::new();
     let mut i = 1;
     while i < response.len() {
-        let id = value_as_i64(&response[i]);
+        // The reply carries the doc KEY ("<config>:<id>", #151-4); recover the
+        // trailing numeric id. Missing string → 0 (positionally present).
+        let id = value_as_string(&response[i])
+            .map(|s| doc_key_to_id(&s))
+            .unwrap_or(0);
         i += 1;
 
         if i < response.len() {
@@ -1397,7 +1423,7 @@ fn parse_ft_search_resp3(pairs: &[(redis::Value, redis::Value)]) -> Vec<(i64, f6
         let mut score = 0.0f64;
         for (k, v) in fields {
             match value_as_string(k).as_deref() {
-                Some("id") => id = value_as_string(v).and_then(|s| s.parse().ok()),
+                Some("id") => id = value_as_string(v).and_then(|s| doc_key_to_id_opt(&s)),
                 Some("extra_attributes") => {
                     if let redis::Value::Map(attrs) = v {
                         for (ak, av) in attrs {
@@ -1429,6 +1455,10 @@ fn value_as_string(v: &redis::Value) -> Option<String> {
 }
 
 /// Parse a RESP value as an i64 doc id (bulk/simple string or integer).
+/// Retained for its unit test; the resp2 hot path now goes through
+/// `doc_key_to_id` (#151-4) to strip the per-config key prefix, so this is
+/// test-only.
+#[cfg(test)]
 fn value_as_i64(v: &redis::Value) -> i64 {
     match v {
         redis::Value::BulkString(data) => String::from_utf8_lossy(data).parse::<i64>().unwrap_or(0),
@@ -1475,7 +1505,7 @@ fn hset_single(
     vector: &[f32],
     metadata: Option<&MetadataItem>,
 ) -> Result<(), String> {
-    let key = id.to_string();
+    let key = format!("{}{}", config.key_prefix, id);
     let vec_bytes: Vec<u8> = match config.data_type.as_str() {
         "FLOAT64" => vector
             .iter()
@@ -1704,6 +1734,12 @@ impl Engine for ValkeyEngine {
             return self.search_filter_only(dataset, params, num_queries);
         }
 
+        // Index-existence guard (#151-4): fail loudly on a missing/mismatched index.
+        {
+            let mut conn = self.get_connection()?;
+            redis_utils::ensure_index_exists(&mut conn, &self.config.index_name)?;
+        }
+
         let ef = params
             .search_params
             .as_ref()
@@ -1759,6 +1795,9 @@ impl Engine for ValkeyEngine {
         let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
+        // Resolve the per-config index name once (not per query / per worker).
+        let index_name = self.config.index_name.clone();
+
         std::thread::scope(|s| {
             let mut handles = Vec::with_capacity(parallel);
             for _ in 0..parallel {
@@ -1771,6 +1810,7 @@ impl Engine for ValkeyEngine {
                 let encoded_queries = &encoded_queries;
                 let query_strs = &query_strs;
                 let query_idx = Arc::clone(&query_idx);
+                let index_name = index_name.as_str();
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -1824,6 +1864,7 @@ impl Engine for ValkeyEngine {
                         let query_start = Instant::now();
                         let results = ft_search_knn(
                             &mut conn,
+                            index_name,
                             &encoded_queries[idx],
                             &query_strs[idx],
                             top,
@@ -1915,6 +1956,12 @@ impl Engine for ValkeyEngine {
         let (dt_fields, text_fields) = schema_transform_fields(dataset);
         self.config.datetime_fields = Arc::new(dt_fields);
         self.config.text_tag_fields = Arc::new(text_fields);
+
+        // Index-existence guard (#151-4): fail loudly on a missing/mismatched index.
+        {
+            let mut conn = self.get_connection()?;
+            redis_utils::ensure_index_exists(&mut conn, &self.config.index_name)?;
+        }
 
         let ef = params
             .search_params
@@ -2038,6 +2085,7 @@ impl Engine for ValkeyEngine {
                             let query_str = build_knn_query_str(parsed_filters[idx].as_ref());
                             let results = ft_search_knn(
                                 &mut conn,
+                                &config.index_name,
                                 &vec_bytes,
                                 &query_str,
                                 top,
@@ -2165,27 +2213,38 @@ impl Engine for ValkeyEngine {
 
     fn delete(&mut self) -> Result<(), String> {
         let mut conn = self.get_connection()?;
-        // Valkey Search does not support DD flag on FT.DROPINDEX
-        let _ = redis::cmd("FT.DROPINDEX").arg("idx").query::<()>(&mut conn);
-        // Flush all keys to clean up uploaded data
-        let _ = redis::cmd("FLUSHALL").query::<()>(&mut conn);
+        // Valkey Search has no DD flag: drop this config's index + its keys via a
+        // prefix-scoped SCAN+UNLINK (not a keyspace-wide FLUSHALL, which under
+        // #151-4 coexistence would wipe sibling configs' data).
+        redis_utils::drop_index_and_keys(
+            &mut conn,
+            &self.config.index_name,
+            &self.config.key_prefix,
+        );
         Ok(())
     }
 
     fn get_memory_usage(&mut self) -> Option<serde_json::Value> {
         let mut conn = self.get_connection().ok()?;
 
+        // used_memory is server-wide (SUM of all resident configs under #151-4);
+        // kept only as a secondary/global figure. The per-config figure is the
+        // FT.INFO index size below.
         let info_str: String = redis::cmd("INFO").arg("memory").query(&mut conn).ok()?;
         let used_memory: i64 = parse_used_memory(&info_str);
 
-        let ft_info: Option<serde_json::Value> = redis::cmd("FT.INFO")
-            .arg("idx")
+        let ft_info_raw: Option<redis::Value> = redis::cmd("FT.INFO")
+            .arg(&self.config.index_name)
             .query::<redis::Value>(&mut conn)
-            .ok()
-            .map(|v| redis_value_to_json(&v));
+            .ok();
+        let index_memory_bytes = ft_info_raw
+            .as_ref()
+            .and_then(redis_utils::ft_info_index_memory_bytes);
+        let ft_info = ft_info_raw.as_ref().map(redis_value_to_json);
 
         Some(serde_json::json!({
             "used_memory": [used_memory],
+            "index_memory_bytes": index_memory_bytes,
             "index_info": ft_info,
         }))
     }
@@ -2196,7 +2255,7 @@ impl Engine for ValkeyEngine {
         // Vector index stats. Errors on the BEFORE snapshot (index not yet
         // created) → index_info: null.
         let ft_info = redis::cmd("FT.INFO")
-            .arg("idx")
+            .arg(&self.config.index_name)
             .query::<redis::Value>(&mut conn)
             .ok()
             .map(|v| redis_value_to_json(&v));
@@ -2444,6 +2503,8 @@ mod tests {
             skip_vector_index: false,
             datetime_fields: Arc::new(dt),
             text_tag_fields: Arc::new(txt),
+            index_name: "idx:test".to_string(),
+            key_prefix: "test:".to_string(),
         };
         assert_eq!(
             encode_string_field(&cfg, "ts", "2021-01-01T00:00:00Z"),
@@ -2469,12 +2530,14 @@ mod tests {
 
     #[test]
     fn parse_ft_search_response_resp2_reads_id_score_pairs() {
-        // RESP2 FT.SEARCH shape: [count, id1, fields1, id2, fields2, ...]
+        // RESP2 FT.SEARCH shape: [count, key1, fields1, key2, fields2, ...]. Doc
+        // ids arrive as the string KEY; a per-config-prefixed key ("cfg:42",
+        // #151-4) resolves to its trailing numeric id.
         let resp = Value::Array(vec![
             Value::Int(2),
             bulk("7"),
             Value::Array(vec![bulk("vector_score"), bulk("0.25")]),
-            Value::Int(42), // id may also arrive as an integer
+            bulk("cfg:42"),
             Value::Array(vec![bulk("vector_score"), bulk("1.5")]),
         ]);
         let hits = parse_ft_search_response(&resp).unwrap();

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -143,6 +143,43 @@ pub fn run(args: &Args) -> Result<(), String> {
         );
     }
 
+    // Collision guard (#151-4): among the selected configs, no two configs of the
+    // same destructive Redis-wire engine (redis/valkey/dragonfly) may derive the
+    // same index namespace, or a sweep would silently overwrite one config's graph
+    // and keyspace with another's (the exact bug this fix closes). Also fires when
+    // an `*_INDEX_NAME_EXACT` pin is set with >1 config for that engine (every
+    // config then resolves to the same verbatim base). In --skip-vector-index mode
+    // the dedup above already leaves one config per engine, so this is a no-op.
+    {
+        use crate::engine::index_naming::{derive_index_name, index_name_exact};
+        let mut seen: std::collections::HashMap<(String, String), String> =
+            std::collections::HashMap::new();
+        for (_name, config) in &engines {
+            let engine_type = config.engine.as_deref().unwrap_or("");
+            let base_env = match engine_type {
+                "redis" => "REDIS_INDEX_NAME",
+                "valkey" => "VALKEY_INDEX_NAME",
+                "dragonfly" => "DRAGONFLY_INDEX_NAME",
+                _ => continue,
+            };
+            let idx = derive_index_name(base_env, "idx", &config.name);
+            if let Some(prev) =
+                seen.insert((engine_type.to_string(), idx.clone()), config.name.clone())
+            {
+                let exact_hint = if index_name_exact(base_env) {
+                    format!(" ({base_env}_EXACT is set — exact mode requires a single config per engine.)")
+                } else {
+                    String::new()
+                };
+                return Err(format!(
+                    "Configs '{}' and '{}' derive the same index namespace '{}'; rename them — \
+                     a sweep would silently overwrite one with the other (issue #151-4).{}",
+                    prev, config.name, idx, exact_hint
+                ));
+            }
+        }
+    }
+
     println!(
         "Found {} datasets, {} engines",
         datasets.len(),
@@ -706,11 +743,25 @@ fn run_single_experiment(
                         });
                     }
                     None => {
-                        eprintln!(
-                            "\tSearch failed (all {} repetition(s)){}",
+                        // Every rep of this search config failed. Under
+                        // exit_on_error (the default) this must abort loudly rather
+                        // than be swallowed with a zero exit — otherwise a hard
+                        // error (e.g. the #151-4 "index not found" guard on a
+                        // --skip-upload run against a config that was never
+                        // uploaded) silently writes nothing and the process exits
+                        // 0, masking wrong/absent results.
+                        let msg = format!(
+                            "search failed (all {} repetition(s)){}",
                             repetitions,
-                            last_err.map(|e| format!(": {}", e)).unwrap_or_default()
+                            last_err
+                                .as_ref()
+                                .map(|e| format!(": {}", e))
+                                .unwrap_or_default()
                         );
+                        eprintln!("\t{}", msg);
+                        if args.exit_on_error {
+                            return Err(msg);
+                        }
                     }
                 }
             }

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -69,6 +69,28 @@ pub fn datetime_to_epoch_secs(s: &str) -> Option<f64> {
     None
 }
 
+/// Recover the numeric doc id from an FT.SEARCH key under the RESP2 arm, where
+/// the id is positionally guaranteed present. Since issue #151-4 the doc key is
+/// `"<config>:<id>"` (per-config keyspace prefix), so the id is the tail after
+/// the last `:`. A bare `"42"` (no prefix, as older uploads and the Class-A
+/// integration tests write) still yields `42`, keeping this backward-compatible.
+/// An unparseable tail falls back to `0` (mirrors the old `value_as_i64`).
+pub fn doc_key_to_id(key: &str) -> i64 {
+    key.rsplit(':')
+        .next()
+        .unwrap_or(key)
+        .parse::<i64>()
+        .unwrap_or(0)
+}
+
+/// Recover the numeric doc id from an FT.SEARCH key under the RESP3 arm, where a
+/// missing/unparseable id must be SKIPPED (returns `None`) rather than emitted as
+/// a phantom `id=0` hit that would pollute recall. Do NOT collapse this into
+/// `doc_key_to_id`: the `Option` semantics are load-bearing here.
+pub fn doc_key_to_id_opt(key: &str) -> Option<i64> {
+    key.rsplit(':').next().unwrap_or(key).parse::<i64>().ok()
+}
+
 /// Parse an FT.SEARCH reply under EITHER protocol:
 /// - RESP2: a flat array `[count, id, fields, id, fields, ...]`
 /// - RESP3: a map `{ results: [ { id, extra_attributes: { vector_score, .. }, .. } ], .. }`
@@ -94,7 +116,11 @@ fn parse_ft_search_resp2(response: &[redis::Value]) -> Vec<(i64, f64)> {
     // First element is total count.
     let mut i = 1;
     while i < response.len() {
-        let id = value_as_i64(&response[i]);
+        // The reply carries the doc KEY (e.g. "cfg:42"), not a bare id; recover
+        // the trailing numeric id. Missing string → 0 (positionally present).
+        let id = value_as_string(&response[i])
+            .map(|s| doc_key_to_id(&s))
+            .unwrap_or(0);
         i += 1;
 
         if i < response.len() {
@@ -133,7 +159,7 @@ fn parse_ft_search_resp3(pairs: &[(redis::Value, redis::Value)]) -> Vec<(i64, f6
         let mut score = 0.0f64;
         for (k, v) in fields {
             match value_as_string(k).as_deref() {
-                Some("id") => id = value_as_string(v).and_then(|s| s.parse().ok()),
+                Some("id") => id = value_as_string(v).and_then(|s| doc_key_to_id_opt(&s)),
                 Some("extra_attributes") => {
                     if let redis::Value::Map(attrs) = v {
                         for (ak, av) in attrs {
@@ -245,6 +271,40 @@ mod tests {
     }
 
     // ---- Regression tests for fuzzer-found crashes (see notes in report). ----
+
+    #[test]
+    fn doc_key_to_id_recovers_prefixed_and_bare() {
+        // Bare (pre-#151-4 uploads + Class-A tests) stays identity.
+        assert_eq!(doc_key_to_id("42"), 42);
+        // Per-config prefixed key: tail after the last ':'.
+        assert_eq!(doc_key_to_id("redis-m-16-ef-64:42"), 42);
+        // Pathological colon shapes never panic; unparseable tail → 0.
+        assert_eq!(doc_key_to_id("a:b:c"), 0);
+        assert_eq!(doc_key_to_id("::"), 0);
+        assert_eq!(doc_key_to_id(""), 0);
+        assert_eq!(doc_key_to_id("a:b:7"), 7);
+    }
+
+    #[test]
+    fn doc_key_to_id_opt_skips_unparseable() {
+        // resp3 arm PRESERVES Option so a bad id is skipped, not emitted as 0.
+        assert_eq!(doc_key_to_id_opt("42"), Some(42));
+        assert_eq!(doc_key_to_id_opt("cfg:42"), Some(42));
+        assert_eq!(doc_key_to_id_opt("cfg:x"), None);
+        assert_eq!(doc_key_to_id_opt(""), None);
+        assert_eq!(doc_key_to_id_opt("a:b:c"), None);
+    }
+
+    #[test]
+    fn ft_search_resp2_recovers_id_from_prefixed_key() {
+        // A prefixed key ("cfg:42") must resolve to id 42, not 0.
+        let resp = Value::Array(vec![
+            Value::Int(1),
+            bulk("cfg:42"),
+            Value::Array(vec![bulk("vector_score"), bulk("0.5")]),
+        ]);
+        assert_eq!(parse_ft_search_response(&resp).unwrap(), vec![(42, 0.5)]);
+    }
 
     #[test]
     fn parse_info_no_panic_on_arbitrary_bytes() {

--- a/src/redisearch/search.rs
+++ b/src/redisearch/search.rs
@@ -476,10 +476,11 @@ fn parse_ft_search_response(response: &[redis::Value]) -> PyResult<Vec<(i64, f64
     // First element is total count
     let mut i = 1;
     while i < response.len() {
-        // doc_id
+        // doc_id — the reply carries the doc KEY (e.g. "cfg:42") since issue
+        // #151-4's per-config keyspace prefix; recover the trailing numeric id.
         let id = match &response[i] {
             redis::Value::BulkString(data) => {
-                String::from_utf8_lossy(data).parse::<i64>().unwrap_or(0)
+                crate::parsers::doc_key_to_id(&String::from_utf8_lossy(data))
             }
             redis::Value::Int(n) => *n,
             _ => 0,

--- a/tests/integration_dragonfly.rs
+++ b/tests/integration_dragonfly.rs
@@ -597,3 +597,217 @@ fn test_dragonfly_non_numeric_ef_rejected() {
 
     let _ = redis::cmd("FT.DROPINDEX").arg("idx").query::<()>(&mut conn);
 }
+
+/// Count keys under a glob (KEYS is fine on the small test keyspace).
+fn count_keys(conn: &mut Connection, pattern: &str) -> usize {
+    redis::cmd("KEYS")
+        .arg(pattern)
+        .query::<Vec<String>>(conn)
+        .map(|k| k.len())
+        .unwrap_or(0)
+}
+
+/// Delete only `*-search-*.json` result files under `root/results`.
+fn delete_search_result_files(root: &std::path::Path) {
+    let dir = root.join("results");
+    if let Ok(rd) = fs::read_dir(&dir) {
+        for entry in rd.filter_map(|e| e.ok()) {
+            if entry.file_name().to_string_lossy().contains("-search-") {
+                fs::remove_file(entry.path()).ok();
+            }
+        }
+    }
+}
+
+/// #151-4 regression (dragonfly mirror): "upload all, then --skip-upload search
+/// each" gives every config its OWN graph. Two configs (dense high-ef vs sparse
+/// low-ef) coexist on one server via disjoint `idx:<config>` indexes + `<config>:`
+/// keyspaces; pre-fix they shared `idx` + keyspace → identical recall on the sweep.
+#[test]
+fn test_dragonfly_coexistence_skip_upload() {
+    wait_for_dragonfly();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 16;
+    let n_docs = 2000;
+    let n_queries = 100;
+    let top = 10;
+    let (vectors, queries, neighbors) = make_data(n_docs, n_queries, dim, top);
+
+    let engine_config = serde_json::json!([
+        {
+            "name": "dragonfly-co-a",
+            "engine": "dragonfly",
+            "connection_params": {},
+            "collection_params": { "hnsw_config": { "M": 64, "EF_CONSTRUCTION": 200 } },
+            "search_params": [{ "parallel": 1, "top": top, "search_params": { "ef": 256 } }],
+            "upload_params": { "parallel": 1, "batch_size": 64 }
+        },
+        {
+            "name": "dragonfly-co-b",
+            "engine": "dragonfly",
+            "connection_params": {},
+            "collection_params": { "hnsw_config": { "M": 4, "EF_CONSTRUCTION": 8 } },
+            "search_params": [{ "parallel": 1, "top": top, "search_params": { "ef": 10 } }],
+            "upload_params": { "parallel": 1, "batch_size": 64 }
+        }
+    ]);
+
+    let root = create_knn_project(
+        "dragonfly-co",
+        &serde_json::to_string_pretty(&engine_config).unwrap(),
+        &vectors,
+        &queries,
+        &neighbors,
+        dim,
+    );
+    let port = test_port().to_string();
+
+    // Phase 1: upload + search BOTH, KEEPING data for the skip-upload phase.
+    assert!(
+        common::run_binary_extra(
+            &root,
+            "dragonfly-co-*",
+            "dragonfly-co",
+            TEST_HOST,
+            &[("DRAGONFLY_PORT", port.as_str())],
+            &["--keep-data"],
+        ),
+        "dragonfly coexistence phase 1 failed"
+    );
+
+    let base_a = common::read_recall(&root, "dragonfly-co-a");
+    let base_b = common::read_recall(&root, "dragonfly-co-b");
+
+    // Deterministic coexistence: `n_docs` keys under EACH per-config prefix, and
+    // both disjoint indexes exist.
+    assert_eq!(
+        count_keys(&mut conn, "dragonfly-co-a:*"),
+        n_docs,
+        "dragonfly-co-a keyspace"
+    );
+    assert_eq!(
+        count_keys(&mut conn, "dragonfly-co-b:*"),
+        n_docs,
+        "dragonfly-co-b keyspace"
+    );
+    assert!(
+        redis::cmd("FT.INFO")
+            .arg("idx:dragonfly-co-a")
+            .query::<redis::Value>(&mut conn)
+            .is_ok(),
+        "idx:dragonfly-co-a must exist"
+    );
+    assert!(
+        redis::cmd("FT.INFO")
+            .arg("idx:dragonfly-co-b")
+            .query::<redis::Value>(&mut conn)
+            .is_ok(),
+        "idx:dragonfly-co-b must exist"
+    );
+
+    delete_search_result_files(&root);
+
+    // Phase 2: --skip-upload search of both against the coexisting indexes.
+    assert!(
+        common::run_binary_extra(
+            &root,
+            "dragonfly-co-*",
+            "dragonfly-co",
+            TEST_HOST,
+            &[("DRAGONFLY_PORT", port.as_str())],
+            &["--skip-upload", "--keep-data"],
+        ),
+        "dragonfly coexistence phase 2 (--skip-upload) failed"
+    );
+
+    let rec_a = common::read_recall(&root, "dragonfly-co-a");
+    let rec_b = common::read_recall(&root, "dragonfly-co-b");
+
+    assert!(
+        (rec_a - base_a).abs() < 1e-9,
+        "dragonfly-co-a skip-upload recall {} != baseline {}",
+        rec_a,
+        base_a
+    );
+    assert!(
+        (rec_b - base_b).abs() < 1e-9,
+        "dragonfly-co-b skip-upload recall {} != baseline {}",
+        rec_b,
+        base_b
+    );
+    assert!(
+        (rec_a - rec_b).abs() > 1e-9,
+        "coexisting configs must have distinct recall: a={} b={}",
+        rec_a,
+        rec_b
+    );
+    assert!(
+        rec_a > rec_b,
+        "dense high-ef graph (a={}) should out-recall the sparse one (b={})",
+        rec_a,
+        rec_b
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+/// #151-4 negative (dragonfly mirror): `--skip-upload` with NO prior upload must
+/// FAIL LOUDLY (index-existence guard), never writing a recall-0.0 result file.
+#[test]
+fn test_dragonfly_skip_upload_without_prior_upload_errors() {
+    wait_for_dragonfly();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 16;
+    let n_docs = 500;
+    let n_queries = 20;
+    let top = 10;
+    let (vectors, queries, neighbors) = make_data(n_docs, n_queries, dim, top);
+
+    let engine_config = serde_json::json!([{
+        "name": "dragonfly-noupload",
+        "engine": "dragonfly",
+        "connection_params": {},
+        "collection_params": { "hnsw_config": { "M": 16, "EF_CONSTRUCTION": 128 } },
+        "search_params": [{ "parallel": 1, "top": top, "search_params": { "ef": 64 } }],
+        "upload_params": { "parallel": 1, "batch_size": 64 }
+    }]);
+
+    let root = create_knn_project(
+        "dragonfly-noupload",
+        &serde_json::to_string_pretty(&engine_config).unwrap(),
+        &vectors,
+        &queries,
+        &neighbors,
+        dim,
+    );
+    let port = test_port().to_string();
+
+    let ok = common::run_binary_extra(
+        &root,
+        "dragonfly-noupload",
+        "dragonfly-noupload",
+        TEST_HOST,
+        &[("DRAGONFLY_PORT", port.as_str())],
+        &["--skip-upload"],
+    );
+    assert!(
+        !ok,
+        "--skip-upload with no prior upload must fail loudly, but exited 0"
+    );
+    let wrote_search = fs::read_dir(root.join("results"))
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .any(|e| e.file_name().to_string_lossy().contains("-search-"))
+        })
+        .unwrap_or(false);
+    assert!(
+        !wrote_search,
+        "guard must prevent any search result file from being written"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -2252,3 +2252,279 @@ fn test_binary_redis_tenancy() {
         );
     }
 }
+
+/// Read `results.mean_recall` for `engine_name` from its search result JSON.
+fn read_search_mean_recall(results_dir: &PathBuf, engine_name: &str) -> f64 {
+    read_search_result_field(results_dir, engine_name, "mean_recall")
+        .and_then(|v| v.as_f64())
+        .unwrap_or_else(|| panic!("no mean_recall for {}", engine_name))
+}
+
+/// FT.INFO num_docs for `index`, or -1 if the index is missing.
+fn ft_info_num_docs(conn: &mut Connection, index: &str) -> i64 {
+    match redis::cmd("FT.INFO").arg(index).query::<redis::Value>(conn) {
+        Ok(info) => extract_ft_info_value(&info, "num_docs").unwrap_or(-1),
+        Err(_) => -1,
+    }
+}
+
+/// Delete only the `*-search-*.json` files under `results_dir` (keeps upload files).
+fn delete_search_result_files(results_dir: &PathBuf) {
+    for entry in fs::read_dir(results_dir).unwrap() {
+        let p = entry.unwrap().path();
+        if p.file_name()
+            .unwrap()
+            .to_string_lossy()
+            .contains("-search-")
+        {
+            fs::remove_file(p).ok();
+        }
+    }
+}
+
+/// #151-4 regression: "upload all, then --skip-upload search each" must give every
+/// config its OWN graph. Two configs (dense high-ef vs sparse low-ef) coexist on
+/// one server; pre-fix they shared index `idx` + keyspace, so the skip-upload
+/// sweep read the last-uploaded graph for BOTH → identical recall. Post-fix they
+/// address disjoint `idx:<config>` indexes + `<config>:` keyspaces → distinct.
+#[test]
+fn test_binary_redis_coexistence_skip_upload() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 32;
+    let count = 2000;
+    let top = 10;
+    let (_, vectors) = generate_test_vectors(count, dim);
+    let queries: Vec<Vec<f32>> = vectors[..20].to_vec();
+    let neighbors: Vec<Vec<i64>> = queries
+        .iter()
+        .map(|q| brute_force_neighbors(q, &vectors, top))
+        .collect();
+
+    let engine_config = serde_json::json!([
+        {
+            "name": "redis-co-a",
+            "engine": "redis",
+            "algorithm": "hnsw",
+            "collection_params": { "hnsw_config": { "M": 64, "EF_CONSTRUCTION": 200 } },
+            "search_params": [{ "parallel": 1, "search_params": { "ef": 256 }, "top": top }],
+            "upload_params": { "data_type": "FLOAT32", "parallel": 1, "batch_size": 64 }
+        },
+        {
+            "name": "redis-co-b",
+            "engine": "redis",
+            "algorithm": "hnsw",
+            "collection_params": { "hnsw_config": { "M": 4, "EF_CONSTRUCTION": 8 } },
+            "search_params": [{ "parallel": 1, "search_params": { "ef": 10 }, "top": top }],
+            "upload_params": { "data_type": "FLOAT32", "parallel": 1, "batch_size": 64 }
+        }
+    ]);
+
+    let root = create_test_project(
+        "test-co",
+        &serde_json::to_string_pretty(&engine_config).unwrap(),
+        &vectors,
+        &queries,
+        &neighbors,
+        "l2",
+        dim,
+    );
+    let bin = binary_path();
+    let port = TEST_PORT.to_string();
+    let results_dir = root.join("results");
+
+    // Phase 1: upload + search BOTH configs, KEEPING data for the skip-upload phase.
+    let out1 = Command::new(&bin)
+        .args([
+            "--engines",
+            "redis-co-*",
+            "--datasets",
+            "test-co",
+            "--host",
+            "localhost",
+            "--keep-data",
+            "--skip-if-exists",
+            "false",
+        ])
+        .env("REDIS_PORT", &port)
+        .current_dir(&root)
+        .output()
+        .expect("run phase 1");
+    assert!(
+        out1.status.success(),
+        "phase 1 failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out1.stdout),
+        String::from_utf8_lossy(&out1.stderr)
+    );
+
+    let base_a = read_search_mean_recall(&results_dir, "redis-co-a");
+    let base_b = read_search_mean_recall(&results_dir, "redis-co-b");
+
+    // Deterministic coexistence proof: two DISJOINT indexes each hold all `count`
+    // docs, and the keyspace carries `count` keys under EACH per-config prefix.
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:redis-co-a"),
+        count as i64,
+        "idx:redis-co-a must hold all docs"
+    );
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:redis-co-b"),
+        count as i64,
+        "idx:redis-co-b must hold all docs"
+    );
+    let keys_a: i64 = redis::cmd("EVAL")
+        .arg("return #redis.call('keys', KEYS[1])")
+        .arg(1)
+        .arg("redis-co-a:*")
+        .query(&mut conn)
+        .unwrap();
+    let keys_b: i64 = redis::cmd("EVAL")
+        .arg("return #redis.call('keys', KEYS[1])")
+        .arg(1)
+        .arg("redis-co-b:*")
+        .query(&mut conn)
+        .unwrap();
+    assert_eq!(keys_a, count as i64, "redis-co-a: keyspace");
+    assert_eq!(keys_b, count as i64, "redis-co-b: keyspace");
+
+    // Delete ONLY the search result files; keep upload files + the server data.
+    delete_search_result_files(&results_dir);
+
+    // Phase 2: --skip-upload search of both configs against the coexisting indexes.
+    let out2 = Command::new(&bin)
+        .args([
+            "--engines",
+            "redis-co-*",
+            "--datasets",
+            "test-co",
+            "--host",
+            "localhost",
+            "--skip-upload",
+            "--keep-data",
+            "--skip-if-exists",
+            "false",
+        ])
+        .env("REDIS_PORT", &port)
+        .current_dir(&root)
+        .output()
+        .expect("run phase 2");
+    assert!(
+        out2.status.success(),
+        "phase 2 (--skip-upload) failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out2.stdout),
+        String::from_utf8_lossy(&out2.stderr)
+    );
+
+    let rec_a = read_search_mean_recall(&results_dir, "redis-co-a");
+    let rec_b = read_search_mean_recall(&results_dir, "redis-co-b");
+
+    // Each config read its OWN graph → recall equals its single-invocation baseline.
+    assert!(
+        (rec_a - base_a).abs() < 1e-9,
+        "redis-co-a skip-upload recall {} != baseline {}",
+        rec_a,
+        base_a
+    );
+    assert!(
+        (rec_b - base_b).abs() < 1e-9,
+        "redis-co-b skip-upload recall {} != baseline {}",
+        rec_b,
+        base_b
+    );
+    // The two graphs are distinct (pre-fix these would be identical — last writer
+    // wins). The dense high-ef graph out-recalls the sparse low-ef one.
+    assert!(
+        (rec_a - rec_b).abs() > 1e-9,
+        "coexisting configs must have distinct recall: a={} b={}",
+        rec_a,
+        rec_b
+    );
+    assert!(
+        rec_a > rec_b,
+        "dense high-ef graph (a={}) should out-recall the sparse one (b={})",
+        rec_a,
+        rec_b
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+/// #151-4 negative: `--skip-upload` with NO prior upload must FAIL LOUDLY (the
+/// per-search index-existence guard), never silently writing a recall-0.0 file.
+#[test]
+fn test_binary_redis_skip_upload_without_prior_upload_errors() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 16;
+    let count = 100;
+    let top = 5;
+    let (_, vectors) = generate_test_vectors(count, dim);
+    let queries: Vec<Vec<f32>> = vectors[..10].to_vec();
+    let neighbors: Vec<Vec<i64>> = queries
+        .iter()
+        .map(|q| brute_force_neighbors(q, &vectors, top))
+        .collect();
+
+    let engine_config = serde_json::json!([{
+        "name": "redis-noupload",
+        "engine": "redis",
+        "algorithm": "hnsw",
+        "collection_params": { "hnsw_config": { "M": 16, "EF_CONSTRUCTION": 128 } },
+        "search_params": [{ "parallel": 1, "search_params": { "ef": 64 }, "top": top }],
+        "upload_params": { "data_type": "FLOAT32", "parallel": 1, "batch_size": 64 }
+    }]);
+
+    let root = create_test_project(
+        "test-noupload",
+        &serde_json::to_string_pretty(&engine_config).unwrap(),
+        &vectors,
+        &queries,
+        &neighbors,
+        "l2",
+        dim,
+    );
+    let bin = binary_path();
+
+    // --skip-upload against a server with no matching index. exit_on_error defaults
+    // true, so the guard's hard error must fail the process.
+    let out = Command::new(&bin)
+        .args([
+            "--engines",
+            "redis-noupload",
+            "--datasets",
+            "test-noupload",
+            "--host",
+            "localhost",
+            "--skip-upload",
+            "--skip-if-exists",
+            "false",
+        ])
+        .env("REDIS_PORT", TEST_PORT.to_string())
+        .current_dir(&root)
+        .output()
+        .expect("run skip-upload-no-index");
+
+    assert!(
+        !out.status.success(),
+        "--skip-upload with no prior upload must fail loudly, but exited 0"
+    );
+    // And it must NOT have written a recall-0.0 search result file.
+    let wrote_search = fs::read_dir(root.join("results"))
+        .map(|rd| {
+            rd.filter_map(|e| e.ok()).any(|e| {
+                e.file_name().to_string_lossy().contains("redis-noupload-")
+                    && e.file_name().to_string_lossy().contains("-search-")
+            })
+        })
+        .unwrap_or(false);
+    assert!(
+        !wrote_search,
+        "guard must prevent any search result file from being written"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -1051,7 +1051,11 @@ fn test_valkey_sub_batched_pipeline_upload_high_dim() {
         let mut pipe_bytes: usize = 0;
 
         for i in chunk_start..chunk_end {
-            let key = ids[i].to_string();
+            // Mirror the engine's now-prefixed key (#151-4) so this byte-accounting
+            // test's RESP wire-size formula and 4096-byte flush boundaries still
+            // track the real sub-batch flush path (a bare key would silently stop
+            // guarding the changed path).
+            let key = format!("valkey-sb:{}", ids[i]);
             let vec_bytes = vec_to_bytes(&vectors[i]);
 
             // Estimate RESP wire size (same formula as engine code)
@@ -1450,4 +1454,228 @@ fn test_binary_valkey_tenancy() {
             r
         );
     }
+}
+
+/// Count keys under a glob (small test keyspace).
+fn count_keys(conn: &mut Connection, pattern: &str) -> usize {
+    redis::cmd("KEYS")
+        .arg(pattern)
+        .query::<Vec<String>>(conn)
+        .map(|k| k.len())
+        .unwrap_or(0)
+}
+
+/// Delete only `*-search-*.json` result files under `root/results`.
+fn delete_search_result_files(root: &std::path::Path) {
+    let dir = root.join("results");
+    if let Ok(rd) = fs::read_dir(&dir) {
+        for entry in rd.filter_map(|e| e.ok()) {
+            if entry.file_name().to_string_lossy().contains("-search-") {
+                fs::remove_file(entry.path()).ok();
+            }
+        }
+    }
+}
+
+/// #151-4 regression (valkey mirror): "upload all, then --skip-upload search each"
+/// gives every config its OWN graph. Two configs (dense high-ef vs sparse low-ef)
+/// coexist via disjoint `idx:<config>` indexes + `<config>:` keyspaces. Pre-fix
+/// valkey's create_index FLUSHALL + shared `idx` collapsed both to one graph.
+#[test]
+fn test_valkey_coexistence_skip_upload() {
+    wait_for_valkey();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 32;
+    let count = 2000;
+    let top = 10;
+    let (_, vectors) = generate_test_vectors(count, dim);
+    let queries: Vec<Vec<f32>> = vectors[..20].to_vec();
+    let neighbors: Vec<Vec<i64>> = queries
+        .iter()
+        .map(|q| brute_force_neighbors(q, &vectors, top))
+        .collect();
+
+    let engine_config = serde_json::json!([
+        {
+            "name": "valkey-co-a",
+            "engine": "valkey",
+            "algorithm": "hnsw",
+            "collection_params": { "hnsw_config": { "M": 64, "EF_CONSTRUCTION": 200 } },
+            "search_params": [{ "parallel": 1, "search_params": { "ef": 256 }, "top": top }],
+            "upload_params": { "data_type": "FLOAT32", "parallel": 1, "batch_size": 64 }
+        },
+        {
+            "name": "valkey-co-b",
+            "engine": "valkey",
+            "algorithm": "hnsw",
+            "collection_params": { "hnsw_config": { "M": 4, "EF_CONSTRUCTION": 8 } },
+            "search_params": [{ "parallel": 1, "search_params": { "ef": 10 }, "top": top }],
+            "upload_params": { "data_type": "FLOAT32", "parallel": 1, "batch_size": 64 }
+        }
+    ]);
+
+    let root = create_test_project(
+        "valkey-co",
+        &serde_json::to_string_pretty(&engine_config).unwrap(),
+        &vectors,
+        &queries,
+        &neighbors,
+        "l2",
+        dim,
+    );
+    let port = test_port().to_string();
+
+    // Phase 1: upload + search BOTH, KEEPING data for the skip-upload phase.
+    assert!(
+        common::run_binary_extra(
+            &root,
+            "valkey-co-*",
+            "valkey-co",
+            TEST_HOST,
+            &[("VALKEY_PORT", port.as_str())],
+            &["--keep-data"],
+        ),
+        "valkey coexistence phase 1 failed"
+    );
+
+    let base_a = common::read_recall(&root, "valkey-co-a");
+    let base_b = common::read_recall(&root, "valkey-co-b");
+
+    // Deterministic coexistence: `count` keys under EACH per-config prefix, and
+    // both disjoint indexes exist.
+    assert_eq!(
+        count_keys(&mut conn, "valkey-co-a:*"),
+        count,
+        "valkey-co-a keyspace"
+    );
+    assert_eq!(
+        count_keys(&mut conn, "valkey-co-b:*"),
+        count,
+        "valkey-co-b keyspace"
+    );
+    assert!(
+        redis::cmd("FT.INFO")
+            .arg("idx:valkey-co-a")
+            .query::<redis::Value>(&mut conn)
+            .is_ok(),
+        "idx:valkey-co-a must exist"
+    );
+    assert!(
+        redis::cmd("FT.INFO")
+            .arg("idx:valkey-co-b")
+            .query::<redis::Value>(&mut conn)
+            .is_ok(),
+        "idx:valkey-co-b must exist"
+    );
+
+    delete_search_result_files(&root);
+
+    // Phase 2: --skip-upload search of both against the coexisting indexes.
+    assert!(
+        common::run_binary_extra(
+            &root,
+            "valkey-co-*",
+            "valkey-co",
+            TEST_HOST,
+            &[("VALKEY_PORT", port.as_str())],
+            &["--skip-upload", "--keep-data"],
+        ),
+        "valkey coexistence phase 2 (--skip-upload) failed"
+    );
+
+    let rec_a = common::read_recall(&root, "valkey-co-a");
+    let rec_b = common::read_recall(&root, "valkey-co-b");
+
+    assert!(
+        (rec_a - base_a).abs() < 1e-9,
+        "valkey-co-a skip-upload recall {} != baseline {}",
+        rec_a,
+        base_a
+    );
+    assert!(
+        (rec_b - base_b).abs() < 1e-9,
+        "valkey-co-b skip-upload recall {} != baseline {}",
+        rec_b,
+        base_b
+    );
+    assert!(
+        (rec_a - rec_b).abs() > 1e-9,
+        "coexisting configs must have distinct recall: a={} b={}",
+        rec_a,
+        rec_b
+    );
+    assert!(
+        rec_a > rec_b,
+        "dense high-ef graph (a={}) should out-recall the sparse one (b={})",
+        rec_a,
+        rec_b
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+/// #151-4 negative (valkey mirror): `--skip-upload` with NO prior upload must FAIL
+/// LOUDLY (index-existence guard), never writing a recall-0.0 result file.
+#[test]
+fn test_valkey_skip_upload_without_prior_upload_errors() {
+    wait_for_valkey();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 16;
+    let count = 200;
+    let top = 5;
+    let (_, vectors) = generate_test_vectors(count, dim);
+    let queries: Vec<Vec<f32>> = vectors[..10].to_vec();
+    let neighbors: Vec<Vec<i64>> = queries
+        .iter()
+        .map(|q| brute_force_neighbors(q, &vectors, top))
+        .collect();
+
+    let engine_config = serde_json::json!([{
+        "name": "valkey-noupload",
+        "engine": "valkey",
+        "algorithm": "hnsw",
+        "collection_params": { "hnsw_config": { "M": 16, "EF_CONSTRUCTION": 128 } },
+        "search_params": [{ "parallel": 1, "search_params": { "ef": 64 }, "top": top }],
+        "upload_params": { "data_type": "FLOAT32", "parallel": 1, "batch_size": 64 }
+    }]);
+
+    let root = create_test_project(
+        "valkey-noupload",
+        &serde_json::to_string_pretty(&engine_config).unwrap(),
+        &vectors,
+        &queries,
+        &neighbors,
+        "l2",
+        dim,
+    );
+    let port = test_port().to_string();
+
+    let ok = common::run_binary_extra(
+        &root,
+        "valkey-noupload",
+        "valkey-noupload",
+        TEST_HOST,
+        &[("VALKEY_PORT", port.as_str())],
+        &["--skip-upload"],
+    );
+    assert!(
+        !ok,
+        "--skip-upload with no prior upload must fail loudly, but exited 0"
+    );
+    let wrote_search = fs::read_dir(root.join("results"))
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .any(|e| e.file_name().to_string_lossy().contains("-search-"))
+        })
+        .unwrap_or(false);
+    assert!(
+        !wrote_search,
+        "guard must prevent any search result file from being written"
+    );
+
+    fs::remove_dir_all(&root).ok();
 }


### PR DESCRIPTION
Fixes item **#4** of #151 — the silent-wrong-data one.

## The bug
A Redis/Valkey/Dragonfly M×EFC sweep (`redis-m-{16,32,64}-ef-{64,128,256,512}`) followed by `--skip-upload` search collapsed to **one** index → **identical recall across all configs**. Triple collision: fixed index name `"idx"`, bare doc keys (`"0","1",…`), and an empty-`PREFIX` index that covers all keys — plus destructive cleanup (redis `FT.DROPINDEX … DD` on the all-keys index; valkey/dragonfly `FLUSHALL`) that wiped the previous config on every upload.

## The fix — coexistence
Each config gets its own **index name** `<base>:<config>` + **doc-key prefix** `<config>:`, with `FT.CREATE … PREFIX 1 "<config>:"`. Result keys are stripped back to ids on read (`doc_key_to_id`/`doc_key_to_id_opt`, resp2/resp3 split — all 6 engine sites + the PyO3 copy). Cleanup is now **non-destructive** (redis DD scoped by prefix; valkey/dragonfly `SCAN`+`UNLINK` only `<prefix>*`). So *"upload all configs → `--skip-upload` search each"* returns each config's own graph.

Every remaining mismatch is now **loud, not silent**:
- startup hard-error if two configs derive the same namespace;
- per-search `FT.INFO` existence guard → hard-error on a missing index;
- the reps loop now propagates an all-reps-failed error under `exit_on_error` (was swallowed → exit 0, defeating the guard).

Memory is reported per-index from `FT.INFO` (server-wide `used_memory` sums all coexisting configs); RESP3 `Double` size fields now parse. `*_INDEX_NAME` env vars become the base namespace (config always suffixed); `*_INDEX_NAME_EXACT=1` opts out.

## How it was built & validated
- **Design:** a 15-agent adversarial workflow chose coexistence over 3 alternatives and closed 15 attack findings (the make-or-break ones: the resp2/resp3 parser split, per-index memory, and the collision/existence guards).
- **Implementation:** worktree-isolated; the full diff independently adversarially reviewed (no critical bugs; 2 fixes folded in — `exit_on_error` propagation + RESP3 memory parsing).
- **Live-validated on real Redis + Valkey + Dragonfly containers:** coexistence returns **distinct per-config data**, and `--skip-upload` with no prior upload **fails loudly**. **redis 26/26, valkey 20/20, dragonfly 8/8**; 575 unit tests; clippy `-D warnings` + fmt clean on the CI toolchain.

## Behavior notes (README updated)
Per-config prefixing stores N copies of otherwise-identical sweep docs (keyspace ×N — the accepted isolation trade); the two-phase incantation is `upload … --keep-data` then `… --skip-upload --skip-if-exists false`; indexes/keys from a pre-fix binary are incompatible (re-upload — `--skip-upload` against them now hard-errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)