### PR TITLE
feat(metrics): report recall_p10 (worst-decile recall) alongside the mean

### DIFF
--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -68,6 +68,11 @@ pub struct SearchResults {
     pub mean_time: f64,
     pub mean_precision: f64,
     pub mean_recall: f64,
+    /// 10th-percentile per-query recall — the "worst 10%" floor. A healthy mean
+    /// with a near-zero p10 means a slice of queries return almost nothing (e.g.
+    /// a filter that occasionally matches an empty/degenerate set); the mean
+    /// hides that, so this is reported alongside it (VSB/VDBBench methodology).
+    pub recall_p10: f64,
     pub mean_mrr: f64,
     pub mean_ndcg: f64,
     pub recalls: Vec<f64>,
@@ -309,11 +314,22 @@ pub fn compute_search_stats(
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let pct = |q: f64| percentile_linear(&sorted, q);
 
+    // Worst-10% recall floor: catches queries that return almost nothing even
+    // when the mean recall looks fine.
+    let recall_p10 = if recalls.is_empty() {
+        0.0
+    } else {
+        let mut sorted_recalls = recalls.to_vec();
+        sorted_recalls.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        percentile_linear(&sorted_recalls, 0.10)
+    };
+
     Ok(SearchResults {
         total_time,
         mean_time,
         mean_precision: mean(precisions),
         mean_recall: mean(recalls),
+        recall_p10,
         mean_mrr: mean(mrrs),
         mean_ndcg: mean(ndcgs),
         recalls: recalls.to_vec(),
@@ -603,5 +619,28 @@ mod stats_tests {
         assert_eq!(results.p50_time, 0.015);
         assert!(results.schedule_delay_p95_time.unwrap() > 0.4);
         assert_eq!(results.end_to_end_p50_time, Some(0.017));
+    }
+
+    #[test]
+    fn recall_p10_surfaces_worst_decile() {
+        // 20% of queries return nothing (recall 0), 80% perfect. The mean looks
+        // healthy (0.8) but recall_p10 exposes the zero-recall slice — the whole
+        // point of reporting the distribution, not just the mean.
+        let recalls = vec![0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0];
+        let times = vec![0.001; 10];
+        let r = compute_search_stats(
+            &times, &recalls, &recalls, &recalls, &recalls, 1.0, 10, 1, 10,
+        )
+        .unwrap();
+        assert!((r.mean_recall - 0.8).abs() < 1e-9);
+        assert!(
+            r.recall_p10 <= 0.1,
+            "recall_p10 should surface the ~zero worst decile, got {}",
+            r.recall_p10
+        );
+        // All-perfect recall → p10 is also 1.0 (no false alarm).
+        let ones = vec![1.0; 10];
+        let r2 = compute_search_stats(&times, &ones, &ones, &ones, &ones, 1.0, 10, 1, 10).unwrap();
+        assert!((r2.recall_p10 - 1.0).abs() < 1e-9);
     }
 }

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -1016,6 +1016,7 @@ fn save_search_results(
             "end_to_end_p99_time": results.end_to_end_p99_time,
             "mean_precisions": results.mean_precision,
             "mean_recall": results.mean_recall,
+            "recall_p10": results.recall_p10,
             "mean_mrr": results.mean_mrr,
             "mean_ndcg": results.mean_ndcg,
             "std_time": results.std_time,

--- a/src/bin/vector_db_benchmark/summary.rs
+++ b/src/bin/vector_db_benchmark/summary.rs
@@ -357,6 +357,7 @@ pub fn save_summary(
                 "parallel": e.parallel,
                 "mean_precisions": e.results.mean_precision,
                 "mean_recall": e.results.mean_recall,
+                "recall_p10": e.results.recall_p10,
                 "mean_mrr": e.results.mean_mrr,
                 "mean_ndcg": e.results.mean_ndcg,
                 "rps": e.results.rps,


### PR DESCRIPTION
From the benchmark-tool exploration (part of the loop). Both **VectorDBBench** and **Pinecone VSB** stress reporting the recall *distribution*, not just the mean — *"p50 recall 80% looks fine, but if p10 recall is 0%, 10% of queries return nothing."*

## What
Add **`recall_p10`** — the 10th-percentile per-query recall (the "worst 10%" floor) — to `SearchResults`, computed in `compute_search_stats` (empty → 0.0), and surface it in the per-config result JSON and the summary JSON next to `mean_recall`. A healthy mean with a near-zero p10 flags a slice of queries that return almost nothing (a filter matching an empty/degenerate set, a selectivity edge case) — which the mean hides.

Cheap: the per-query recalls are already collected; this is one extra percentile.

## Test
`recall_p10_surfaces_worst_decile` — 20% zero-recall + 80% perfect → mean 0.8 but `recall_p10` ~0; all-perfect → p10 1.0 (no false alarm). Full unit suite 510/510; clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)