### PR TITLE
feat(pgvector): geo-radius filter support (was dropped -> unfiltered)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -30,6 +30,10 @@ fn pg_column_type(field_type: &str) -> Option<&'static str> {
         // ISO into a TIMESTAMPTZ column, so a plain scalar column filters fine.
         "bool" => Some("BOOLEAN"),
         "datetime" => Some("TIMESTAMPTZ"),
+        // Geo point stored as a "lat,lon" TEXT scalar; filtered with the
+        // earthdistance extension (great-circle metres). A dedicated earth/cube
+        // column would need binary COPY, so the text form keeps the COPY path.
+        "geo" => Some("TEXT"),
         _ => None,
     }
 }
@@ -53,7 +57,9 @@ fn copy_field(meta: Option<&MetadataItem>, column: &str) -> String {
         Some(MetadataValue::Int(n)) => n.to_string(),
         Some(MetadataValue::Float(f)) => f.to_string(),
         Some(MetadataValue::Labels(labels)) => escape_copy_text(&labels.join(";")),
-        // geo / missing → NULL (geo isn't a scalar filter column here)
+        // Geo point -> "lat,lon" TEXT (earthdistance filter splits it back out).
+        Some(MetadataValue::Geo { lon, lat }) => escape_copy_text(&format!("{},{}", lat, lon)),
+        // missing → NULL
         _ => "\\N".to_string(),
     }
 }
@@ -182,6 +188,10 @@ impl Engine for PgVectorEngine {
         println!("Creating vector extension...");
         conn.execute("CREATE EXTENSION IF NOT EXISTS vector", &[])
             .map_err(|e| format!("Failed to create vector extension: {}", e))?;
+        // cube + earthdistance back the geo-radius filter (great-circle metres).
+        // Best-effort: only needed when a dataset has a geo field.
+        let _ = conn.execute("CREATE EXTENSION IF NOT EXISTS cube", &[]);
+        let _ = conn.execute("CREATE EXTENSION IF NOT EXISTS earthdistance", &[]);
 
         // Drop existing table
         println!("Dropping existing items table...");
@@ -832,6 +842,26 @@ fn build_pg_clause(entry: &serde_json::Value, builder: &mut FilterBuilder) -> Op
                         }
                     }
                 }
+                "geo" => {
+                    // Geo-radius over the "lat,lon" TEXT column via earthdistance
+                    // (great-circle metres). lat/lon/radius are dataset numbers
+                    // (not injectable), so inline them; the stored point is split
+                    // back into (lat, lon) for ll_to_earth.
+                    if let (Some(lat), Some(lon), Some(radius)) = (
+                        criteria.get("lat").and_then(|v| v.as_f64()),
+                        criteria.get("lon").and_then(|v| v.as_f64()),
+                        criteria.get("radius").and_then(|v| v.as_f64()),
+                    ) {
+                        parts.push(format!(
+                            "earth_distance(ll_to_earth(split_part(\"{f}\", ',', 1)::float8, \
+                             split_part(\"{f}\", ',', 2)::float8), ll_to_earth({lat}, {lon})) <= {radius}",
+                            f = field_name,
+                            lat = lat,
+                            lon = lon,
+                            radius = radius
+                        ));
+                    }
+                }
                 _ => {}
             }
         }
@@ -1136,11 +1166,15 @@ mod tests {
     // ── Geo filter (unsupported → None) ────────────────────────────────────
 
     #[test]
-    fn geo_is_unsupported_returns_none() {
-        // pgvector filters on scalar columns only; geo has no clause arm, so the
-        // filter is dropped. Assert None so an accidental future change is caught.
+    fn geo_builds_earthdistance_clause() {
+        // Geo-radius is filtered via earthdistance over the "lat,lon" TEXT column:
+        // earth_distance(ll_to_earth(lat, lon), ll_to_earth(qlat, qlon)) <= radius.
         let cond = json!({"and":[{"loc":{"geo":{"lat":20.0,"lon":10.0,"radius":5}}}]});
-        assert!(parse(&cond).is_none());
+        let (sql, binds) = parse(&cond).expect("geo clause should be built");
+        assert!(sql.contains("earth_distance"), "sql: {sql}");
+        assert!(sql.contains("ll_to_earth(20"), "query point inlined: {sql}");
+        assert!(sql.contains("<= 5"), "radius inlined: {sql}");
+        assert!(binds.is_empty(), "geo inlines its numeric args, no binds");
     }
 
     // ── Distance-metric mapping ────────────────────────────────────────────

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -893,7 +893,11 @@ mod tests {
         assert_eq!(pg_column_type("text"), Some("TEXT"));
         assert_eq!(pg_column_type("int"), Some("BIGINT"));
         assert_eq!(pg_column_type("float"), Some("DOUBLE PRECISION"));
-        assert_eq!(pg_column_type("geo"), None);
+        assert_eq!(pg_column_type("bool"), Some("BOOLEAN"));
+        assert_eq!(pg_column_type("datetime"), Some("TIMESTAMPTZ"));
+        // Geo is now stored as a "lat,lon" TEXT scalar (earthdistance filter).
+        assert_eq!(pg_column_type("geo"), Some("TEXT"));
+        assert_eq!(pg_column_type("unknown"), None);
     }
 
     #[test]

--- a/tests/integration_pgvector.rs
+++ b/tests/integration_pgvector.rs
@@ -643,6 +643,38 @@ fn test_binary_pgvector_fulltext() {
     );
 }
 
+/// Geo-radius filter end-to-end. Regression: `geo` had no column type and no
+/// filter arm, so it was dropped and the search ran unfiltered. Now the point is
+/// stored as a "lat,lon" TEXT scalar and filtered with the earthdistance
+/// extension (`earth_distance(ll_to_earth(...)) <= radius`), selecting the docs
+/// within the query radius.
+#[test]
+fn test_binary_pgvector_geo() {
+    wait_for_postgres();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "pg-geo", "engine": "pgvector",
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_geo_project("geo-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "pg-geo",
+            "geo-test",
+            "127.0.0.1",
+            &[("PGVECTOR_PORT", "5433")]
+        ),
+        "pgvector geo run failed"
+    );
+    let recall = common::read_recall(&proj.root, "pg-geo");
+    println!("pgvector geo recall={:.3}", recall);
+    assert!(recall >= 0.9, "pgvector geo recall {:.3} < 0.9", recall);
+}
+
 /// End-to-end `match_any` on a MULTI-VALUED keyword field (`labels`, #88). The
 /// ';'-joined TEXT column is filtered with array-overlap (`match_any`) and set
 /// membership (exact-match); this exercises the full binary path against a live


### PR DESCRIPTION
Part of the filter-parity series (follows the geo fixture/coverage #171). Adds a **missing** filter feature.

## The bug (silent-wrong)
A `{geo:{lat,lon,radius}}` clause had no column type and no filter arm, so the geo field was dropped on upload and the geo-filtered search ran **unfiltered** while recall was scored against filtered ground truth.

## Fix (earthdistance)
- `pg_column_type("geo")` → `TEXT`: the point is stored as a `"lat,lon"` scalar (a dedicated cube/earth column would need binary COPY; text keeps the COPY path).
- `copy_field`: `MetadataValue::Geo` → `"lat,lon"`.
- `create_index`: also `CREATE EXTENSION cube + earthdistance` (best-effort).
- filter: `earth_distance(ll_to_earth(split_part(col,',',1), split_part(col,',',2)), ll_to_earth(qlat, qlon)) <= radius` (great-circle metres; lat/lon/radius inlined dataset numbers). Brings pgvector to geo parity with redis/qdrant/es/os/weaviate.

## Coverage
Unit test `geo_builds_earthdistance_clause` + end-to-end `test_binary_pgvector_geo` (shared `write_geo_project` fixture), recall ≥ 0.9 vs haversine ground truth. **Live-validated on pgvector pg18** (passes; full suite **15/15**). clippy `-D warnings` + fmt clean.

Geo remaining: qdrant test (add); milvus geo support (investigate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)