### PR TITLE
fix(reliability): per-search wall-clock watchdog (#151 item 5)

### DIFF
--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -69,6 +69,14 @@ pub struct Args {
     #[arg(long, default_value = "86400.0")]
     pub timeout: f64,
 
+    /// Per-search-point wall-clock watchdog in seconds. A single search/mixed
+    /// call that runs longer than this (e.g. a proxy/connection-pool stall at
+    /// high `parallel`) is aborted with a diagnostic instead of hanging the whole
+    /// sweep silently. Progress is logged while a point is in flight. 0 disables
+    /// (default) — behavior is then unchanged.
+    #[arg(long, default_value = "0.0")]
+    pub search_timeout: f64,
+
     /// Upload start index
     #[arg(long, default_value = "0")]
     pub upload_start_idx: usize,
@@ -188,6 +196,14 @@ mod tests {
         assert_eq!(args.search_duration, 300.0);
         assert_eq!(args.warmup_seconds, 10.0);
         assert_eq!(args.max_lateness_ms, 250.0);
+    }
+
+    // Per-search watchdog (#151-5): opt-in, defaults to 0.0 (disabled) so the
+    // unchanged behavior is preserved, and parses an explicit value.
+    #[test]
+    fn search_timeout_parses() {
+        assert_eq!(parse(&[]).search_timeout, 0.0, "omitted → disabled");
+        assert_eq!(parse(&["--search-timeout", "300"]).search_timeout, 300.0);
     }
 
     // `--describe datasets|engines` is what the docker-build smoke test exercises;

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -27,6 +27,52 @@ fn results_dir() -> PathBuf {
 }
 
 /// Run all matching experiments
+/// Run one search/mixed call under a per-point wall-clock watchdog (#151-5).
+///
+/// `f` executes on the CURRENT thread — so the timed measurement path and its
+/// fidelity are untouched. A monitor thread only watches the clock: it logs
+/// progress every 60s while the point is in flight and, if the point exceeds
+/// `timeout_secs`, prints a diagnostic naming the stuck point and aborts the
+/// process (rather than letting one hung search — e.g. connection-pool
+/// exhaustion at high `parallel` — stall the whole sweep silently). A
+/// `timeout_secs <= 0` disables the watchdog entirely (behavior unchanged).
+fn run_with_search_watchdog<T>(timeout_secs: f64, label: &str, f: impl FnOnce() -> T) -> T {
+    if !timeout_secs.is_finite() || timeout_secs <= 0.0 {
+        return f();
+    }
+    let (tx, rx) = std::sync::mpsc::channel::<()>();
+    let label = label.to_string();
+    let watchdog = std::thread::spawn(move || {
+        let start = Instant::now();
+        loop {
+            match rx.recv_timeout(Duration::from_secs(60)) {
+                // `f` finished (tx dropped) → stop watching promptly.
+                Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    let secs = start.elapsed().as_secs_f64();
+                    if secs >= timeout_secs {
+                        eprintln!(
+                            "\n✗ WATCHDOG: search point '{}' exceeded --search-timeout {:.0}s with no \
+                             result — likely a proxy/connection-pool stall (parallel exceeding server \
+                             capacity). Aborting; reduce parallel or raise --search-timeout.",
+                            label, timeout_secs
+                        );
+                        std::process::exit(3);
+                    }
+                    eprintln!(
+                        "\t⏳ WATCHDOG: '{}' still running after {:.0}s (limit {:.0}s, no result yet)",
+                        label, secs, timeout_secs
+                    );
+                }
+            }
+        }
+    });
+    let result = f();
+    drop(tx); // signals completion; the monitor wakes on Disconnected and exits
+    let _ = watchdog.join();
+    result
+}
+
 pub fn run(args: &Args) -> Result<(), String> {
     println!("vector-db-benchmark v{}", env!("CARGO_PKG_VERSION"));
 
@@ -563,9 +609,10 @@ fn run_single_experiment(
                         "\tOpen-loop warm-up: {:.1} QPS for {:.1}s",
                         args.target_qps, args.warmup_seconds
                     );
-                    engine
-                        .search(dataset, &warmup_params, args.queries)
-                        .map_err(|e| format!("open-loop warm-up failed: {}", e))?;
+                    run_with_search_watchdog(args.search_timeout, "open-loop warm-up", || {
+                        engine.search(dataset, &warmup_params, args.queries)
+                    })
+                    .map_err(|e| format!("open-loop warm-up failed: {}", e))?;
                 } else if args.search_duration > 0.0 && args.warmup_seconds > 0.0 {
                     // Closed-loop-duration warm-up: a discarded search phase so the
                     // measured window sees a warm server for BOTH engines (Vertex
@@ -575,9 +622,10 @@ fn run_single_experiment(
                     warmup_params.duration_seconds = Some(args.warmup_seconds);
                     warmup_params.target_qps = None;
                     println!("\tClosed-loop warm-up: {:.1}s", args.warmup_seconds);
-                    engine
-                        .search(dataset, &warmup_params, args.queries)
-                        .map_err(|e| format!("closed-loop warm-up failed: {}", e))?;
+                    run_with_search_watchdog(args.search_timeout, "closed-loop warm-up", || {
+                        engine.search(dataset, &warmup_params, args.queries)
+                    })
+                    .map_err(|e| format!("closed-loop warm-up failed: {}", e))?;
                 }
 
                 // Run the measured search `repetitions` times and keep the
@@ -617,12 +665,20 @@ fn run_single_experiment(
                     // A window-scoped sample would require the Engine trait to
                     // return the measured-loop CPU, which is deliberately avoided.
                     let cpu_before = crate::proc_cpu::sample();
-                    let search_result = match phase {
-                        Some(ratio) => {
-                            engine.search_mixed(dataset, effective_params, args.queries, ratio)
-                        }
-                        None => engine.search(dataset, effective_params, args.queries),
-                    };
+                    let wd_label = format!(
+                        "{}/{} {}[parallel={}]",
+                        engine.name(),
+                        dataset.config.name,
+                        if phase.is_some() { "mixed" } else { "search" },
+                        effective_params.parallel.unwrap_or(1),
+                    );
+                    let search_result =
+                        run_with_search_watchdog(args.search_timeout, &wd_label, || match phase {
+                            Some(ratio) => {
+                                engine.search_mixed(dataset, effective_params, args.queries, ratio)
+                            }
+                            None => engine.search(dataset, effective_params, args.queries),
+                        });
                     let cpu_after = crate::proc_cpu::sample();
 
                     match search_result {
@@ -1063,7 +1119,37 @@ fn save_upload_results(
 #[cfg(test)]
 mod tests {
     use super::parse_update_search_ratio;
+    use super::run_with_search_watchdog;
     use crate::engine::UpdateSearchRatio;
+
+    // Watchdog disabled (timeout <= 0, non-finite): must run `f` inline on the
+    // current thread and return its value verbatim — the default, unchanged path.
+    #[test]
+    fn watchdog_disabled_runs_inline_and_returns_value() {
+        assert_eq!(run_with_search_watchdog(0.0, "off", || 42), 42);
+        assert_eq!(run_with_search_watchdog(-1.0, "neg", || 7), 7);
+        assert_eq!(run_with_search_watchdog(f64::NAN, "nan", || 5), 5);
+        assert_eq!(
+            run_with_search_watchdog(f64::INFINITY, "inf", || 9),
+            9,
+            "infinite (non-finite) timeout disables rather than never-firing"
+        );
+    }
+
+    // Watchdog enabled but `f` completes well within the limit: the monitor
+    // thread must observe completion (tx drop → Disconnected) and let the call
+    // return the closure's value without aborting.
+    #[test]
+    fn watchdog_enabled_fast_completion_returns_value() {
+        let out = run_with_search_watchdog(30.0, "fast", || {
+            let mut acc = 0u64;
+            for i in 0..1000 {
+                acc += i;
+            }
+            acc
+        });
+        assert_eq!(out, 499_500);
+    }
 
     #[test]
     fn parses_valid_ratio() {


### PR DESCRIPTION
## What

Addresses **item 5** of #151 (Vertex/Redis reliability): a single search/mixed point that stalls — e.g. a proxy or connection-pool exhaustion at high `--parallel` — could hang the whole sweep **silently for ~an hour** with no output, so you couldn't tell a stuck run from a slow one.

## How

Opt-in `--search-timeout <secs>` watchdog:

- `run_with_search_watchdog` runs the search **on the current thread**, so the timed measurement path and its fidelity are untouched. A monitor thread only watches the clock: it logs progress every 60s while a point is in flight, and if the point exceeds the timeout it prints a diagnostic naming the stuck point (`engine/dataset mode[parallel=N]`) and aborts the process (exit 3) instead of hanging.
- Wraps the measured search/mixed call **and** both warm-up calls.
- Default `0.0` **disables** it → behavior unchanged. NaN/inf are treated as disabled.

## Tests

- `watchdog_disabled_runs_inline_and_returns_value` — 0/negative/NaN/inf all run `f` inline and return its value verbatim.
- `watchdog_enabled_fast_completion_returns_value` — monitor observes completion (tx drop) and returns without aborting.
- `search_timeout_parses` — flag defaults to disabled and parses an explicit value.

Full suite green on `cargo +stable` (clippy `-D warnings`, fmt, 496+82 tests).

Refs #151 (item 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)