### PR TITLE
test(geo): add geo-radius fixture + coverage for redis/es/os/weaviate

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -771,6 +771,53 @@ pub fn write_datetime_project(
     )
 }
 
+/// Great-circle distance in metres (haversine, R=6_371_000 m). Used to
+/// brute-force geo-radius ground truth. The ~55 m margin baked into
+/// [`write_geo_project`] keeps every doc clearly inside or outside the radius
+/// despite tiny differences vs each engine's own earth model.
+fn haversine_m(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
+    const R: f64 = 6_371_000.0;
+    let (p1, p2) = (lat1.to_radians(), lat2.to_radians());
+    let dphi = (lat2 - lat1).to_radians();
+    let dlambda = (lon2 - lon1).to_radians();
+    let a = (dphi / 2.0).sin().powi(2) + p1.cos() * p2.cos() * (dlambda / 2.0).sin().powi(2);
+    2.0 * R * a.sqrt().asin()
+}
+
+/// geo-radius filter: field `location` (schema `geo`), one point per doc along a
+/// meridian ~111 m apart from (lat 40.0, lon -74.0). The query is a radius around
+/// doc 0's location selecting the nearest ~198 docs; ground truth is brute-forced
+/// with [`haversine_m`]. The reader parses geo as `{"lon":..,"lat":..}`; the
+/// query condition is `{geo:{lat,lon,radius}}` with radius in METERS.
+pub fn write_geo_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+) -> FilterProject {
+    let (lat0, lon0) = (40.0_f64, -74.0_f64);
+    let loc = |id: usize| (lat0 + id as f64 * 0.001, lon0);
+    // ~111 m per 0.001 deg latitude; 22 km ≈ the nearest 198 docs, and the
+    // radius falls ~55 m between doc 197 (inside) and doc 198 (outside).
+    let radius = 22_000.0_f64;
+    let (q_lat, q_lon) = loc(0);
+    write_filter_project(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        GtMetric::L2,
+        serde_json::json!({ "location": "geo" }),
+        move |id| {
+            let (lat, lon) = loc(id);
+            serde_json::json!({ "location": { "lon": lon, "lat": lat } })
+        },
+        serde_json::json!({ "and": [ { "location": { "geo": { "lat": q_lat, "lon": q_lon, "radius": radius } } } ] }),
+        move |id| {
+            let (lat, lon) = loc(id);
+            haversine_m(lat, lon, q_lat, q_lon) <= radius
+        },
+    )
+}
+
 // ── Multi-tenancy fixture ───────────────────────────────────────────────────
 //
 // Mirrors upstream qdrant/vector-db-benchmark's `random-768-*-tenants` scenario:

--- a/tests/integration_elasticsearch.rs
+++ b/tests/integration_elasticsearch.rs
@@ -1012,6 +1012,35 @@ fn test_binary_elasticsearch_datetime() {
     assert!(recall >= 0.9, "es datetime recall {:.3} < 0.9", recall);
 }
 
+/// Geo-radius filter end-to-end (previously untested for ES). `geo` -> geo_point
+/// mapping + `geo_distance` query; recall vs haversine ground truth.
+#[test]
+fn test_binary_elasticsearch_geo() {
+    wait_for_elasticsearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "es-geo", "engine": "elasticsearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_geo_project("geo-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "es-geo",
+            "geo-test",
+            "127.0.0.1",
+            &[("ELASTIC_PORT", "9201"), ("ELASTIC_INDEX", "bench_geo")],
+        ),
+        "es geo run failed"
+    );
+    let recall = common::read_recall(&proj.root, "es-geo");
+    println!("es geo recall={:.3}", recall);
+    assert!(recall >= 0.9, "es geo recall {:.3} < 0.9", recall);
+}
+
 /// End-to-end full-text filter (#120): the query carries a single
 /// `{"body":{"match":{"text":"quick"}}}` condition and ground truth is
 /// brute-forced over only the docs whose body CONTAINS "quick". Before the fix,

--- a/tests/integration_opensearch.rs
+++ b/tests/integration_opensearch.rs
@@ -802,6 +802,38 @@ fn test_binary_opensearch_datetime() {
     );
 }
 
+/// Geo-radius filter end-to-end (previously untested for OS). `geo` -> geo_point
+/// mapping + `geo_distance` query; recall vs haversine ground truth.
+#[test]
+fn test_binary_opensearch_geo() {
+    wait_for_opensearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "os-geo", "engine": "opensearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_geo_project("geo-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "os-geo",
+            "geo-test",
+            "http://127.0.0.1",
+            &[
+                ("OPENSEARCH_PORT", "9202"),
+                ("OPENSEARCH_INDEX", "bench_geo")
+            ],
+        ),
+        "opensearch geo run failed"
+    );
+    let recall = common::read_recall(&proj.root, "os-geo");
+    println!("opensearch geo recall={:.3}", recall);
+    assert!(recall >= 0.9, "opensearch geo recall {:.3} < 0.9", recall);
+}
+
 /// End-to-end full-text filter (#120): the query carries a single
 /// `{"body":{"match":{"text":"quick"}}}` condition and ground truth is
 /// brute-forced over only the docs whose body CONTAINS "quick". Before the fix,

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -2275,6 +2275,14 @@ fn test_binary_redis_datetime() {
     run_filter_recall_test("redis-dt", "dt-test", common::write_datetime_project);
 }
 
+/// Geo-radius filter: points along a meridian, query a radius selecting the
+/// nearest ~198. Exercises RediSearch's `@location:[lon lat radius m]` GEO filter
+/// against haversine ground truth (new fixture — geo was previously untested).
+#[test]
+fn test_binary_redis_geo() {
+    run_filter_recall_test("redis-geo", "geo-test", common::write_geo_project);
+}
+
 /// Multi-tenancy: many tenants share ONE index and every query is scoped to a
 /// single tenant via a keyword-equality filter on a `tenant` field, with ground
 /// truth brute-forced over ONLY that tenant's docs. Reuses the keyword-TAG

--- a/tests/integration_weaviate.rs
+++ b/tests/integration_weaviate.rs
@@ -676,6 +676,18 @@ fn test_binary_weaviate_datetime() {
     );
 }
 
+/// Geo-radius filter end-to-end (previously untested for Weaviate). `geo` ->
+/// geoCoordinates property + `WithinGeoRange`; recall vs haversine ground truth.
+#[test]
+fn test_binary_weaviate_geo() {
+    wait_for_weaviate();
+    let proj = common::write_geo_project("geo-test", &weaviate_filter_config(), 8);
+    assert!(proj.matching_docs >= proj.top);
+    let recall = run_weaviate_filter(&proj.root, "geo-test", "BenchGeo");
+    println!("weaviate geo recall={:.3}", recall);
+    assert!(recall >= 0.9, "weaviate geo recall {:.3} < 0.9", recall);
+}
+
 /// Full-text filter end-to-end. Regression: a `{match:{text}}` clause was dropped
 /// (the match arm required a `value` key), so the kNN ran UNFILTERED. Now `text`
 /// routes to `Equal valueText` on the word-tokenized `text` property, which


### PR DESCRIPTION
Geo-radius filtering was supported by several engines but had **no test coverage** (no fixture/dataset existed), so a regression could silently break it. Found while auditing filter parity.

## What
A shared `write_geo_project` fixture: points along a meridian ~111 m apart, a query radius selecting the nearest ~198 docs, and **haversine-brute-forced ground truth** (new `haversine_m`, R=6.371e6 m, ~55 m margin so no doc sits on the radius boundary vs each engine's own earth model). Reader parses geo as `{"lon":..,"lat":..}`; query condition `{geo:{lat,lon,radius}}` (meters).

New end-to-end tests assert recall ≥ 0.9 for the engines that already support geo:
- **redis** (`@location:[lon lat radius m]`)
- **elasticsearch / opensearch** (`geo_point` + `geo_distance`)
- **weaviate** (`geoCoordinates` + `WithinGeoRange`)

**Live-validated on all four** (redis 8.8, ES 9.x, OS 3.x, weaviate 1.38 — all pass). clippy `-D warnings` + fmt clean.

Follow-ups: geo test for qdrant; geo **support** for pgvector (earthdistance) and milvus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)