### PR TITLE
fix(sweep): opt-in --reset-between-configs to cap --keep-data sweep memory (#184)

### DIFF
--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -42,6 +42,15 @@ pub struct Args {
     #[arg(long, default_value = "false")]
     pub keep_data: bool,
 
+    /// On a multi-config sweep with `--keep-data`, free each config's data before
+    /// the next runs so only ONE config's corpus is resident at a time (keeping
+    /// just the last config's). Prevents the per-config keyspaces from
+    /// accumulating and OOMing a memory-bounded server (#184). Off by default, so
+    /// `--keep-data` still keeps every config's data coexisting (the default,
+    /// needed for `--skip-upload` reuse across configs).
+    #[arg(long, default_value = "false")]
+    pub reset_between_configs: bool,
+
     /// Skip if results already exist (accepts an optional value, e.g.
     /// `--skip-if-exists false`; bare `--skip-if-exists` means true)
     #[arg(

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -259,7 +259,15 @@ pub fn run(args: &Args) -> Result<(), String> {
         None
     };
 
-    'experiments: for (_engine_name, engine_config) in &engines {
+    let num_engine_configs = engines.len();
+    'experiments: for (engine_idx, (_engine_name, engine_config)) in engines.iter().enumerate() {
+        // On a multi-config sweep, `--keep-data` must keep only ONE config's data
+        // resident at a time — otherwise every config's copy of the (identical)
+        // corpus accumulates and OOMs a memory-bounded server (#184). So only the
+        // LAST config keeps its data; earlier configs tear down after finishing,
+        // even under `--keep-data`. (A full M×EF sweep runs every config over the
+        // same datasets, so the last config is the last to touch each dataset.)
+        let is_last_config = engine_idx + 1 == num_engine_configs;
         // Apply --skip-vector-index: override name and set flag on config
         let mut engine_config = (*engine_config).clone();
         if args.skip_vector_index {
@@ -310,7 +318,7 @@ pub fn run(args: &Args) -> Result<(), String> {
             let mut engine = create_engine(&engine_config, &args.host)?;
 
             // Run experiment phases
-            if let Err(e) = run_single_experiment(&mut *engine, &dataset, args) {
+            if let Err(e) = run_single_experiment(&mut *engine, &dataset, args, is_last_config) {
                 eprintln!("Experiment failed: {}", e);
                 if args.exit_on_error {
                     pb.finish_and_clear();
@@ -351,7 +359,12 @@ fn run_single_experiment(
     engine: &mut dyn Engine,
     dataset: &Dataset,
     args: &Args,
+    is_last_config: bool,
 ) -> Result<(), String> {
+    // `--keep-data` only skips cleanup for the LAST config in a sweep; earlier
+    // configs still tear down so their (identical) corpus copy doesn't accumulate
+    // and OOM the server (#184). For a single-config run this is always the last.
+    let keep_data = args.keep_data && is_last_config;
     // Check if we should skip
     if args.skip_if_exists {
         let glob_pattern = format!("{}-{}-upload-*.json", engine.name(), dataset.config.name);
@@ -448,10 +461,17 @@ fn run_single_experiment(
                      skipping search (no filter conditions possible)",
                     dataset.config.name
                 );
-                if args.keep_data {
+                if keep_data {
                     println!("Experiment stage: Keep data (cleanup skipped)");
                 } else {
-                    println!("Experiment stage: Cleanup (deleting index and data)");
+                    if args.keep_data {
+                        println!(
+                            "Experiment stage: Cleanup (multi-config --keep-data: freeing this \
+                             config's data before the next; only the last config's data is kept)"
+                        );
+                    } else {
+                        println!("Experiment stage: Cleanup (deleting index and data)");
+                    }
                     engine.delete()?;
                 }
                 println!("Experiment stage: Done");
@@ -858,11 +878,20 @@ fn run_single_experiment(
         )?;
     }
 
-    // Cleanup unless the caller wants to reuse the populated index.
-    if args.keep_data {
+    // Cleanup unless the caller wants to reuse the populated index. On a
+    // multi-config sweep `--keep-data` keeps only the LAST config's data; earlier
+    // configs tear down here so their corpus copy doesn't accumulate (#184).
+    if keep_data {
         println!("Experiment stage: Keep data (cleanup skipped)");
     } else {
-        println!("Experiment stage: Cleanup (deleting index and data)");
+        if args.keep_data {
+            println!(
+                "Experiment stage: Cleanup (multi-config --keep-data: freeing this config's data \
+                 before the next; only the last config's data is kept)"
+            );
+        } else {
+            println!("Experiment stage: Cleanup (deleting index and data)");
+        }
         engine.delete()?;
     }
 

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -260,13 +260,26 @@ pub fn run(args: &Args) -> Result<(), String> {
     };
 
     let num_engine_configs = engines.len();
+    // `--keep-data` on a multi-config sweep keeps EVERY config's data coexisting
+    // (the default — needed for `--skip-upload` reuse across configs). On a
+    // memory-bounded server that accumulation OOMs (#184); `--reset-between-configs`
+    // opts into freeing each config before the next so only the LAST config's data
+    // is kept. Warn up-front when the user is on the accumulating path with >1
+    // config so the peak-memory cost isn't a silent surprise.
+    if args.keep_data && num_engine_configs > 1 && !args.reset_between_configs {
+        eprintln!(
+            "NOTE: --keep-data with {} configs keeps EVERY config's data resident \
+             simultaneously (peak memory ≈ sum of all configs' datasets). On a \
+             memory-bounded server pass --reset-between-configs to keep only one \
+             config's data at a time, or drop --keep-data.",
+            num_engine_configs
+        );
+    }
     'experiments: for (engine_idx, (_engine_name, engine_config)) in engines.iter().enumerate() {
-        // On a multi-config sweep, `--keep-data` must keep only ONE config's data
-        // resident at a time — otherwise every config's copy of the (identical)
-        // corpus accumulates and OOMs a memory-bounded server (#184). So only the
-        // LAST config keeps its data; earlier configs tear down after finishing,
-        // even under `--keep-data`. (A full M×EF sweep runs every config over the
-        // same datasets, so the last config is the last to touch each dataset.)
+        // With --reset-between-configs, only the LAST config keeps its data under
+        // --keep-data; earlier configs tear down after finishing so at most one
+        // config's corpus is resident (#184). (A full M×EF sweep runs every config
+        // over the same datasets, so the last config is the last to touch each.)
         let is_last_config = engine_idx + 1 == num_engine_configs;
         // Apply --skip-vector-index: override name and set flag on config
         let mut engine_config = (*engine_config).clone();
@@ -361,10 +374,12 @@ fn run_single_experiment(
     args: &Args,
     is_last_config: bool,
 ) -> Result<(), String> {
-    // `--keep-data` only skips cleanup for the LAST config in a sweep; earlier
-    // configs still tear down so their (identical) corpus copy doesn't accumulate
-    // and OOM the server (#184). For a single-config run this is always the last.
-    let keep_data = args.keep_data && is_last_config;
+    // With --reset-between-configs, `--keep-data` only skips cleanup for the LAST
+    // config in a sweep; earlier configs tear down so their (identical) corpus
+    // copy doesn't accumulate and OOM the server (#184). Without the flag,
+    // `--keep-data` keeps every config's data (the default coexistence behaviour,
+    // needed for --skip-upload reuse). A single-config run is always the last.
+    let keep_data = args.keep_data && (is_last_config || !args.reset_between_configs);
     // Check if we should skip
     if args.skip_if_exists {
         let glob_pattern = format!("{}-{}-upload-*.json", engine.name(), dataset.config.name);

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -2299,11 +2299,13 @@ fn test_binary_redis_or_filter() {
     run_filter_recall_test("redis-or", "or-test", common::write_or_filter_project);
 }
 
-/// Regression for #184: a multi-config sweep with `--keep-data` must keep only
-/// the LAST config's data resident, not accumulate every config's copy (which
-/// OOMs a memory-bounded server). Runs a 2-config sweep with `--keep-data` and
-/// asserts exactly ONE FT index survives (the last config's) — the buggy
-/// behaviour left both, and the total keyspace stays at one config's size.
+/// Regression for #184: a multi-config sweep with `--keep-data
+/// --reset-between-configs` must keep only the LAST config's data resident, not
+/// accumulate every config's copy (which OOMs a memory-bounded server). Runs a
+/// 2-config sweep with both flags and asserts exactly ONE FT index survives (the
+/// last config's) and the keyspace stays at one config's size. (Without
+/// --reset-between-configs, --keep-data keeps both configs coexisting — see
+/// test_binary_redis_coexistence_skip_upload.)
 #[test]
 fn test_binary_redis_keep_data_sweep_frees_prior_configs() {
     wait_for_redis();
@@ -2337,7 +2339,7 @@ fn test_binary_redis_keep_data_sweep_frees_prior_configs() {
             "sweep-test",
             "localhost",
             &[("REDIS_PORT", &TEST_PORT.to_string())],
-            &["--keep-data"],
+            &["--keep-data", "--reset-between-configs"],
         ),
         "redis keep-data sweep run failed"
     );

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -2299,6 +2299,75 @@ fn test_binary_redis_or_filter() {
     run_filter_recall_test("redis-or", "or-test", common::write_or_filter_project);
 }
 
+/// Regression for #184: a multi-config sweep with `--keep-data` must keep only
+/// the LAST config's data resident, not accumulate every config's copy (which
+/// OOMs a memory-bounded server). Runs a 2-config sweep with `--keep-data` and
+/// asserts exactly ONE FT index survives (the last config's) — the buggy
+/// behaviour left both, and the total keyspace stays at one config's size.
+#[test]
+fn test_binary_redis_keep_data_sweep_frees_prior_configs() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 8;
+    // Two configs over the SAME dataset — a minimal M×EF sweep. Distinct names →
+    // distinct per-config index/keyspace (idx:redis-sweepa / idx:redis-sweepb).
+    let configs = serde_json::json!([
+        {
+            "name": "redis-sweepa", "engine": "redis",
+            "search_params": [{"parallel": 1, "search_params": {"ef": 128}}],
+            "upload_params": {"parallel": 1, "batch_size": 200}
+        },
+        {
+            "name": "redis-sweepb", "engine": "redis",
+            "search_params": [{"parallel": 1, "search_params": {"ef": 128}}],
+            "upload_params": {"parallel": 1, "batch_size": 200}
+        }
+    ]);
+    let proj =
+        common::write_bool_project("sweep-test", &serde_json::to_string(&configs).unwrap(), dim);
+
+    // `redis-sweep*` matches both configs; `--keep-data` would (pre-fix) leave
+    // both configs' data behind.
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "redis-sweep*",
+            "sweep-test",
+            "localhost",
+            &[("REDIS_PORT", &TEST_PORT.to_string())],
+            &["--keep-data"],
+        ),
+        "redis keep-data sweep run failed"
+    );
+
+    // Exactly one FT index must remain (the last config's); the first config's
+    // was torn down despite --keep-data. Pre-fix this was 2.
+    let indexes: Vec<String> = redis::cmd("FT._LIST").query(&mut conn).unwrap_or_default();
+    let sweep_indexes: Vec<&String> = indexes
+        .iter()
+        .filter(|i| i.contains("sweepa") || i.contains("sweepb"))
+        .collect();
+    println!("surviving sweep indexes: {:?}", sweep_indexes);
+    assert_eq!(
+        sweep_indexes.len(),
+        1,
+        "expected exactly 1 surviving sweep index (only the last config kept), got {:?}",
+        sweep_indexes
+    );
+
+    // And the keyspace holds one config's docs, not two (the memory symptom).
+    let dbsize: i64 = redis::cmd("DBSIZE").query(&mut conn).unwrap_or(0);
+    println!("dbsize after keep-data sweep: {}", dbsize);
+    assert!(
+        dbsize <= 600,
+        "keyspace should hold ~one config's 400 docs, not two configs' 800 (got {dbsize})"
+    );
+
+    flush_db(&mut conn);
+}
+
 /// Nested boolean: `(color==red AND size>=50) OR (color==blue AND size<10)` —
 /// verifies the parser recurses into grouped sub-conditions (parenthesised
 /// RediSearch clause) instead of flattening the tree. A flattening parser matches


### PR DESCRIPTION
## The regression (#184)

Since per-config disjoint keyspaces (#153), a multi-config sweep with `--keep-data` keeps **every** config's copy of the (identical) corpus resident simultaneously — cleanup is skipped for all of them. On a fixed-memory server this silently OOMs partway through a sweep (a 10M `deep-image-96` M×EF sweep died at config 2/12 on a 25 GB DB), and the leftover poisons the next run.

## Why not just "keep only the last config" by default

The first attempt did that — and CI caught that it **breaks a deliberate feature**: `test_binary_redis_coexistence_skip_upload` (#153/#155) relies on `--keep-data` keeping *all* configs' data coexisting, so a later `--skip-upload` run can search each config's own index. Tearing down prior configs by default regresses that.

## Fix (opt-in — #184 option 2)

Add a `--reset-between-configs` flag (default **off**):

- **Default** (`--keep-data` alone): every config's data coexists, exactly as before — the coexistence + `--skip-upload` feature is preserved (its test passes unchanged).
- **`--keep-data --reset-between-configs`**: each config tears down when it finishes, so only **one config's corpus is resident at a time** (the last config's is kept). Memory-bounded sweeps use this to avoid the OOM.

Also adds an up-front **NOTE** when `--keep-data` is used with >1 config *without* the flag, so the peak-memory ≈ sum-of-configs cost isn't a silent surprise (#184 option 1b).

## Tests

- **`test_binary_redis_keep_data_sweep_frees_prior_configs`** (new): 2-config sweep with `--keep-data --reset-between-configs` → exactly **one** FT index survives (the last config's), `DBSIZE = 400` (one config's docs, not two).
- **`test_binary_redis_coexistence_skip_upload`** (existing, unchanged): still passes — default `--keep-data` keeps both configs coexisting.

529 unit tests pass; `fmt`/`clippy` clean.

Fixes #184. (#188 — the N× re-upload *time* sibling — is a separate follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)