### PR TITLE
fix(es,opensearch): bool + datetime filter fields failed index creation

### DIFF
--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -164,6 +164,14 @@ impl ElasticsearchEngine {
                     let es_type = match ft {
                         "int" => "long",
                         "geo" => "geo_point",
+                        // Bools/datetimes arrive from the reader as strings
+                        // ("true"/"false", ISO-8601); ES coerces those into a
+                        // `boolean` field and parses ISO into a `date` field. The
+                        // canonical schema names them "bool"/"datetime", which are
+                        // NOT valid ES types — forwarding them verbatim made
+                        // index creation reject the whole mapping.
+                        "bool" => "boolean",
+                        "datetime" => "date",
                         other => other,
                     };
                     props.insert(

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -166,6 +166,13 @@ impl OpenSearchEngine {
                     let os_type = match ft {
                         "int" => "long",
                         "geo" => "geo_point",
+                        // "bool"/"datetime" are not valid OS types; map to the real
+                        // ones. OS coerces the reader's "true"/"false" string into a
+                        // `boolean` field and parses ISO-8601 into a `date` field.
+                        // Forwarding them verbatim made index creation reject the
+                        // whole mapping.
+                        "bool" => "boolean",
+                        "datetime" => "date",
                         other => other,
                     };
                     props.insert(

--- a/tests/integration_elasticsearch.rs
+++ b/tests/integration_elasticsearch.rs
@@ -949,6 +949,69 @@ fn test_binary_elasticsearch_match_any() {
     assert!(recall >= 0.9, "es match_any recall {:.3} < 0.9", recall);
 }
 
+/// Bool-field equality filter end-to-end. Regression for the schema-type bug:
+/// the canonical schema names the field "bool", which is NOT a valid ES type —
+/// forwarding it verbatim made index creation reject the whole mapping. With
+/// "bool" -> "boolean" ES coerces the reader's "true"/"false" string and the
+/// `{flag:{match:{value:true}}}` filter selects the even ids.
+#[test]
+fn test_binary_elasticsearch_bool() {
+    wait_for_elasticsearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "es-bool", "engine": "elasticsearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_bool_project("bool-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "es-bool",
+            "bool-test",
+            "127.0.0.1",
+            &[("ELASTIC_PORT", "9201"), ("ELASTIC_INDEX", "bench_bool")],
+        ),
+        "es bool run failed"
+    );
+    let recall = common::read_recall(&proj.root, "es-bool");
+    println!("es bool recall={:.3}", recall);
+    assert!(recall >= 0.9, "es bool recall {:.3} < 0.9", recall);
+}
+
+/// Datetime range filter end-to-end. Regression for the schema-type bug:
+/// "datetime" is not a valid ES type; with "datetime" -> "date" ES parses the
+/// reader's ISO-8601 strings and the `{ts:{range:{gte,lt}}}` ISO bounds select
+/// the [day 100, day 300) window.
+#[test]
+fn test_binary_elasticsearch_datetime() {
+    wait_for_elasticsearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "es-dt", "engine": "elasticsearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_datetime_project("dt-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "es-dt",
+            "dt-test",
+            "127.0.0.1",
+            &[("ELASTIC_PORT", "9201"), ("ELASTIC_INDEX", "bench_dt")],
+        ),
+        "es datetime run failed"
+    );
+    let recall = common::read_recall(&proj.root, "es-dt");
+    println!("es datetime recall={:.3}", recall);
+    assert!(recall >= 0.9, "es datetime recall {:.3} < 0.9", recall);
+}
+
 /// End-to-end full-text filter (#120): the query carries a single
 /// `{"body":{"match":{"text":"quick"}}}` condition and ground truth is
 /// brute-forced over only the docs whose body CONTAINS "quick". Before the fix,

--- a/tests/integration_opensearch.rs
+++ b/tests/integration_opensearch.rs
@@ -732,6 +732,76 @@ fn test_binary_opensearch_match_any() {
     );
 }
 
+/// Bool-field equality filter end-to-end. Regression for the schema-type bug:
+/// "bool" is not a valid OS type; with "bool" -> "boolean" OS coerces the
+/// reader's "true"/"false" string and selects the even ids.
+#[test]
+fn test_binary_opensearch_bool() {
+    wait_for_opensearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "os-bool", "engine": "opensearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_bool_project("bool-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "os-bool",
+            "bool-test",
+            "http://127.0.0.1",
+            &[
+                ("OPENSEARCH_PORT", "9202"),
+                ("OPENSEARCH_INDEX", "bench_bool")
+            ],
+        ),
+        "opensearch bool run failed"
+    );
+    let recall = common::read_recall(&proj.root, "os-bool");
+    println!("opensearch bool recall={:.3}", recall);
+    assert!(recall >= 0.9, "opensearch bool recall {:.3} < 0.9", recall);
+}
+
+/// Datetime range filter end-to-end. Regression for the schema-type bug:
+/// "datetime" is not a valid OS type; with "datetime" -> "date" OS parses the
+/// reader's ISO-8601 strings and selects the [day 100, day 300) window.
+#[test]
+fn test_binary_opensearch_datetime() {
+    wait_for_opensearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "os-dt", "engine": "opensearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_datetime_project("dt-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "os-dt",
+            "dt-test",
+            "http://127.0.0.1",
+            &[
+                ("OPENSEARCH_PORT", "9202"),
+                ("OPENSEARCH_INDEX", "bench_dt")
+            ],
+        ),
+        "opensearch datetime run failed"
+    );
+    let recall = common::read_recall(&proj.root, "os-dt");
+    println!("opensearch datetime recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "opensearch datetime recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// End-to-end full-text filter (#120): the query carries a single
 /// `{"body":{"match":{"text":"quick"}}}` condition and ground truth is
 /// brute-forced over only the docs whose body CONTAINS "quick". Before the fix,


### PR DESCRIPTION
Found by a filter-feature × engine gap analysis (part of the loop to add missing filtering to all competitors).

## The bug
The canonical dataset schema names boolean fields `"bool"` and timestamp fields `"datetime"`, but the ES/OS engines forwarded those names verbatim into the index mapping (`other => other`). Neither is a valid ES/OS type (`boolean` and `date` are), so **`configure()` was rejected for the entire index** — any dataset with a bool or datetime field (e.g. the shipped `synthetic-filter-32`, whose generator emits a bool filter on 25% of queries and a datetime range on another 25%) **could not be benchmarked on ES or OS at all**.

## Fix
Map `"bool" => "boolean"` and `"datetime" => "date"` in both engines' schema type maps. The filter side already forwards a native bool for `{match:{value}}` and ISO-8601 bounds for `{range:{...}}`; ES/OS coerce the reader's `"true"`/`"false"` string into a `boolean` field and parse ISO-8601 into a `date` field, so **no filter change is needed**. This brings ES/OS to bool+datetime parity with redis/valkey/qdrant/mongodb.

## Coverage
New end-to-end regression tests `test_binary_{elasticsearch,opensearch}_{bool,datetime}` — each uploads a bool/datetime field, filters it, and asserts recall ≥ 0.9 against **filtered-brute-force ground truth**.

**Live-validated** on ES 9.x + OS 3.x: all four new tests pass; full suites **ES 19/19, OS 10/10**. `cargo +stable` clippy `-D warnings` + fmt clean.

Part of a series closing per-engine filter gaps; milvus / pgvector / weaviate / vertex bool+datetime + geo/full-text follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)