### PR TITLE
fix(readers): warn when a dataset has no ground truth (silent recall=1.0)

### DIFF
--- a/src/readers/jsonl_reader.rs
+++ b/src/readers/jsonl_reader.rs
@@ -97,7 +97,15 @@ pub fn read_jsonl_queries(
         }
         result
     } else {
-        // No ground truth available
+        // No neighbours.jsonl: every query gets an EMPTY ground-truth set, which
+        // compute_metrics scores as a vacuous recall/precision/mrr/ndcg = 1.0.
+        // Warn loudly so a missing ground-truth file is not mistaken for a
+        // perfect-quality run that masks real recall differences between engines.
+        eprintln!(
+            "WARNING: no neighbours.jsonl found for this dataset — ground truth is \
+             empty, so reported recall/precision/mrr/ndcg will be a meaningless 1.0. \
+             Provide neighbours.jsonl to measure real search quality."
+        );
         vec![vec![]; queries.len()]
     };
 


### PR DESCRIPTION
Found by the adversarial silent-wrong-result audit.

## The bug
A JSONL dataset directory with `queries.jsonl` but no `neighbours.jsonl` falls into the reader's "no ground truth" branch, substituting an **empty** truth set per query. `compute_metrics` scores an empty-truth query as a vacuous `recall=precision=mrr=ndcg=1.0`, so the whole run reports **perfect quality with no error** — silently masking real recall differences between engines.

## Fix
Emit a loud `WARNING` when `neighbours.jsonl` is absent, so a missing ground-truth file isn't mistaken for a perfect-quality result. The per-query `1.0` for a genuinely-empty *filtered* truth set is intentional and unchanged.

`cargo +stable` clippy `-D warnings` + fmt clean; jsonl reader tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)