### PR TITLE
test(filters): extend multi-condition AND coverage to 5 more engines

### DIFF
--- a/tests/integration_milvus.rs
+++ b/tests/integration_milvus.rs
@@ -488,6 +488,46 @@ fn test_binary_milvus_bool() {
     assert!(recall >= 0.9, "milvus bool recall {:.3} < 0.9", recall);
 }
 
+/// Multi-condition AND (keyword match AND numeric range) — verifies Milvus
+/// composes two conditions of different types into one boolean-expr `&&`
+/// (`color == "red" && size >= 50`), not just a single clause.
+#[test]
+fn test_binary_milvus_and_filter() {
+    wait_for_milvus();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "milvus-and", "engine": "milvus",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100, "index_params": {"M": 16, "efConstruction": 200}}
+    }]);
+    let proj = common::write_and_filter_project(
+        "and-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "milvus-and",
+            "and-test",
+            "127.0.0.1",
+            &[
+                ("MILVUS_PORT", "19531"),
+                ("MILVUS_COLLECTION_NAME", "bench_and")
+            ],
+        ),
+        "milvus and-filter run failed"
+    );
+    let recall = common::read_recall(&proj.root, "milvus-and");
+    println!("milvus and-filter recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "milvus and-filter recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// Datetime range filter end-to-end. Regression: `"datetime"` was dropped from
 /// the schema and the range builder inlined the quoted ISO string. Now
 /// `datetime` -> Int64 epoch column; upload and the range filter both convert

--- a/tests/integration_mongodb.rs
+++ b/tests/integration_mongodb.rs
@@ -1191,6 +1191,58 @@ fn test_binary_mongodb_match_any() {
     );
 }
 
+/// Multi-condition AND (keyword match AND numeric range) — verifies MongoDB
+/// composes two conditions of different types into one `$vectorSearch` filter
+/// (`color == "red"` AND `size >= 50` via `$and`/`$gte`), not just a single
+/// clause. Recall is brute-forced over only the intersecting docs, so an engine
+/// that drops or mis-joins either clause scores low.
+#[test]
+fn test_binary_mongodb_and_filter() {
+    wait_for_mongodb();
+    drop_test_collection();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "mongo-and", "engine": "mongodb",
+        "connection_params": {}, "collection_params": {},
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_and_filter_project(
+        "and-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = std::env::var("MONGODB_PORT").unwrap_or_else(|_| MONGODB_PORT.to_string());
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "mongo-and",
+            "and-test",
+            MONGODB_HOST,
+            &[
+                ("MONGODB_PORT", port.as_str()),
+                ("MONGODB_DB", TEST_DB),
+                ("MONGODB_COLLECTION", TEST_COLLECTION),
+                ("MONGODB_INDEX_NAME", TEST_INDEX),
+            ],
+        ),
+        "mongodb and-filter run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, "mongo-and");
+    println!("mongodb and-filter recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "mongodb and-filter recall {:.3} < 0.9",
+        recall
+    );
+    drop_test_collection();
+    fs::remove_dir_all(&proj.root).ok();
+}
+
 /// End-to-end `match_any` on the INT `size` field. Proves the numeric `$in`
 /// filter matches natively-stored integers end-to-end. Ground truth is
 /// brute-forced over ONLY the docs whose `size` is in the IN-set (a strict

--- a/tests/integration_opensearch.rs
+++ b/tests/integration_opensearch.rs
@@ -765,6 +765,46 @@ fn test_binary_opensearch_bool() {
     assert!(recall >= 0.9, "opensearch bool recall {:.3} < 0.9", recall);
 }
 
+/// Multi-condition AND (keyword match AND numeric range) — verifies OpenSearch
+/// composes two conditions of different types into one `bool.filter` array
+/// (term on `color` AND range on `size`), not just a single clause.
+#[test]
+fn test_binary_opensearch_and_filter() {
+    wait_for_opensearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "os-and", "engine": "opensearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_and_filter_project(
+        "and-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "os-and",
+            "and-test",
+            "http://127.0.0.1",
+            &[
+                ("OPENSEARCH_PORT", "9202"),
+                ("OPENSEARCH_INDEX", "bench_and")
+            ],
+        ),
+        "opensearch and-filter run failed"
+    );
+    let recall = common::read_recall(&proj.root, "os-and");
+    println!("opensearch and-filter recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "opensearch and-filter recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// Datetime range filter end-to-end. Regression for the schema-type bug:
 /// "datetime" is not a valid OS type; with "datetime" -> "date" OS parses the
 /// reader's ISO-8601 strings and selects the [day 100, day 300) window.

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -1386,6 +1386,14 @@ fn test_binary_valkey_datetime() {
     run_filter_recall_test("valkey-dt", "dt-test", common::write_datetime_project);
 }
 
+/// Multi-condition AND (keyword match AND numeric range) — verifies Valkey Search
+/// composes two conditions of different types into one intersecting FT.SEARCH
+/// filter (`@color:{red} @size:[50 +inf]`), not just a single clause.
+#[test]
+fn test_binary_valkey_and_filter() {
+    run_filter_recall_test("valkey-and", "and-test", common::write_and_filter_project);
+}
+
 /// Multi-tenancy: many tenants share ONE index and every query is scoped to a
 /// single tenant via a keyword-equality filter on a `tenant` field, with ground
 /// truth brute-forced over ONLY that tenant's docs. Reuses the keyword-TAG

--- a/tests/integration_weaviate.rs
+++ b/tests/integration_weaviate.rs
@@ -658,6 +658,23 @@ fn test_binary_weaviate_bool() {
     assert!(recall >= 0.9, "weaviate bool recall {:.3} < 0.9", recall);
 }
 
+/// Multi-condition AND (keyword match AND numeric range) — verifies Weaviate
+/// composes two conditions of different types into one `Filters.And` operand
+/// (`Equal color` AND `GreaterThanEqual size`), not just a single clause.
+#[test]
+fn test_binary_weaviate_and_filter() {
+    wait_for_weaviate();
+    let proj = common::write_and_filter_project("and-test", &weaviate_filter_config(), 8);
+    assert!(proj.matching_docs >= proj.top);
+    let recall = run_weaviate_filter(&proj.root, "and-test", "BenchAnd");
+    println!("weaviate and-filter recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "weaviate and-filter recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// Datetime range filter end-to-end. Regression: `datetime` was dropped and the
 /// range builder only emitted valueInt/valueNumber. Now `datetime` -> `date`
 /// property and the ISO bound is sent as `valueText` (Weaviate compares dates


### PR DESCRIPTION
## What

Multi-condition **AND** composition — a keyword `match` **AND** a numeric `range` intersected in a single filter — was only exercised end-to-end on **redis / qdrant / elasticsearch / pgvector** (#175). This extends that coverage to the remaining locally-testable engines that support it:

- **valkey** — `@color:{red} @size:[50 +inf]` (FT.SEARCH intersection)
- **opensearch** — `bool.filter` array (term + range)
- **weaviate** — `Filters.And` operand (`Equal` + `GreaterThanEqual`)
- **milvus** — boolean-expr `&&` (`color == "red" && size >= 50`)
- **mongodb** — `$vectorSearch` filter `$and` / `$gte`

All **nine** locally-testable filtering engines now verify that two clauses of **different types** are correctly intersected — not silently dropped or OR'd together.

## How

Each test reuses the shared `write_and_filter_project` fixture (`color == "red" AND size >= 50`) with ground truth brute-forced over **only** the intersecting docs, so an engine that mis-joins either clause scores low recall.

## Validation

Live-validated against real containers — all five at **recall 1.000**:

| engine | recall |
|---|---|
| valkey | 1.000 |
| opensearch | 1.000 |
| weaviate | 1.000 |
| milvus | 1.000 |
| mongodb | 1.000 |

`cargo +stable build --bins`, `fmt --check`, `clippy --tests -- -D warnings` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)