### PR TITLE
test(filters): multi-condition OR coverage across all 9 filtering engines

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -849,6 +849,38 @@ pub fn write_and_filter_project(
     )
 }
 
+/// Multi-condition OR fixture: same `color`/`size` payload as the AND fixture,
+/// but the query is a top-level `{or: [...]}` UNION — `color == "red" OR size >=
+/// 90`. The two arms overlap only partially (all reds, plus the blue docs with
+/// size in 90..99), so the union (~220 docs) is strictly larger than either arm
+/// and strictly larger than their intersection. An engine that mis-handles OR —
+/// treating it as AND, or dropping an arm — searches a much smaller doc set, so
+/// its nearest neighbours diverge from the union's and recall collapses.
+pub fn write_or_filter_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+) -> FilterProject {
+    write_filter_project(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        GtMetric::L2,
+        serde_json::json!({ "color": "keyword", "size": "int" }),
+        move |id| {
+            serde_json::json!({
+                "color": if id % 2 == 0 { "red" } else { "blue" },
+                "size": (id % 100) as i64,
+            })
+        },
+        serde_json::json!({ "or": [
+            { "color": { "match": { "value": "red" } } },
+            { "size": { "range": { "gte": 90 } } },
+        ] }),
+        move |id| id % 2 == 0 || (id % 100) as i64 >= 90,
+    )
+}
+
 // ── Selectivity-ladder fixture ──────────────────────────────────────────────
 //
 // The #1 methodology idea shared by VectorDBBench, Pinecone VSB and qdrant's

--- a/tests/integration_elasticsearch.rs
+++ b/tests/integration_elasticsearch.rs
@@ -1073,6 +1073,35 @@ fn test_binary_elasticsearch_and_filter() {
     assert!(recall >= 0.9, "es and-filter recall {:.3} < 0.9", recall);
 }
 
+/// Multi-condition OR (`color == "red" OR size >= 90`) — verifies ES unions two
+/// clauses into a `bool.should` (minimum_should_match 1), searching the union.
+#[test]
+fn test_binary_elasticsearch_or_filter() {
+    wait_for_elasticsearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "es-or", "engine": "elasticsearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_or_filter_project("or-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "es-or",
+            "or-test",
+            "127.0.0.1",
+            &[("ELASTIC_PORT", "9201"), ("ELASTIC_INDEX", "bench_or")],
+        ),
+        "es or-filter run failed"
+    );
+    let recall = common::read_recall(&proj.root, "es-or");
+    println!("es or-filter recall={:.3}", recall);
+    assert!(recall >= 0.9, "es or-filter recall {:.3} < 0.9", recall);
+}
+
 /// Selectivity ladder: one `rank < K` range query per rung, sweeping filter
 /// selectivity from ~3% to ~99% in a single dataset. Verifies ES's pre-filtered
 /// kNN keeps recall across the whole selectivity range (recall vs per-rung

--- a/tests/integration_milvus.rs
+++ b/tests/integration_milvus.rs
@@ -562,6 +562,38 @@ fn test_binary_milvus_and_filter() {
     );
 }
 
+/// Multi-condition OR (`color == "red" OR size >= 90`) — verifies Milvus unions
+/// two clauses into a boolean-expr `||` (`color == "red" || size >= 90`).
+#[test]
+fn test_binary_milvus_or_filter() {
+    wait_for_milvus();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "milvus-or", "engine": "milvus",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100, "index_params": {"M": 16, "efConstruction": 200}}
+    }]);
+    let proj =
+        common::write_or_filter_project("or-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "milvus-or",
+            "or-test",
+            "127.0.0.1",
+            &[
+                ("MILVUS_PORT", "19531"),
+                ("MILVUS_COLLECTION_NAME", "bench_or")
+            ],
+        ),
+        "milvus or-filter run failed"
+    );
+    let recall = common::read_recall(&proj.root, "milvus-or");
+    println!("milvus or-filter recall={:.3}", recall);
+    assert!(recall >= 0.9, "milvus or-filter recall {:.3} < 0.9", recall);
+}
+
 /// Datetime range filter end-to-end. Regression: `"datetime"` was dropped from
 /// the schema and the range builder inlined the quoted ISO string. Now
 /// `datetime` -> Int64 epoch column; upload and the range filter both convert

--- a/tests/integration_mongodb.rs
+++ b/tests/integration_mongodb.rs
@@ -1287,6 +1287,54 @@ fn test_binary_mongodb_and_filter() {
     fs::remove_dir_all(&proj.root).ok();
 }
 
+/// Multi-condition OR (`color == "red" OR size >= 90`) — verifies MongoDB unions
+/// two clauses into a `$vectorSearch` filter `$or`, searching the union (not the
+/// intersection). Recall is brute-forced over the union, so an engine that
+/// mis-joins or drops an arm scores low.
+#[test]
+fn test_binary_mongodb_or_filter() {
+    wait_for_mongodb();
+    drop_test_collection();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "mongo-or", "engine": "mongodb",
+        "connection_params": {}, "collection_params": {},
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_or_filter_project("or-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = std::env::var("MONGODB_PORT").unwrap_or_else(|_| MONGODB_PORT.to_string());
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "mongo-or",
+            "or-test",
+            MONGODB_HOST,
+            &[
+                ("MONGODB_PORT", port.as_str()),
+                ("MONGODB_DB", TEST_DB),
+                ("MONGODB_COLLECTION", TEST_COLLECTION),
+                ("MONGODB_INDEX_NAME", TEST_INDEX),
+            ],
+        ),
+        "mongodb or-filter run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, "mongo-or");
+    println!("mongodb or-filter recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "mongodb or-filter recall {:.3} < 0.9",
+        recall
+    );
+    drop_test_collection();
+    fs::remove_dir_all(&proj.root).ok();
+}
+
 /// End-to-end `match_any` on the INT `size` field. Proves the numeric `$in`
 /// filter matches natively-stored integers end-to-end. Ground truth is
 /// brute-forced over ONLY the docs whose `size` is in the IN-set (a strict

--- a/tests/integration_opensearch.rs
+++ b/tests/integration_opensearch.rs
@@ -805,6 +805,42 @@ fn test_binary_opensearch_and_filter() {
     );
 }
 
+/// Multi-condition OR (`color == "red" OR size >= 90`) — verifies OpenSearch
+/// unions two clauses into a `bool.should` (minimum_should_match 1).
+#[test]
+fn test_binary_opensearch_or_filter() {
+    wait_for_opensearch();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "os-or", "engine": "opensearch",
+        "search_params": [{"parallel": 1, "num_candidates": 400}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_or_filter_project("or-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "os-or",
+            "or-test",
+            "http://127.0.0.1",
+            &[
+                ("OPENSEARCH_PORT", "9202"),
+                ("OPENSEARCH_INDEX", "bench_or")
+            ],
+        ),
+        "opensearch or-filter run failed"
+    );
+    let recall = common::read_recall(&proj.root, "os-or");
+    println!("opensearch or-filter recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "opensearch or-filter recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// UUID exact-match filter end-to-end. Regression for the schema-type bug:
 /// "uuid" is not a valid OS type; forwarding it verbatim made index creation
 /// reject the whole mapping. With "uuid" -> "keyword" OS does an exact term

--- a/tests/integration_pgvector.rs
+++ b/tests/integration_pgvector.rs
@@ -706,6 +706,39 @@ fn test_binary_pgvector_geo() {
     assert!(recall >= 0.9, "pgvector geo recall {:.3} < 0.9", recall);
 }
 
+/// Multi-condition OR (`color == "red" OR size >= 90`) — verifies pgvector unions
+/// two clauses with SQL `OR` (searching the union), not `AND`.
+#[test]
+fn test_binary_pgvector_or_filter() {
+    wait_for_postgres();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "pg-or", "engine": "pgvector",
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 400}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_or_filter_project("or-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "pg-or",
+            "or-test",
+            "127.0.0.1",
+            &[("PGVECTOR_PORT", "5433")]
+        ),
+        "pgvector or run failed"
+    );
+    let recall = common::read_recall(&proj.root, "pg-or");
+    println!("pgvector or-filter recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "pgvector or-filter recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// Multi-condition AND (keyword match AND numeric range) — verifies pgvector
 /// composes two clauses into one SQL WHERE (`"color" = $1 AND "size" >= $2`).
 #[test]

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -769,6 +769,41 @@ fn test_binary_qdrant_and_filter() {
     );
 }
 
+/// Multi-condition OR (`color == "red" OR size >= 90`) — verifies qdrant unions
+/// two clauses into `Filter.should` (not `must`), searching the whole union.
+#[test]
+fn test_binary_qdrant_or_filter() {
+    wait_for_qdrant();
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "qdrant-or", "engine": "qdrant",
+        "connection_params": {"timeout": 60}, "collection_params": {"timeout": 60},
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 128}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj =
+        common::write_or_filter_project("or-test", &serde_json::to_string(&configs).unwrap(), dim);
+    assert!(proj.matching_docs >= proj.top);
+    let grpc = QDRANT_GRPC_PORT.to_string();
+    let rest = QDRANT_REST_PORT.to_string();
+    assert!(
+        common::run_binary(
+            &proj.root,
+            "qdrant-or",
+            "or-test",
+            "localhost",
+            &[
+                ("QDRANT_GRPC_PORT", grpc.as_str()),
+                ("QDRANT_REST_PORT", rest.as_str()),
+            ],
+        ),
+        "qdrant or-filter run failed"
+    );
+    let recall = common::read_recall(&proj.root, "qdrant-or");
+    println!("qdrant or-filter recall={:.3}", recall);
+    assert!(recall >= 0.9, "qdrant or-filter recall {:.3} < 0.9", recall);
+}
+
 /// UUID exact-match filter end-to-end. Qdrant maps the `uuid` schema type to its
 /// dedicated `FieldType::Uuid` payload index (distinct from keyword), which was
 /// otherwise untested — this proves an exact `uid == UUIDS[0]` match selects the

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -2291,6 +2291,14 @@ fn test_binary_redis_and_filter() {
     run_filter_recall_test("redis-and", "and-test", common::write_and_filter_project);
 }
 
+/// Multi-condition OR: `color == "red" OR size >= 90` in one query — verifies the
+/// engine UNIONs two clauses (top-level `{or:[...]}`). An engine that treats it
+/// as AND, or drops an arm, searches a strict subset and recall collapses.
+#[test]
+fn test_binary_redis_or_filter() {
+    run_filter_recall_test("redis-or", "or-test", common::write_or_filter_project);
+}
+
 /// Selectivity ladder: one `rank < K` range query per rung, sweeping filter
 /// selectivity from ~3% to ~99% in a single dataset. Verifies the numeric-range
 /// filter path stays correct (recall vs per-rung ground truth) across the whole

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -1402,6 +1402,14 @@ fn test_binary_valkey_selectivity() {
     run_filter_recall_test("valkey-sel", "sel-test", common::write_selectivity_project);
 }
 
+/// Multi-condition OR: `color == "red" OR size >= 90` — verifies Valkey Search
+/// UNIONs two clauses (top-level `{or:[...]}` → `@color:{red} | @size:[90 +inf]`),
+/// not an intersection.
+#[test]
+fn test_binary_valkey_or_filter() {
+    run_filter_recall_test("valkey-or", "or-test", common::write_or_filter_project);
+}
+
 /// Multi-tenancy: many tenants share ONE index and every query is scoped to a
 /// single tenant via a keyword-equality filter on a `tenant` field, with ground
 /// truth brute-forced over ONLY that tenant's docs. Reuses the keyword-TAG

--- a/tests/integration_weaviate.rs
+++ b/tests/integration_weaviate.rs
@@ -673,6 +673,23 @@ fn test_binary_weaviate_uuid() {
     assert!(recall >= 0.9, "weaviate uuid recall {:.3} < 0.9", recall);
 }
 
+/// Multi-condition OR (`color == "red" OR size >= 90`) — verifies Weaviate unions
+/// two clauses into a `Filters.Or` operand, searching the union not the
+/// intersection.
+#[test]
+fn test_binary_weaviate_or_filter() {
+    wait_for_weaviate();
+    let proj = common::write_or_filter_project("or-test", &weaviate_filter_config(), 8);
+    assert!(proj.matching_docs >= proj.top);
+    let recall = run_weaviate_filter(&proj.root, "or-test", "BenchOr");
+    println!("weaviate or-filter recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "weaviate or-filter recall {:.3} < 0.9",
+        recall
+    );
+}
+
 /// Multi-condition AND (keyword match AND numeric range) — verifies Weaviate
 /// composes two conditions of different types into one `Filters.And` operand
 /// (`Equal color` AND `GreaterThanEqual size`), not just a single clause.


### PR DESCRIPTION
## What

Top-level **`{or: [...]}` (clause UNION)** was **implemented in every engine's filter builder but had zero end-to-end coverage** — only the AND intersection path was tested (#175/#176). OR is a distinct complex-query feature, and an engine that mis-handles it (treats OR as AND, or drops an arm) returns wrong neighbours with no test to catch it.

## How

Adds `write_or_filter_project`: same `color`/`size` payload as the AND fixture, but the query is `color == "red" OR size >= 90`. The arms overlap only partially, so:

- `color == "red"` → 200 docs
- `size >= 90` → 40 docs
- **union → 220 docs** (strictly larger than either arm)
- intersection → 20 docs

An engine that collapses OR to AND searches only ~20 docs, so its nearest neighbours diverge from the union's and recall collapses well below 0.9.

## Coverage

OR recall tests added for **all nine** locally-testable filtering engines, each exercising its native union operator:

| engine | union operator | recall |
|---|---|---|
| redis | RediSearch `\|` | 1.000 |
| valkey | Valkey Search `\|` | 1.000 |
| qdrant | `Filter.should` | 1.000 |
| elasticsearch | `bool.should` (msm 1) | 1.000 |
| opensearch | `bool.should` (msm 1) | 1.000 |
| pgvector | SQL `OR` | 1.000 |
| milvus | boolean-expr `\|\|` | 1.000 |
| weaviate | `Filters.Or` | 1.000 |
| mongodb | `$or` | 1.000 |

All live-validated at recall 1.000 vs union ground truth. `build --bins`, `fmt --check`, `clippy --tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)