### PR TITLE
fix(es,os): uuid filter — map "uuid" schema type to keyword (+qdrant coverage)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -172,6 +172,12 @@ impl ElasticsearchEngine {
                         // index creation reject the whole mapping.
                         "bool" => "boolean",
                         "datetime" => "date",
+                        // A `uuid` is an exact-match opaque string; "uuid" is not
+                        // a valid ES type, so (like bool/datetime above) forwarding
+                        // it verbatim made index creation reject the whole mapping,
+                        // silently breaking every uuid-equality filter. Map it to
+                        // `keyword` (exact term match, no analysis).
+                        "uuid" => "keyword",
                         other => other,
                     };
                     props.insert(

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -173,6 +173,12 @@ impl OpenSearchEngine {
                         // whole mapping.
                         "bool" => "boolean",
                         "datetime" => "date",
+                        // A `uuid` is an exact-match opaque string; "uuid" is not a
+                        // valid OS type, so (like bool/datetime above) forwarding it
+                        // verbatim made index creation reject the whole mapping,
+                        // silently breaking every uuid-equality filter. Map it to
+                        // `keyword` (exact term match, no analysis).
+                        "uuid" => "keyword",
                         other => other,
                     };
                     props.insert(

--- a/tests/integration_elasticsearch.rs
+++ b/tests/integration_elasticsearch.rs
@@ -1107,6 +1107,38 @@ fn test_binary_elasticsearch_selectivity() {
     assert!(recall >= 0.9, "es selectivity recall {:.3} < 0.9", recall);
 }
 
+/// UUID exact-match filter end-to-end. Regression for the schema-type bug:
+/// "uuid" is not a valid ES type; forwarding it verbatim made index creation
+/// reject the whole mapping (silently breaking the filter). With "uuid" ->
+/// "keyword" ES does an exact term match, selecting the quarter of docs whose
+/// `uid` equals UUIDS[0].
+#[test]
+fn test_binary_elasticsearch_uuid() {
+    wait_for_elasticsearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "es-uuid", "engine": "elasticsearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_uuid_project("uuid-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "es-uuid",
+            "uuid-test",
+            "127.0.0.1",
+            &[("ELASTIC_PORT", "9201"), ("ELASTIC_INDEX", "bench_uuid")],
+        ),
+        "es uuid run failed"
+    );
+    let recall = common::read_recall(&proj.root, "es-uuid");
+    println!("es uuid recall={:.3}", recall);
+    assert!(recall >= 0.9, "es uuid recall {:.3} < 0.9", recall);
+}
+
 /// End-to-end full-text filter (#120): the query carries a single
 /// `{"body":{"match":{"text":"quick"}}}` condition and ground truth is
 /// brute-forced over only the docs whose body CONTAINS "quick". Before the fix,

--- a/tests/integration_opensearch.rs
+++ b/tests/integration_opensearch.rs
@@ -805,6 +805,40 @@ fn test_binary_opensearch_and_filter() {
     );
 }
 
+/// UUID exact-match filter end-to-end. Regression for the schema-type bug:
+/// "uuid" is not a valid OS type; forwarding it verbatim made index creation
+/// reject the whole mapping. With "uuid" -> "keyword" OS does an exact term
+/// match, selecting the quarter of docs whose `uid` equals UUIDS[0].
+#[test]
+fn test_binary_opensearch_uuid() {
+    wait_for_opensearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "os-uuid", "engine": "opensearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_uuid_project("uuid-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "os-uuid",
+            "uuid-test",
+            "http://127.0.0.1",
+            &[
+                ("OPENSEARCH_PORT", "9202"),
+                ("OPENSEARCH_INDEX", "bench_uuid")
+            ],
+        ),
+        "opensearch uuid run failed"
+    );
+    let recall = common::read_recall(&proj.root, "os-uuid");
+    println!("opensearch uuid recall={:.3}", recall);
+    assert!(recall >= 0.9, "opensearch uuid recall {:.3} < 0.9", recall);
+}
+
 /// Datetime range filter end-to-end. Regression for the schema-type bug:
 /// "datetime" is not a valid OS type; with "datetime" -> "date" OS parses the
 /// reader's ISO-8601 strings and selects the [day 100, day 300) window.

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -769,6 +769,43 @@ fn test_binary_qdrant_and_filter() {
     );
 }
 
+/// UUID exact-match filter end-to-end. Qdrant maps the `uuid` schema type to its
+/// dedicated `FieldType::Uuid` payload index (distinct from keyword), which was
+/// otherwise untested — this proves an exact `uid == UUIDS[0]` match selects the
+/// quarter of docs it should through that special index.
+#[test]
+fn test_binary_qdrant_uuid() {
+    wait_for_qdrant();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "qdrant-uuid", "engine": "qdrant",
+        "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 128}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_uuid_project("uuid-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    let grpc = QDRANT_GRPC_PORT.to_string();
+    let rest = QDRANT_REST_PORT.to_string();
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "qdrant-uuid",
+            "uuid-test",
+            "localhost",
+            &[
+                ("QDRANT_GRPC_PORT", grpc.as_str()),
+                ("QDRANT_REST_PORT", rest.as_str()),
+            ],
+        ),
+        "qdrant uuid run failed"
+    );
+    let recall = common::read_recall(&proj.root, "qdrant-uuid");
+    println!("qdrant uuid recall={:.3}", recall);
+    assert!(recall >= 0.9, "qdrant uuid recall {:.3} < 0.9", recall);
+}
+
 /// Selectivity ladder: one `rank < K` range query per rung, sweeping filter
 /// selectivity from ~3% to ~99% in a single dataset. Verifies qdrant's
 /// filterable HNSW keeps recall across the whole selectivity range (recall vs


### PR DESCRIPTION
## The bug

The **`uuid` filter datatype was silently broken on Elasticsearch and OpenSearch.** Both schema-type maps forward unknown types verbatim (`other => other`), so a `uuid` field was created with `"type": "uuid"` — which is **not a valid ES/OS field type**. ES/OS reject the entire mapping at index creation (`mapper_parsing_exception`), breaking every uuid-equality filter. This is the exact same failure mode as the original bool/datetime schema-type bug.

`uuid` was only ever exercised end-to-end on **redis/valkey** (which alias it to a TAG), so this went unnoticed.

## Fix

Map `"uuid" => "keyword"` on both engines. A uuid is an exact-match opaque string, so a `keyword` field (exact term match, no analysis) is the correct target — mirroring the existing `bool => boolean` / `datetime => date` fixes right above it.

## Coverage

End-to-end uuid recall tests added for **elasticsearch**, **opensearch**, and **qdrant**. The qdrant test validates its dedicated `FieldType::Uuid` payload index (distinct from keyword), which was previously **untested**.

| engine | recall | note |
|---|---|---|
| elasticsearch | 1.000 | was broken (invalid mapping) → fixed |
| opensearch | 1.000 | was broken (invalid mapping) → fixed |
| qdrant | 1.000 | `FieldType::Uuid` path, now covered |

Each brute-forces ground truth over only the docs whose `uid` equals `UUIDS[0]`, so an engine that drops/mishandles the filter scores low. `build --bins`, `fmt --check`, `clippy --bins --tests` all clean.

## Context

Surfaced by the deep exploration of qdrant/vector-db-benchmark, which ships `uuid` as a first-class filter datatype — a gap our shipped engines had for ES/OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)