### PR TITLE
fix(milvus): support bool + datetime filter fields (were dropped / SQL-broken)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -14,6 +14,7 @@ use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::{Engine, SearchResults, UploadStats};
+use vector_db_benchmark::parsers::datetime_to_epoch_secs;
 use vector_db_benchmark::readers::metadata::{is_multivalued_keyword_field, MetadataItem};
 
 const DEFAULT_COLLECTION: &str = "Benchmark";
@@ -196,6 +197,11 @@ impl MilvusEngine {
                             "int" => "Int64",
                             "keyword" | "text" => "VarChar",
                             "float" => "Double",
+                            // Milvus has a native Bool type. No native date type, so
+                            // datetimes are stored as Int64 epoch seconds (upload +
+                            // filter both convert via datetime_to_epoch_secs).
+                            "bool" => "Bool",
+                            "datetime" => "Int64",
                             _ => continue,
                         };
                         let mut field = serde_json::json!({
@@ -458,7 +464,21 @@ fn insert_batch(
                 // string, or the strict VarChar column rejects the whole batch.
                 let v = v.coerce_for_schema(schema_types.get(k).map(|s| s.as_str()));
                 let val = match v.as_ref() {
-                    MetadataValue::String(s) => serde_json::Value::String(s.clone()),
+                    MetadataValue::String(s) => match schema_types.get(k).map(|t| t.as_str()) {
+                        // Native Bool column needs a JSON bool, not the reader's
+                        // "true"/"false" string.
+                        Some("bool") => match s.as_str() {
+                            "true" => serde_json::Value::Bool(true),
+                            "false" => serde_json::Value::Bool(false),
+                            _ => serde_json::Value::String(s.clone()),
+                        },
+                        // datetime -> Int64 epoch seconds (same conversion the range
+                        // filter uses, so stored and queried values compare exactly).
+                        Some("datetime") => datetime_to_epoch_secs(s)
+                            .map(|e| serde_json::Value::from(e as i64))
+                            .unwrap_or_else(|| serde_json::Value::String(s.clone())),
+                        _ => serde_json::Value::String(s.clone()),
+                    },
                     MetadataValue::Int(n) => serde_json::Value::from(*n),
                     MetadataValue::Float(f) => serde_json::json!(*f),
                     MetadataValue::Labels(labels) => {
@@ -778,24 +798,26 @@ fn build_milvus_filter(
         "range" => {
             let criteria_obj = criteria.as_object()?;
             let mut clauses = Vec::new();
-            if let Some(lt) = criteria_obj.get("lt") {
-                if !lt.is_null() {
-                    clauses.push(format!("{} < {}", field_name, lt));
+            // Render a range bound as a Milvus scalar literal. A numeric bound is
+            // emitted verbatim; a string bound is an ISO-8601 datetime over the
+            // Int64-epoch column, converted with datetime_to_epoch_secs (the same
+            // conversion upload uses). A bound we can't render is dropped.
+            let bound_literal = |v: &serde_json::Value| -> Option<String> {
+                if v.is_number() {
+                    Some(v.to_string())
+                } else if let Some(s) = v.as_str() {
+                    datetime_to_epoch_secs(s).map(|e| (e as i64).to_string())
+                } else {
+                    None
                 }
-            }
-            if let Some(gt) = criteria_obj.get("gt") {
-                if !gt.is_null() {
-                    clauses.push(format!("{} > {}", field_name, gt));
-                }
-            }
-            if let Some(lte) = criteria_obj.get("lte") {
-                if !lte.is_null() {
-                    clauses.push(format!("{} <= {}", field_name, lte));
-                }
-            }
-            if let Some(gte) = criteria_obj.get("gte") {
-                if !gte.is_null() {
-                    clauses.push(format!("{} >= {}", field_name, gte));
+            };
+            for (key, sql_op) in [("lt", "<"), ("gt", ">"), ("lte", "<="), ("gte", ">=")] {
+                if let Some(bound) = criteria_obj.get(key) {
+                    if !bound.is_null() {
+                        if let Some(lit) = bound_literal(bound) {
+                            clauses.push(format!("{} {} {}", field_name, sql_op, lit));
+                        }
+                    }
                 }
             }
             if clauses.is_empty() {

--- a/tests/integration_milvus.rs
+++ b/tests/integration_milvus.rs
@@ -454,6 +454,74 @@ fn test_binary_milvus_match_any() {
     assert!(recall >= 0.9, "milvus match_any recall {:.3} < 0.9", recall);
 }
 
+/// Bool-field equality filter end-to-end. Regression: `"bool"` hit the schema
+/// `_ => continue` arm so no column was created, while the filter emitted a
+/// native `flag == true` against the missing column. Now `bool` -> native Bool
+/// column (upload converts the reader's "true"/"false" string to a JSON bool).
+#[test]
+fn test_binary_milvus_bool() {
+    wait_for_milvus();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "milvus-bool", "engine": "milvus",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100, "index_params": {"M": 16, "efConstruction": 200}}
+    }]);
+    let proj =
+        common::write_bool_project("bool-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "milvus-bool",
+            "bool-test",
+            "127.0.0.1",
+            &[
+                ("MILVUS_PORT", "19531"),
+                ("MILVUS_COLLECTION_NAME", "bench_bool")
+            ],
+        ),
+        "milvus bool run failed"
+    );
+    let recall = common::read_recall(&proj.root, "milvus-bool");
+    println!("milvus bool recall={:.3}", recall);
+    assert!(recall >= 0.9, "milvus bool recall {:.3} < 0.9", recall);
+}
+
+/// Datetime range filter end-to-end. Regression: `"datetime"` was dropped from
+/// the schema and the range builder inlined the quoted ISO string. Now
+/// `datetime` -> Int64 epoch column; upload and the range filter both convert
+/// ISO-8601 to epoch seconds, so the `[day 100, day 300)` window is selected.
+#[test]
+fn test_binary_milvus_datetime() {
+    wait_for_milvus();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "milvus-dt", "engine": "milvus",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100, "index_params": {"M": 16, "efConstruction": 200}}
+    }]);
+    let proj =
+        common::write_datetime_project("dt-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "milvus-dt",
+            "dt-test",
+            "127.0.0.1",
+            &[
+                ("MILVUS_PORT", "19531"),
+                ("MILVUS_COLLECTION_NAME", "bench_dt")
+            ],
+        ),
+        "milvus datetime run failed"
+    );
+    let recall = common::read_recall(&proj.root, "milvus-dt");
+    println!("milvus datetime recall={:.3}", recall);
+    assert!(recall >= 0.9, "milvus datetime recall {:.3} < 0.9", recall);
+}
+
 /// End-to-end `match_any` on a MULTI-VALUED keyword field (`labels`, #88).
 /// Milvus stores it as an Array(VarChar) and filters with
 /// `array_contains_any`; before the fix it was a comma-joined VarChar tested


### PR DESCRIPTION
Part of the per-engine filter-parity series (ES/OS #164, pgvector #165, weaviate #166). Found by the filter-feature gap analysis.

## The bug
The schema map's `_ => continue` dropped `"bool"` and `"datetime"` fields, so no column was created — the bool filter emitted a native `flag == true` against a missing column, and the datetime range inlined the quoted ISO string. Any dataset with a bool/datetime field (e.g. shipped `synthetic-filter-32`) got wrong recall on Milvus.

## Fix
- **schema**: `"bool" => Bool` (Milvus native), `"datetime" => Int64` (epoch seconds — Milvus has no native date type).
- **upload**: convert the reader's `"true"`/`"false"` to a native JSON bool for the Bool column; convert ISO-8601 → epoch seconds (`datetime_to_epoch_secs`) for the Int64 column.
- **range filter**: a string (ISO) bound is converted to epoch via the **same** helper, so stored and queried datetimes compare exactly; the four bounds were refactored to a table + shared literal renderer. The bool match already emits `flag == true`.

## Coverage
New `test_binary_milvus_{bool,datetime}` — upload, filter, assert recall ≥ 0.9 vs filtered-brute-force ground truth. **Live-validated on Milvus 2.6** (both pass; full suite **8/8**). clippy `-D warnings` + fmt clean.

Remaining in the series: vertex bool+datetime (needs a live GCP run); then geo + full-text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)