### PR TITLE
fix(weaviate): support bool + datetime filter fields (were dropped)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -414,6 +414,12 @@ fn weaviate_property(field_name: &str, field_type: &str) -> Option<serde_json::V
         "keyword" | "text" => "text",
         "float" => "number",
         "geo" => "geoCoordinates",
+        // Bools become a `boolean` property (upload converts the reader's
+        // "true"/"false" string to a native bool). Datetimes become a `date`
+        // property; Weaviate stores/filters RFC3339 strings, and its gRPC filter
+        // compares date properties via valueText (there is no ValueDate variant).
+        "bool" => "boolean",
+        "datetime" => "date",
         _ => return None,
     };
     let mut prop = serde_json::json!({
@@ -462,6 +468,15 @@ fn coerce_metadata_value(
                 .parse::<f64>()
                 .map(serde_json::Value::from)
                 .unwrap_or_else(|_| serde_json::Value::String(s.clone())),
+            // A `boolean` property needs a native JSON bool, not the "true"/
+            // "false" string the reader produces (Weaviate is strict-typed).
+            Some("bool") => match s.as_str() {
+                "true" => serde_json::Value::Bool(true),
+                "false" => serde_json::Value::Bool(false),
+                _ => serde_json::Value::String(s.clone()),
+            },
+            // `datetime` -> `date` property: keep the RFC3339 string as-is
+            // (Weaviate parses ISO-8601 date strings).
             _ => serde_json::Value::String(s.clone()),
         },
         MetadataValue::Int(n) => serde_json::Value::from(*n),
@@ -1103,6 +1118,10 @@ fn build_weaviate_filter(
             let value_key = |v: &serde_json::Value| -> &str {
                 if v.is_i64() {
                     "valueInt"
+                } else if v.is_string() {
+                    // ISO-8601 datetime bound over a `date` property — Weaviate's
+                    // gRPC filter compares dates via valueText (RFC3339).
+                    "valueText"
                 } else {
                     "valueNumber"
                 }

--- a/tests/integration_weaviate.rs
+++ b/tests/integration_weaviate.rs
@@ -604,6 +604,78 @@ fn test_binary_weaviate_match_any() {
     );
 }
 
+/// Run a filter project on Weaviate over the default gRPC transport, returning
+/// recall. Runs the binary directly so per-query stderr is surfaced.
+fn run_weaviate_filter(root: &std::path::Path, ds_name: &str, class_name: &str) -> f64 {
+    let port = std::env::var("WEAVIATE_HTTP_PORT").unwrap_or_else(|_| WEAVIATE_PORT.to_string());
+    let out = std::process::Command::new(common::binary_path())
+        .args([
+            "--engines",
+            "weaviate-f",
+            "--datasets",
+            ds_name,
+            "--host",
+            WEAVIATE_HOST,
+            "--skip-if-exists",
+            "false",
+        ])
+        .env("WEAVIATE_HTTP_PORT", &port)
+        .env("WEAVIATE_CLASS_NAME", class_name)
+        .current_dir(root)
+        .output()
+        .expect("run vector-db-benchmark");
+    println!(
+        "weaviate {} stdout:\n{}\nstderr:\n{}",
+        ds_name,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(out.status.success(), "weaviate {} run failed", ds_name);
+    common::read_recall(root, "weaviate-f")
+}
+
+fn weaviate_filter_config() -> String {
+    serde_json::json!([{
+        "name": "weaviate-f", "engine": "weaviate",
+        "connection_params": {},
+        "search_params": [{"parallel": 1, "vectorIndexConfig": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }])
+    .to_string()
+}
+
+/// Bool-field equality filter end-to-end. Regression: the `bool` schema type was
+/// dropped (no property created), so the filter matched nothing. Now `bool` ->
+/// `boolean` property, the upload converts the reader's "true"/"false" string to
+/// a native bool, and the gRPC `valueBoolean` filter selects the even ids.
+#[test]
+fn test_binary_weaviate_bool() {
+    wait_for_weaviate();
+    let proj = common::write_bool_project("bool-test", &weaviate_filter_config(), 8);
+    assert!(proj.matching_docs >= proj.top);
+    let recall = run_weaviate_filter(&proj.root, "bool-test", "BenchBool");
+    println!("weaviate bool recall={:.3}", recall);
+    assert!(recall >= 0.9, "weaviate bool recall {:.3} < 0.9", recall);
+}
+
+/// Datetime range filter end-to-end. Regression: `datetime` was dropped and the
+/// range builder only emitted valueInt/valueNumber. Now `datetime` -> `date`
+/// property and the ISO bound is sent as `valueText` (Weaviate compares dates
+/// via RFC3339 text), selecting the [day 100, day 300) window.
+#[test]
+fn test_binary_weaviate_datetime() {
+    wait_for_weaviate();
+    let proj = common::write_datetime_project("dt-test", &weaviate_filter_config(), 8);
+    assert!(proj.matching_docs >= proj.top);
+    let recall = run_weaviate_filter(&proj.root, "dt-test", "BenchDt");
+    println!("weaviate datetime recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "weaviate datetime recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// End-to-end `match_any` on a MULTI-VALUED keyword field (`labels`, #88).
 /// `labels` is declared as a `text[]` array property and each doc stores an
 /// array; the OR-of-`Equal` filter matches per element (Weaviate's `Equal` on


### PR DESCRIPTION
Part of the per-engine filter-parity series (follows ES/OS #164, pgvector #165). Found by the filter-feature gap analysis.

## The bug
The property builder returned `None` for `"bool"` and `"datetime"`, so neither property was created — the filter then matched nothing (bool) or dropped the clause and ran **unfiltered** (datetime range), giving wrong recall on any dataset with a bool/datetime field (e.g. shipped `synthetic-filter-32`).

## Fix (Weaviate is strict-typed via gRPC — three coordinated changes)
- **property**: `"bool" => "boolean"`, `"datetime" => "date"`.
- **upload**: a `boolean` property needs a native JSON bool, so convert the reader's `"true"`/`"false"` string; a `date` property keeps the RFC3339 string.
- **filter**: the datetime range emits its ISO bound as `valueText` — Weaviate's gRPC `Filters` has no `ValueDate`, so date properties are compared via RFC3339 text. The bool match already lowered `value:true` to `valueBoolean`.

## Coverage
New `test_binary_weaviate_{bool,datetime}` — upload the field, filter over gRPC, assert recall ≥ 0.9 vs filtered-brute-force ground truth. **Live-validated on Weaviate 1.38** (both pass; full suite **9/9**). clippy `-D warnings` + fmt clean.

Remaining in the series: milvus, vertex bool+datetime; then geo + full-text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)