### PR TITLE
fix(qdrant,mongodb): bool-field filters silently matched nothing (0 recall)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -1058,7 +1058,13 @@ fn build_mongo_filter_entry(entry: &serde_json::Value) -> Option<Document> {
 fn json_to_bson(value: &serde_json::Value) -> mongodb::bson::Bson {
     match value {
         serde_json::Value::Null => mongodb::bson::Bson::Null,
-        serde_json::Value::Bool(b) => mongodb::bson::Bson::Boolean(*b),
+        // Bools are STORED as the string "true"/"false" (metadata_value_to_bson —
+        // readers::metadata has no Bool variant), so a filter bool must compare as
+        // that string. A native Bson::Boolean never equals the stored String and
+        // silently matches zero documents (0 recall). json_to_bson is filter-only.
+        serde_json::Value::Bool(b) => {
+            mongodb::bson::Bson::String(if *b { "true" } else { "false" }.to_string())
+        }
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 mongodb::bson::Bson::Int64(i)
@@ -1797,8 +1803,12 @@ mod tests {
     fn json_to_bson_covers_all_arms() {
         use mongodb::bson::Bson;
         assert_eq!(json_to_bson(&json!(null)), Bson::Null);
-        assert_eq!(json_to_bson(&json!(true)), Bson::Boolean(true));
-        assert_eq!(json_to_bson(&json!(false)), Bson::Boolean(false));
+        // Bools compare as the stored string form, not native Bson::Boolean.
+        assert_eq!(json_to_bson(&json!(true)), Bson::String("true".to_string()));
+        assert_eq!(
+            json_to_bson(&json!(false)),
+            Bson::String("false".to_string())
+        );
         // Integer JSON numbers map to Int64, floats to Double.
         assert_eq!(json_to_bson(&json!(7)), Bson::Int64(7));
         assert_eq!(json_to_bson(&json!(1.5)), Bson::Double(1.5));

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -302,7 +302,11 @@ impl QdrantEngine {
                         "float" => FieldType::Float,
                         "geo" => FieldType::Geo,
                         "uuid" => FieldType::Uuid,
-                        "bool" => FieldType::Bool,
+                        // Bools are stored as the STRING "true"/"false" (readers::metadata
+                        // has no Bool variant), so index them as Keyword — a Bool index
+                        // would index nothing for a string payload and the filter would
+                        // silently match zero points.
+                        "bool" => FieldType::Keyword,
                         "datetime" => FieldType::Datetime,
                         _ => continue,
                     };
@@ -879,7 +883,14 @@ fn build_qdrant_filter(
             if let Some(s) = value.as_str() {
                 Some(Condition::matches(field_name.to_string(), s.to_string()))
             } else if let Some(b) = value.as_bool() {
-                Some(Condition::matches(field_name.to_string(), b))
+                // Bools are stored+indexed as the STRING "true"/"false", so match
+                // the string form. A native boolean Match never matches the string
+                // payload and silently returns zero points (0 recall).
+                let token = if b { "true" } else { "false" };
+                Some(Condition::matches(
+                    field_name.to_string(),
+                    token.to_string(),
+                ))
             } else {
                 value
                     .as_i64()
@@ -1505,8 +1516,22 @@ mod tests {
 
     #[test]
     fn builds_bool_exact_match() {
+        use qdrant_client::qdrant::r#match::MatchValue;
+        // Bools are stored as the string "true"/"false", so the filter must match
+        // the STRING keyword, NOT a native boolean (which matches 0 points).
         let c = build_qdrant_filter("flag", "match", &json!({"value": true})).unwrap();
-        assert!(field_condition(&c).r#match.is_some());
+        let m = field_condition(&c).r#match.expect("match present");
+        assert_eq!(
+            m.match_value,
+            Some(MatchValue::Keyword("true".to_string())),
+            "bool true must match keyword \"true\", not a native boolean"
+        );
+        let c = build_qdrant_filter("flag", "match", &json!({"value": false})).unwrap();
+        let m = field_condition(&c).r#match.expect("match present");
+        assert_eq!(
+            m.match_value,
+            Some(MatchValue::Keyword("false".to_string()))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Found by an adversarial silent-wrong-result audit; **verified end-to-end against live qdrant 1.18 + mongodb-atlas-local 8.0**.

## The bug (silent — no error, ~0 recall)

`MetadataValue` has no `Bool` variant, so `parse_metadata_from_json` stores a JSON `true` as the **string** `"true"`. But Qdrant and MongoDB built a **native boolean** predicate for a bool-field equality filter, which can never match the string payload — so every bool-equality query returned **0 points with no error**, and recall/precision for those queries was silently ~0. This corrupts results on the shipped `synthetic-filter-32` dataset (declares `flag: bool`).

Live proof (same store-as-string the engines do):
```
qdrant  — fixed keyword "true" → ids [1,2] ✓   old native bool true → [] (0 recall)
mongodb — fixed {flag:"true"}  → ids [1,2] ✓   old {flag:true}      → [] (0 recall)
```

## Fix (all-string — matches how redis/vectorsets already store+match bool)

- **qdrant.rs**: index a `bool` schema field as `FieldType::Keyword` (was `Bool` — a Bool index indexes nothing for a string payload), and the exact-match filter emits a keyword match on `"true"`/`"false"` instead of a native boolean.
- **mongodb_engine.rs**: `json_to_bson` (filter-only) maps a JSON bool to `Bson::String("true"/"false")`.

## Validation
- Unit tests updated to assert the string form (`builds_bool_exact_match`, `json_to_bson_covers_all_arms`).
- `cargo +stable` clippy `-D warnings` + fmt clean.
- **integration_qdrant 12/12 + integration_mongodb 11/11 green** (live containers).

## Follow-up (not in this PR)
Milvus has a related bool gap — a `bool` schema field hits `_ => continue` (no column created) while the filter still emits native `flag == true`. Logged for its own verify+fix (needs a live milvus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)