### PR TITLE
fix(pgvector): support bool + datetime filter fields (were dropped / SQL-broken)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -25,6 +25,11 @@ fn pg_column_type(field_type: &str) -> Option<&'static str> {
         "keyword" | "text" => Some("TEXT"),
         "int" => Some("BIGINT"),
         "float" => Some("DOUBLE PRECISION"),
+        // Bools/datetimes arrive from the reader as strings ("true"/"false",
+        // ISO-8601). COPY-text coerces those into a BOOLEAN column and parses
+        // ISO into a TIMESTAMPTZ column, so a plain scalar column filters fine.
+        "bool" => Some("BOOLEAN"),
+        "datetime" => Some("TIMESTAMPTZ"),
         _ => None,
     }
 }
@@ -795,8 +800,22 @@ fn build_pg_clause(entry: &serde_json::Value, builder: &mut FilterBuilder) -> Op
                             } else if let Some(f) = val.as_f64() {
                                 let ph = builder.bind(PgValue::Float(f));
                                 parts.push(format!("\"{}\" {} {}", field_name, sql_op, ph));
+                            } else if let Some(s) = val.as_str() {
+                                // A string bound is an ISO-8601 datetime range over a
+                                // TIMESTAMPTZ column. Inline as a single-quoted SQL
+                                // literal + cast: binding `$n::timestamptz` makes
+                                // Postgres infer the param type as timestamptz and
+                                // reject a text value ("error serializing parameter").
+                                // Single-quote-escape the benchmark-controlled ISO
+                                // string (was previously inlined bare, i.e. rendered
+                                // with double quotes → a broken SQL identifier).
+                                let esc = s.replace('\'', "''");
+                                parts.push(format!(
+                                    "\"{}\" {} '{}'::timestamptz",
+                                    field_name, sql_op, esc
+                                ));
                             } else {
-                                // Non-numeric range bound (degenerate) — inline.
+                                // Non-scalar range bound (degenerate) — inline.
                                 parts.push(format!("\"{}\" {} {}", field_name, sql_op, val));
                             }
                         }

--- a/tests/integration_pgvector.rs
+++ b/tests/integration_pgvector.rs
@@ -541,6 +541,72 @@ fn test_binary_pgvector_match_any() {
     );
 }
 
+/// Bool-field equality filter end-to-end. Regression for the missing-column bug:
+/// `pg_column_type("bool")` returned None so no column was created and the filter
+/// referenced a non-existent column (SQL error). With a BOOLEAN column, COPY
+/// coerces the reader's "true"/"false" string and `flag = $1` selects the evens.
+#[test]
+fn test_binary_pgvector_bool() {
+    wait_for_postgres();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "pg-bool", "engine": "pgvector",
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_bool_project("bool-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "pg-bool",
+            "bool-test",
+            "127.0.0.1",
+            &[("PGVECTOR_PORT", "5433")]
+        ),
+        "pgvector bool run failed"
+    );
+    let recall = common::read_recall(&proj.root, "pg-bool");
+    println!("pgvector bool recall={:.3}", recall);
+    assert!(recall >= 0.9, "pgvector bool recall {:.3} < 0.9", recall);
+}
+
+/// Datetime range filter end-to-end. Regression for two bugs: no TIMESTAMPTZ
+/// column was created, and the range builder inlined the ISO bound as a bare
+/// (identifier-quoted) token → SQL error. With a TIMESTAMPTZ column and a
+/// `$n::timestamptz` bind, the `[day 100, day 300)` window is selected.
+#[test]
+fn test_binary_pgvector_datetime() {
+    wait_for_postgres();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "pg-dt", "engine": "pgvector",
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_datetime_project("dt-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "pg-dt",
+            "dt-test",
+            "127.0.0.1",
+            &[("PGVECTOR_PORT", "5433")]
+        ),
+        "pgvector datetime run failed"
+    );
+    let recall = common::read_recall(&proj.root, "pg-dt");
+    println!("pgvector datetime recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "pgvector datetime recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// End-to-end `match_any` on a MULTI-VALUED keyword field (`labels`, #88). The
 /// ';'-joined TEXT column is filtered with array-overlap (`match_any`) and set
 /// membership (exact-match); this exercises the full binary path against a live


### PR DESCRIPTION
Part of the per-engine filter-parity series (follows ES/OS #164). Found by the filter-feature gap analysis.

## The bug
`pg_column_type` returned `None` for `"bool"` and `"datetime"`, so neither column was created. The bool filter then referenced a non-existent column (SQL error), and the datetime range **inlined the ISO bound as a bare token** — rendered double-quoted → a broken SQL identifier. Any dataset with a bool/datetime field (e.g. shipped `synthetic-filter-32`) failed on pgvector.

## Fix
- `pg_column_type`: `"bool" => BOOLEAN`, `"datetime" => TIMESTAMPTZ`. COPY-text coerces the reader's `"true"`/`"false"` into `BOOLEAN` and parses ISO-8601 into `TIMESTAMPTZ`.
- Range builder: a string (ISO) bound → single-quoted `'...'::timestamptz` literal (quote-escaped). *Binding* `$n::timestamptz` makes Postgres infer the param as timestamptz and reject a text value (`error serializing parameter`), so a literal is used. The bool filter already binds a native `PgValue::Bool` once the column exists.

## Coverage
New `test_binary_pgvector_{bool,datetime}` — upload the field, filter, assert recall ≥ 0.9 vs filtered-brute-force ground truth. **Live-validated on pgvector pg18** (both pass; full suite **13/13**). clippy `-D warnings` + fmt clean.

Remaining in the series: weaviate, milvus, vertex bool+datetime; then geo + full-text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)