### PR TITLE
feat(weaviate): full-text filter support (was silently dropped -> unfiltered)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -1095,6 +1095,20 @@ fn build_weaviate_filter(
                 });
             }
 
+            // Full-text match: `{match:{text}}` over a word-tokenized `text`
+            // property. Weaviate `Equal` on a token matches objects whose property
+            // CONTAINS that token (verified: Equal "quick" matches "the quick brown
+            // fox"), so route it to the same Equal path. Dropping the clause would
+            // run the kNN query UNFILTERED while recall is scored against filtered
+            // ground truth.
+            if let Some(text) = criteria.get("text").and_then(|v| v.as_str()) {
+                return Some(serde_json::json!({
+                    "path": [field_name],
+                    "operator": "Equal",
+                    "valueText": text,
+                }));
+            }
+
             let value = criteria.get("value")?;
             // Guard non-scalar: an array/object/null under `value` is malformed
             // input — the canonical model uses `match.any` for lists. Without

--- a/tests/integration_weaviate.rs
+++ b/tests/integration_weaviate.rs
@@ -676,6 +676,24 @@ fn test_binary_weaviate_datetime() {
     );
 }
 
+/// Full-text filter end-to-end. Regression: a `{match:{text}}` clause was dropped
+/// (the match arm required a `value` key), so the kNN ran UNFILTERED. Now `text`
+/// routes to `Equal valueText` on the word-tokenized `text` property, which
+/// matches objects containing the token (`Equal "quick"` -> "the quick brown fox").
+#[test]
+fn test_binary_weaviate_fulltext() {
+    wait_for_weaviate();
+    let proj = common::write_fulltext_project("ft-test", &weaviate_filter_config(), 8);
+    assert!(proj.matching_docs >= proj.top);
+    let recall = run_weaviate_filter(&proj.root, "ft-test", "BenchFt");
+    println!("weaviate fulltext recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "weaviate fulltext recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// End-to-end `match_any` on a MULTI-VALUED keyword field (`labels`, #88).
 /// `labels` is declared as a `text[]` array property and each doc stores an
 /// array; the OR-of-`Equal` filter matches per element (Weaviate's `Equal` on


### PR DESCRIPTION
Part of the filter-parity series (follows pgvector full-text #168). Found by the gap analysis.

## The bug (silent-wrong)
A `{match:{text}}` clause was dropped by weaviate's match arm (it required a `value` key), so a full-text-filtered kNN ran **unfiltered** while recall was scored against filtered ground truth.

## Fix
Route `{match:{text}}` to `Equal valueText(token)` on the word-tokenized `text` property. Weaviate `Equal` on a token matches objects whose property **contains** that token (verified live: `Equal "quick"` → "the quick brown fox"), so it's correct token-containment full-text over both gRPC (`ValueText`) and GraphQL. Brings weaviate to full-text parity with redis/qdrant/es/os/pgvector.

## Coverage
New `test_binary_weaviate_fulltext` using the shared `write_fulltext_project` fixture, recall ≥ 0.9 vs filtered-brute-force ground truth. **Live-validated on Weaviate 1.38** (passes; full suite **10/10**). clippy `-D warnings` + fmt clean.

Full-text still missing on milvus (TEXT_MATCH) / mongodb (Atlas filter has no `$text` — bigger lift) / turbopuffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)