### PR TITLE
feat(milvus): full-text filter support (was silently dropped -> unfiltered)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -209,10 +209,18 @@ impl MilvusEngine {
                             "dataType": milvus_type,
                         });
                         if milvus_type == "VarChar" {
-                            field.as_object_mut().unwrap().insert(
-                                "elementTypeParams".to_string(),
-                                serde_json::json!({"max_length": "500"}),
-                            );
+                            let mut params = serde_json::json!({"max_length": "500"});
+                            if ft == "text" {
+                                // Enable the analyzer + match inverted index so
+                                // TEXT_MATCH full-text filtering works on this field.
+                                let p = params.as_object_mut().unwrap();
+                                p.insert("enable_analyzer".to_string(), serde_json::json!(true));
+                                p.insert("enable_match".to_string(), serde_json::json!(true));
+                            }
+                            field
+                                .as_object_mut()
+                                .unwrap()
+                                .insert("elementTypeParams".to_string(), params);
                         }
                         field
                     };
@@ -772,6 +780,18 @@ fn build_milvus_filter(
                     ));
                 }
                 return Some(format!("{} in [{}]", field_name, items.join(", ")));
+            }
+            // Full-text: `{match:{text}}` -> Milvus TEXT_MATCH over an
+            // analyzer-enabled VarChar field (schema creation sets
+            // enable_analyzer/enable_match for `text` fields). Matches rows whose
+            // analyzed field CONTAINS the token; dropping the clause would run the
+            // search UNFILTERED while recall is scored against filtered truth.
+            if let Some(text) = criteria.get("text").and_then(|v| v.as_str()) {
+                return Some(format!(
+                    "TEXT_MATCH({}, {})",
+                    field_name,
+                    quote_milvus_string(text)
+                ));
             }
             let value = criteria.get("value")?;
             if let Some(s) = value.as_str() {

--- a/tests/integration_milvus.rs
+++ b/tests/integration_milvus.rs
@@ -522,6 +522,40 @@ fn test_binary_milvus_datetime() {
     assert!(recall >= 0.9, "milvus datetime recall {:.3} < 0.9", recall);
 }
 
+/// Full-text filter end-to-end. Regression: a `{match:{text}}` clause was dropped
+/// (the match arm required `value`/`any`), so the search ran UNFILTERED. Now the
+/// `text` VarChar column is created with enable_analyzer/enable_match and the
+/// filter uses `TEXT_MATCH(body, 'quick')`, selecting docs containing the token.
+#[test]
+fn test_binary_milvus_fulltext() {
+    wait_for_milvus();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "milvus-ft", "engine": "milvus",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100, "index_params": {"M": 16, "efConstruction": 200}}
+    }]);
+    let proj =
+        common::write_fulltext_project("ft-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "milvus-ft",
+            "ft-test",
+            "127.0.0.1",
+            &[
+                ("MILVUS_PORT", "19531"),
+                ("MILVUS_COLLECTION_NAME", "bench_ft")
+            ],
+        ),
+        "milvus fulltext run failed"
+    );
+    let recall = common::read_recall(&proj.root, "milvus-ft");
+    println!("milvus fulltext recall={:.3}", recall);
+    assert!(recall >= 0.9, "milvus fulltext recall {:.3} < 0.9", recall);
+}
+
 /// End-to-end `match_any` on a MULTI-VALUED keyword field (`labels`, #88).
 /// Milvus stores it as an Array(VarChar) and filters with
 /// `array_contains_any`; before the fix it was a comma-joined VarChar tested


### PR DESCRIPTION
Part of the filter-parity series (follows pgvector #168, weaviate #169). Found by the gap analysis.

## The bug (silent-wrong)
A `{match:{text}}` clause was dropped by milvus's match arm (required `value`/`any`), so a full-text-filtered search ran **unfiltered** while recall was scored against filtered ground truth.

## Fix
- **schema**: a `text` VarChar field is now created with `enable_analyzer` + `enable_match`, building the analyzer + match inverted index Milvus `TEXT_MATCH` needs. Keyword VarChar fields are unchanged (plain exact match).
- **filter**: `{match:{text}}` → `TEXT_MATCH(field, 'token')`, matching rows whose analyzed field contains the token. Brings milvus to full-text parity with redis/qdrant/es/os/pgvector/weaviate.

## Coverage
New `test_binary_milvus_fulltext` using the shared `write_fulltext_project` fixture, recall ≥ 0.9 vs filtered-brute-force ground truth. **Live-validated on Milvus 2.6** (passes; full suite **9/9**). clippy `-D warnings` + fmt clean.

Full-text remaining: mongodb (Atlas `$vectorSearch` filter has no `$text` — needs Atlas Search + hybrid, a larger design), turbopuffer (cloud-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)