### PR TITLE
test(filters): selectivity-ladder coverage (sweep filter selectivity ~3%–99%)

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -849,6 +849,58 @@ pub fn write_and_filter_project(
     )
 }
 
+// ── Selectivity-ladder fixture ──────────────────────────────────────────────
+//
+// The #1 methodology idea shared by VectorDBBench, Pinecone VSB and qdrant's
+// vector-db-benchmark: filter recall/latency must be measured as a FUNCTION of
+// filter selectivity, not at a single point. A restrictive filter (few matching
+// docs) and a permissive one exercise very different engine code paths — and
+// naive post-filtering HNSW can COLLAPSE at low selectivity, because the graph
+// walk rarely reaches a matching node, whereas a pre-filtering (or
+// brute-force-below-threshold) engine stays correct.
+//
+// This fixture puts an int field `rank` = doc id (0..N_DOCS) on every doc and
+// emits ONE query per rung of `SELECTIVITY_LADDER`, each a `rank < K` range that
+// selects exactly the K lowest ranks (selectivity K/N_DOCS). So a single dataset
+// sweeps the same range-filter path from ~3% to ~99% selectivity. Ground truth
+// is brute-forced over only the surviving docs per rung, so an engine that drops
+// the filter — or whose recall collapses at the restrictive end — scores low.
+//
+// SCOPE NOTE: with only N_DOCS=400 and a high ef, search is near-exhaustive, so
+// this asserts range-filter CORRECTNESS across selectivity boundaries (each rung
+// a distinct range extent) rather than reproducing at-scale post-filter collapse
+// (which needs ef << corpus). It is the local, deterministic counterpart to the
+// large selectivity-graded datasets those external tools ship.
+
+/// Filter-match counts (out of `N_DOCS` = 400) for each selectivity rung, from
+/// highly restrictive (~3%) to barely filtered (~99%). The tightest rung keeps
+/// `>= TOP` matches so recall is well-defined at every point.
+pub const SELECTIVITY_LADDER: [usize; 8] = [12, 20, 40, 100, 200, 300, 360, 396];
+
+/// selectivity-ladder filter: field `rank` (schema type `int`) = doc id. Query
+/// `q` filters `rank < SELECTIVITY_LADDER[q]`, sweeping selectivity across the
+/// ladder, with per-rung ground truth brute-forced over only the matching docs.
+pub fn write_selectivity_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+) -> FilterProject {
+    write_filter_project_multi(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        GtMetric::L2,
+        SELECTIVITY_LADDER.len(),
+        serde_json::json!({ "rank": "int" }),
+        |id| serde_json::json!({ "rank": id as i64 }),
+        move |q| {
+            let k = SELECTIVITY_LADDER[q] as i64;
+            serde_json::json!({ "and": [ { "rank": { "range": { "lt": k } } } ] })
+        },
+        move |q, id| (id as i64) < SELECTIVITY_LADDER[q] as i64,
+    )
+}
+
 // ── Multi-tenancy fixture ───────────────────────────────────────────────────
 //
 // Mirrors upstream qdrant/vector-db-benchmark's `random-768-*-tenants` scenario:

--- a/tests/integration_elasticsearch.rs
+++ b/tests/integration_elasticsearch.rs
@@ -1073,6 +1073,40 @@ fn test_binary_elasticsearch_and_filter() {
     assert!(recall >= 0.9, "es and-filter recall {:.3} < 0.9", recall);
 }
 
+/// Selectivity ladder: one `rank < K` range query per rung, sweeping filter
+/// selectivity from ~3% to ~99% in a single dataset. Verifies ES's pre-filtered
+/// kNN keeps recall across the whole selectivity range (recall vs per-rung
+/// ground truth), not just at one operating point.
+#[test]
+fn test_binary_elasticsearch_selectivity() {
+    wait_for_elasticsearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "es-sel", "engine": "elasticsearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_selectivity_project(
+        "sel-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "es-sel",
+            "sel-test",
+            "127.0.0.1",
+            &[("ELASTIC_PORT", "9201"), ("ELASTIC_INDEX", "bench_sel")],
+        ),
+        "es selectivity run failed"
+    );
+    let recall = common::read_recall(&proj.root, "es-sel");
+    println!("es selectivity recall={:.3}", recall);
+    assert!(recall >= 0.9, "es selectivity recall {:.3} < 0.9", recall);
+}
+
 /// End-to-end full-text filter (#120): the query carries a single
 /// `{"body":{"match":{"text":"quick"}}}` condition and ground truth is
 /// brute-forced over only the docs whose body CONTAINS "quick". Before the fix,

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -769,6 +769,50 @@ fn test_binary_qdrant_and_filter() {
     );
 }
 
+/// Selectivity ladder: one `rank < K` range query per rung, sweeping filter
+/// selectivity from ~3% to ~99% in a single dataset. Verifies qdrant's
+/// filterable HNSW keeps recall across the whole selectivity range (recall vs
+/// per-rung ground truth), not just at one operating point.
+#[test]
+fn test_binary_qdrant_selectivity() {
+    wait_for_qdrant();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "qdrant-sel", "engine": "qdrant",
+        "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 128}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_selectivity_project(
+        "sel-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    assert!(proj.matching_docs >= proj.top);
+    let grpc = QDRANT_GRPC_PORT.to_string();
+    let rest = QDRANT_REST_PORT.to_string();
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "qdrant-sel",
+            "sel-test",
+            "localhost",
+            &[
+                ("QDRANT_GRPC_PORT", grpc.as_str()),
+                ("QDRANT_REST_PORT", rest.as_str()),
+            ],
+        ),
+        "qdrant selectivity run failed"
+    );
+    let recall = common::read_recall(&proj.root, "qdrant-sel");
+    println!("qdrant selectivity recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "qdrant selectivity recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// Control for the multi-valued `labels` fixture (#88). Qdrant already stores
 /// `labels` as a native list payload and matches per element, so it must clear
 /// 0.9 recall. If this fails alongside the Milvus/Weaviate/pgvector labels

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -2291,6 +2291,15 @@ fn test_binary_redis_and_filter() {
     run_filter_recall_test("redis-and", "and-test", common::write_and_filter_project);
 }
 
+/// Selectivity ladder: one `rank < K` range query per rung, sweeping filter
+/// selectivity from ~3% to ~99% in a single dataset. Verifies the numeric-range
+/// filter path stays correct (recall vs per-rung ground truth) across the whole
+/// selectivity range, not just at one operating point.
+#[test]
+fn test_binary_redis_selectivity() {
+    run_filter_recall_test("redis-sel", "sel-test", common::write_selectivity_project);
+}
+
 /// Multi-tenancy: many tenants share ONE index and every query is scoped to a
 /// single tenant via a keyword-equality filter on a `tenant` field, with ground
 /// truth brute-forced over ONLY that tenant's docs. Reuses the keyword-TAG

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -1394,6 +1394,14 @@ fn test_binary_valkey_and_filter() {
     run_filter_recall_test("valkey-and", "and-test", common::write_and_filter_project);
 }
 
+/// Selectivity ladder: one `rank < K` range query per rung, sweeping filter
+/// selectivity from ~3% to ~99% in a single dataset. Verifies the numeric-range
+/// filter path stays correct across the whole selectivity range.
+#[test]
+fn test_binary_valkey_selectivity() {
+    run_filter_recall_test("valkey-sel", "sel-test", common::write_selectivity_project);
+}
+
 /// Multi-tenancy: many tenants share ONE index and every query is scoped to a
 /// single tenant via a keyword-equality filter on a `tenant` field, with ground
 /// truth brute-forced over ONLY that tenant's docs. Reuses the keyword-TAG


### PR DESCRIPTION
## What

Adopts the **#1 methodology idea** shared by [VectorDBBench](https://github.com/zilliztech/vectordbbench), [Pinecone VSB](https://github.com/pinecone-io/VSB) and [qdrant/vector-db-benchmark](https://github.com/qdrant/vector-db-benchmark): filter recall must be measured as a **function of selectivity**, not at a single operating point. A restrictive filter (few matching docs) and a permissive one exercise very different engine code paths — and naive post-filtering HNSW can **collapse** at low selectivity (the graph walk rarely reaches a matching node), while a pre-filtering engine stays correct.

## How

Adds `write_selectivity_project` (+ `SELECTIVITY_LADDER`): an int `rank` = doc id on every doc, and **one `rank < K` range query per rung** of the ladder `[12, 20, 40, 100, 200, 300, 360, 396]` (out of 400 docs = **~3% … 99%** selectivity). Per-rung ground truth is brute-forced over only the surviving docs, so a single dataset sweeps the same numeric-range filter path across the whole selectivity range. An engine that drops the filter — or whose recall collapses at the restrictive end — scores low mean recall.

Tests added for **redis, valkey** (one-liners), **qdrant** and **elasticsearch** — three distinct filter architectures (RediSearch hybrid, Qdrant filterable-HNSW, Lucene pre-filter).

## Validation

Live-validated against real containers — all at **recall 1.000** across the ladder:

| engine | recall |
|---|---|
| redis | 1.000 |
| valkey | 1.000 |
| qdrant | 1.000 |
| elasticsearch | 1.000 |

`build --bins`, `fmt --check`, `clippy --tests -- -D warnings` all clean.

## Scope (honest)

With `N_DOCS=400` and a high ef, search is near-exhaustive, so this asserts range-filter **correctness across selectivity boundaries** (each rung a distinct range extent) rather than reproducing at-scale post-filter collapse (which needs `ef << corpus`). It is the local, deterministic counterpart to the large selectivity-graded datasets those external tools ship — and a scaffold (`SELECTIVITY_LADDER`) for a future large generated dataset that would exercise the collapse regime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)