### PR TITLE
feat(pgvector): full-text filter support (was silently dropped -> unfiltered)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -779,6 +779,17 @@ fn build_pg_clause(entry: &serde_json::Value, builder: &mut FilterBuilder) -> Op
                             // As the sole condition this leaves `parts` empty →
                             // the builder returns None.
                         }
+                    } else if let Some(text) = criteria.get("text").and_then(|v| v.as_str()) {
+                        // Full-text match: a `{match:{text}}` clause over a TEXT
+                        // column. Postgres FTS token containment via
+                        // `to_tsvector(col) @@ plainto_tsquery(term)`. Dropping the
+                        // clause would run the kNN query UNFILTERED while recall is
+                        // scored against the filtered ground truth.
+                        let ph = builder.bind(PgValue::Text(text.to_string()));
+                        parts.push(format!(
+                            "to_tsvector('english', \"{}\") @@ plainto_tsquery('english', {})",
+                            field_name, ph
+                        ));
                     }
                 }
                 "range" => {

--- a/tests/integration_pgvector.rs
+++ b/tests/integration_pgvector.rs
@@ -607,6 +607,42 @@ fn test_binary_pgvector_datetime() {
     );
 }
 
+/// Full-text filter end-to-end. Regression: a `{match:{text}}` clause was dropped
+/// (the match arm only handled `value`/`any`), so the kNN query ran UNFILTERED
+/// while recall was scored against the filtered ground truth. Now the TEXT column
+/// is filtered with Postgres FTS (`to_tsvector @@ plainto_tsquery`), selecting the
+/// docs whose body contains the query token.
+#[test]
+fn test_binary_pgvector_fulltext() {
+    wait_for_postgres();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "pg-ft", "engine": "pgvector",
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_fulltext_project("ft-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "pg-ft",
+            "ft-test",
+            "127.0.0.1",
+            &[("PGVECTOR_PORT", "5433")]
+        ),
+        "pgvector fulltext run failed"
+    );
+    let recall = common::read_recall(&proj.root, "pg-ft");
+    println!("pgvector fulltext recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "pgvector fulltext recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// End-to-end `match_any` on a MULTI-VALUED keyword field (`labels`, #88). The
 /// ';'-joined TEXT column is filtered with array-overlap (`match_any`) and set
 /// membership (exact-match); this exercises the full binary path against a live


### PR DESCRIPTION
Part of the filter-parity series. Found by the filter-feature gap analysis.

## The bug (silent-wrong)
A `{match:{text}}` full-text clause was **dropped** by pgvector's match arm (it only handled `value`/`any`), so a full-text-filtered kNN query ran **unfiltered** while recall was scored against the filtered ground truth.

## Fix
Add a full-text branch filtering the `TEXT` column with Postgres FTS: `to_tsvector('english', "col") @@ plainto_tsquery('english', $n)` (token parameterized). Brings pgvector to full-text parity with redis/qdrant/es/os.

## Coverage
New `test_binary_pgvector_fulltext` using the shared `write_fulltext_project` fixture (docs contain "quick" iff id even; query `{body:{match:{text:"quick"}}}`), asserting recall ≥ 0.9 vs filtered-brute-force ground truth. **Live-validated on pgvector pg18** (passes; full suite **14/14**). clippy `-D warnings` + fmt clean.

Full-text still missing on milvus / weaviate / mongodb / turbopuffer — follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)