### PR TITLE
test(filters): multi-condition AND coverage (compose two clauses)

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -818,6 +818,37 @@ pub fn write_geo_project(
     )
 }
 
+/// Multi-condition AND filter: a keyword match AND a numeric range in one query
+/// (`color == "red" AND size >= 50`). Every other fixture puts a SINGLE condition
+/// under `and`; this exercises that engines correctly COMPOSE (intersect) two
+/// clauses of different types. `color` is `id % 2 == 0 ? "red" : "blue"` and
+/// `size` is `id % 100`, so the ground truth is the even ids whose `id % 100 >=
+/// 50` — an AND that neither clause alone selects.
+pub fn write_and_filter_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+) -> FilterProject {
+    write_filter_project(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        GtMetric::L2,
+        serde_json::json!({ "color": "keyword", "size": "int" }),
+        move |id| {
+            serde_json::json!({
+                "color": if id % 2 == 0 { "red" } else { "blue" },
+                "size": (id % 100) as i64,
+            })
+        },
+        serde_json::json!({ "and": [
+            { "color": { "match": { "value": "red" } } },
+            { "size": { "range": { "gte": 50 } } },
+        ] }),
+        move |id| id % 2 == 0 && (id % 100) as i64 >= 50,
+    )
+}
+
 // ── Multi-tenancy fixture ───────────────────────────────────────────────────
 //
 // Mirrors upstream qdrant/vector-db-benchmark's `random-768-*-tenants` scenario:

--- a/tests/integration_elasticsearch.rs
+++ b/tests/integration_elasticsearch.rs
@@ -1041,6 +1041,38 @@ fn test_binary_elasticsearch_geo() {
     assert!(recall >= 0.9, "es geo recall {:.3} < 0.9", recall);
 }
 
+/// Multi-condition AND (keyword match AND numeric range) — verifies ES composes
+/// two clauses of different types into one `bool.must`.
+#[test]
+fn test_binary_elasticsearch_and_filter() {
+    wait_for_elasticsearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "es-and", "engine": "elasticsearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_and_filter_project(
+        "and-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "es-and",
+            "and-test",
+            "127.0.0.1",
+            &[("ELASTIC_PORT", "9201"), ("ELASTIC_INDEX", "bench_and")],
+        ),
+        "es and-filter run failed"
+    );
+    let recall = common::read_recall(&proj.root, "es-and");
+    println!("es and-filter recall={:.3}", recall);
+    assert!(recall >= 0.9, "es and-filter recall {:.3} < 0.9", recall);
+}
+
 /// End-to-end full-text filter (#120): the query carries a single
 /// `{"body":{"match":{"text":"quick"}}}` condition and ground truth is
 /// brute-forced over only the docs whose body CONTAINS "quick". Before the fix,

--- a/tests/integration_pgvector.rs
+++ b/tests/integration_pgvector.rs
@@ -675,6 +675,42 @@ fn test_binary_pgvector_geo() {
     assert!(recall >= 0.9, "pgvector geo recall {:.3} < 0.9", recall);
 }
 
+/// Multi-condition AND (keyword match AND numeric range) — verifies pgvector
+/// composes two clauses into one SQL WHERE (`"color" = $1 AND "size" >= $2`).
+#[test]
+fn test_binary_pgvector_and_filter() {
+    wait_for_postgres();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "pg-and", "engine": "pgvector",
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_and_filter_project(
+        "and-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "pg-and",
+            "and-test",
+            "127.0.0.1",
+            &[("PGVECTOR_PORT", "5433")]
+        ),
+        "pgvector and-filter run failed"
+    );
+    let recall = common::read_recall(&proj.root, "pg-and");
+    println!("pgvector and-filter recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "pgvector and-filter recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// End-to-end `match_any` on a MULTI-VALUED keyword field (`labels`, #88). The
 /// ';'-joined TEXT column is filtered with array-overlap (`match_any`) and set
 /// membership (exact-match); this exercises the full binary path against a live

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -727,6 +727,48 @@ fn test_binary_qdrant_geo() {
     assert!(recall >= 0.9, "qdrant geo recall {:.3} < 0.9", recall);
 }
 
+/// Multi-condition AND (keyword match AND numeric range) — verifies qdrant
+/// composes two conditions into one Filter.must (intersection).
+#[test]
+fn test_binary_qdrant_and_filter() {
+    wait_for_qdrant();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "qdrant-and", "engine": "qdrant",
+        "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 128}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_and_filter_project(
+        "and-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+    let grpc = QDRANT_GRPC_PORT.to_string();
+    let rest = QDRANT_REST_PORT.to_string();
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "qdrant-and",
+            "and-test",
+            "localhost",
+            &[
+                ("QDRANT_GRPC_PORT", grpc.as_str()),
+                ("QDRANT_REST_PORT", rest.as_str()),
+            ],
+        ),
+        "qdrant and-filter run failed"
+    );
+    let recall = common::read_recall(&proj.root, "qdrant-and");
+    println!("qdrant and-filter recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "qdrant and-filter recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// Control for the multi-valued `labels` fixture (#88). Qdrant already stores
 /// `labels` as a native list payload and matches per element, so it must clear
 /// 0.9 recall. If this fails alongside the Milvus/Weaviate/pgvector labels

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -2283,6 +2283,14 @@ fn test_binary_redis_geo() {
     run_filter_recall_test("redis-geo", "geo-test", common::write_geo_project);
 }
 
+/// Multi-condition AND: `color == "red" AND size >= 50` in one query — verifies
+/// the engine intersects two clauses of different types (every other fixture
+/// filters on a single condition).
+#[test]
+fn test_binary_redis_and_filter() {
+    run_filter_recall_test("redis-and", "and-test", common::write_and_filter_project);
+}
+
 /// Multi-tenancy: many tenants share ONE index and every query is scoped to a
 /// single tenant via a keyword-equality filter on a `tenant` field, with ground
 /// truth brute-forced over ONLY that tenant's docs. Reuses the keyword-TAG


### PR DESCRIPTION
Found by the filter-feature gap analysis. Every filter fixture put a **single** condition under `and`, so an engine composing **multiple** clauses of different types was untested — a real gap (the parsers iterate the `and` array and intersect clauses).

## What
A shared `write_and_filter_project` fixture: `color == "red" AND size >= 50` (a keyword match AND a numeric range), ground truth = docs satisfying **both** (an AND that neither clause alone selects).

New end-to-end tests assert recall ≥ 0.9 across four distinct filter-builder architectures:
- **redis** (RediSearch pipe-joined clauses)
- **elasticsearch** (`bool.must` array)
- **pgvector** (SQL `AND`)
- **qdrant** (`Filter.must` intersection)

**Live-validated on all four** (redis 8.8, ES 9.x, pgvector pg18, qdrant 1.18 — all pass). clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)