### PR TITLE
fix(pgvector,weaviate,milvus): uuid filter — was dropped, silently broke filter

### DIFF
--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -195,7 +195,11 @@ impl MilvusEngine {
                     } else {
                         let milvus_type = match ft {
                             "int" => "Int64",
-                            "keyword" | "text" => "VarChar",
+                            // A `uuid` is an exact-match opaque string → a plain
+                            // VarChar (no analyzer), same as keyword. Without this
+                            // arm it hit `_ => continue`, so no field was created
+                            // and every uuid filter silently broke.
+                            "keyword" | "text" | "uuid" => "VarChar",
                             "float" => "Double",
                             // Milvus has a native Bool type. No native date type, so
                             // datetimes are stored as Int64 epoch seconds (upload +

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -22,7 +22,10 @@ use vector_db_benchmark::readers::metadata::{
 /// types pgvector can't filter on with a plain scalar column (e.g. geo).
 fn pg_column_type(field_type: &str) -> Option<&'static str> {
     match field_type {
-        "keyword" | "text" => Some("TEXT"),
+        // A `uuid` is an exact-match opaque string; store it in a TEXT column
+        // (exact `=` match, like keyword). Without this arm it hit `_ => None`,
+        // so no column was created and every uuid filter silently broke.
+        "keyword" | "text" | "uuid" => Some("TEXT"),
         "int" => Some("BIGINT"),
         "float" => Some("DOUBLE PRECISION"),
         // Bools/datetimes arrive from the reader as strings ("true"/"false",
@@ -897,6 +900,7 @@ mod tests {
         assert_eq!(pg_column_type("datetime"), Some("TIMESTAMPTZ"));
         // Geo is now stored as a "lat,lon" TEXT scalar (earthdistance filter).
         assert_eq!(pg_column_type("geo"), Some("TEXT"));
+        assert_eq!(pg_column_type("uuid"), Some("TEXT"));
         assert_eq!(pg_column_type("unknown"), None);
     }
 

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -420,6 +420,11 @@ fn weaviate_property(field_name: &str, field_type: &str) -> Option<serde_json::V
         // compares date properties via valueText (there is no ValueDate variant).
         "bool" => "boolean",
         "datetime" => "date",
+        // A `uuid` is an exact-match opaque string → a `text` property with
+        // `field` tokenization (whole-value equality, like keyword). Without this
+        // arm it hit `_ => return None`, so no property was created and every
+        // uuid filter silently broke.
+        "uuid" => "text",
         _ => return None,
     };
     let mut prop = serde_json::json!({
@@ -434,7 +439,9 @@ fn weaviate_property(field_name: &str, field_type: &str) -> Option<serde_json::V
     // `field` tokenization for keyword; keep `word` for full-text. Tokenization
     // and `indexSearchable` apply only to text-backed properties.
     if let Some(tok) = match field_type {
-        "keyword" => Some("field"),
+        // `uuid` needs whole-value equality just like keyword, so force `field`
+        // tokenization (default `word` would turn `Equal` into token-containment).
+        "keyword" | "uuid" => Some("field"),
         "text" => Some("word"),
         _ => None,
     } {

--- a/tests/integration_milvus.rs
+++ b/tests/integration_milvus.rs
@@ -488,6 +488,40 @@ fn test_binary_milvus_bool() {
     assert!(recall >= 0.9, "milvus bool recall {:.3} < 0.9", recall);
 }
 
+/// UUID exact-match filter end-to-end. Regression: `uuid` hit the schema map's
+/// `_ => continue`, so no field was created and the filter silently broke. Now
+/// `uuid` -> VarChar (no analyzer, exact match), and `uid == UUIDS[0]` selects
+/// the quarter of docs it should.
+#[test]
+fn test_binary_milvus_uuid() {
+    wait_for_milvus();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "milvus-uuid", "engine": "milvus",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100, "index_params": {"M": 16, "efConstruction": 200}}
+    }]);
+    let proj =
+        common::write_uuid_project("uuid-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "milvus-uuid",
+            "uuid-test",
+            "127.0.0.1",
+            &[
+                ("MILVUS_PORT", "19531"),
+                ("MILVUS_COLLECTION_NAME", "bench_uuid")
+            ],
+        ),
+        "milvus uuid run failed"
+    );
+    let recall = common::read_recall(&proj.root, "milvus-uuid");
+    println!("milvus uuid recall={:.3}", recall);
+    assert!(recall >= 0.9, "milvus uuid recall {:.3} < 0.9", recall);
+}
+
 /// Multi-condition AND (keyword match AND numeric range) — verifies Milvus
 /// composes two conditions of different types into one boolean-expr `&&`
 /// (`color == "red" && size >= 50`), not just a single clause.

--- a/tests/integration_mongodb.rs
+++ b/tests/integration_mongodb.rs
@@ -1191,6 +1191,50 @@ fn test_binary_mongodb_match_any() {
     );
 }
 
+/// UUID exact-match filter end-to-end. MongoDB stores `uuid` values as plain
+/// BSON strings (no special schema type), so a `uid == UUIDS[0]` `$vectorSearch`
+/// filter is a straight string equality. This confirms uuid works out of the box
+/// (unlike ES/OS/pgvector/weaviate/milvus, which needed a schema-type fix).
+#[test]
+fn test_binary_mongodb_uuid() {
+    wait_for_mongodb();
+    drop_test_collection();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "mongo-uuid", "engine": "mongodb",
+        "connection_params": {}, "collection_params": {},
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_uuid_project("uuid-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = std::env::var("MONGODB_PORT").unwrap_or_else(|_| MONGODB_PORT.to_string());
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "mongo-uuid",
+            "uuid-test",
+            MONGODB_HOST,
+            &[
+                ("MONGODB_PORT", port.as_str()),
+                ("MONGODB_DB", TEST_DB),
+                ("MONGODB_COLLECTION", TEST_COLLECTION),
+                ("MONGODB_INDEX_NAME", TEST_INDEX),
+            ],
+        ),
+        "mongodb uuid run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, "mongo-uuid");
+    println!("mongodb uuid recall={:.3}", recall);
+    assert!(recall >= 0.9, "mongodb uuid recall {:.3} < 0.9", recall);
+    drop_test_collection();
+    fs::remove_dir_all(&proj.root).ok();
+}
+
 /// Multi-condition AND (keyword match AND numeric range) — verifies MongoDB
 /// composes two conditions of different types into one `$vectorSearch` filter
 /// (`color == "red"` AND `size >= 50` via `$and`/`$gte`), not just a single

--- a/tests/integration_pgvector.rs
+++ b/tests/integration_pgvector.rs
@@ -541,6 +541,37 @@ fn test_binary_pgvector_match_any() {
     );
 }
 
+/// UUID exact-match filter end-to-end. Regression for the schema-type bug:
+/// `uuid` hit `pg_column_type`'s `_ => None`, so no column was created and the
+/// filter referenced a missing column. With `uuid` -> TEXT the exact `=` match
+/// selects the quarter of docs whose `uid` equals UUIDS[0].
+#[test]
+fn test_binary_pgvector_uuid() {
+    wait_for_postgres();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "pg-uuid", "engine": "pgvector",
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_uuid_project("uuid-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "pg-uuid",
+            "uuid-test",
+            "127.0.0.1",
+            &[("PGVECTOR_PORT", "5433")]
+        ),
+        "pgvector uuid run failed"
+    );
+    let recall = common::read_recall(&proj.root, "pg-uuid");
+    println!("pgvector uuid recall={:.3}", recall);
+    assert!(recall >= 0.9, "pgvector uuid recall {:.3} < 0.9", recall);
+}
+
 /// Bool-field equality filter end-to-end. Regression for the missing-column bug:
 /// `pg_column_type("bool")` returned None so no column was created and the filter
 /// referenced a non-existent column (SQL error). With a BOOLEAN column, COPY

--- a/tests/integration_weaviate.rs
+++ b/tests/integration_weaviate.rs
@@ -658,6 +658,21 @@ fn test_binary_weaviate_bool() {
     assert!(recall >= 0.9, "weaviate bool recall {:.3} < 0.9", recall);
 }
 
+/// UUID exact-match filter end-to-end. Regression: `uuid` hit the property
+/// builder's `_ => return None`, so no property was created and the filter
+/// matched nothing. Now `uuid` -> `text` property with `field` tokenization
+/// (whole-value equality), and `Equal uid == UUIDS[0]` selects the quarter of
+/// docs it should.
+#[test]
+fn test_binary_weaviate_uuid() {
+    wait_for_weaviate();
+    let proj = common::write_uuid_project("uuid-test", &weaviate_filter_config(), 8);
+    assert!(proj.matching_docs >= proj.top);
+    let recall = run_weaviate_filter(&proj.root, "uuid-test", "BenchUuid");
+    println!("weaviate uuid recall={:.3}", recall);
+    assert!(recall >= 0.9, "weaviate uuid recall {:.3} < 0.9", recall);
+}
+
 /// Multi-condition AND (keyword match AND numeric range) — verifies Weaviate
 /// composes two conditions of different types into one `Filters.And` operand
 /// (`Equal color` AND `GreaterThanEqual size`), not just a single clause.


### PR DESCRIPTION
## The bug (wave 2)

Follow-up to #180 (ES/OS). The **`uuid` filter datatype was silently broken on three more engines** — their schema-type maps dropped it via the catch-all arm, so no column/property/field was created and every uuid-equality filter matched nothing (or errored on a missing column):

| engine | catch-all that dropped uuid | fix |
|---|---|---|
| pgvector | `pg_column_type` → `_ => None` (no column) | `"uuid" => Some("TEXT")` |
| weaviate | property builder → `_ => return None` (no property) | `"uuid" => "text"` + `field` tokenization |
| milvus | schema map → `_ => continue` (no field) | `"uuid" => "VarChar"` (no analyzer) |

A uuid is an exact-match opaque string, so each maps to that engine's keyword-equivalent storage (whole-value equality, no analysis) — mirroring the `bool`/`datetime`/`geo` fixes already in these maps.

**MongoDB** already stored uuid as a plain BSON string and worked out of the box — a test is added to lock that in.

## Coverage

End-to-end uuid recall tests for **pgvector, weaviate, milvus, mongodb** (+ the pgvector schema unit test now asserts `uuid => TEXT`).

| engine | recall | status |
|---|---|---|
| pgvector | 1.000 | was broken → fixed |
| weaviate | 1.000 | was broken → fixed |
| milvus | 1.000 | was broken → fixed |
| mongodb | 1.000 | already worked (locked in) |

`build --bins`, `fmt --check`, `clippy --bins --tests`, and the pgvector unit test all clean.

## Result

Combined with #180 (redis/valkey/es/os/qdrant), **`uuid` is now supported and tested on all 11 locally-testable filtering engines.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)