### PR TITLE
ci(docker-publish): skip publish (don't fail master) when Docker Hub secrets absent

### DIFF
--- a/.github/workflows/docker-publish-master.yml
+++ b/.github/workflows/docker-publish-master.yml
@@ -32,15 +32,23 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Check Docker Hub credentials
+        id: check
         run: |
           if [[ -z "${{ secrets.DOCKER_USERNAME }}" || -z "${{ secrets.DOCKER_PASSWORD }}" ]]; then
-            echo "Docker Hub credentials not configured!"
-            echo "Please set DOCKER_USERNAME and DOCKER_PASSWORD secrets in repository settings."
-            exit 1
+            # Publishing is optional infrastructure (e.g. before the Docker Hub
+            # secrets are configured on a fork/new org). Skip it cleanly instead
+            # of failing the whole push — a perpetually-red master hides real
+            # regressions. CI + Validate still gate correctness.
+            echo "Docker Hub credentials not configured — SKIPPING publish."
+            echo "Set DOCKER_USERNAME and DOCKER_PASSWORD repo secrets to enable it."
+            echo "has_creds=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Docker Hub credentials are configured"
+            echo "has_creds=true" >> "$GITHUB_OUTPUT"
           fi
-          echo "Docker Hub credentials are configured"
 
       - name: Log in to Docker Hub
+        if: steps.check.outputs.has_creds == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -48,6 +56,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for Docker
+        if: steps.check.outputs.has_creds == 'true'
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
@@ -56,6 +65,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker image
+        if: steps.check.outputs.has_creds == 'true'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -67,6 +77,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Update Docker Hub description
+        if: steps.check.outputs.has_creds == 'true'
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -76,6 +87,12 @@ jobs:
 
       - name: Generate summary
         run: |
+          if [[ "${{ steps.check.outputs.has_creds }}" != "true" ]]; then
+            echo "## Docker Publish skipped" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Docker Hub credentials (\`DOCKER_USERNAME\` / \`DOCKER_PASSWORD\`) are not configured on this repository, so the image was **not** published. Set those repo secrets to enable publishing." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
           echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Repository:** \`${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## The master failure

Every push to master shows a red **`Docker Publish - Latest`** — even though `CI` and `Validate Datasets` pass. The workflow's credentials-check step does `exit 1` when `DOCKER_USERNAME` / `DOCKER_PASSWORD` aren't configured:

```
Docker Hub credentials not configured!
Please set DOCKER_USERNAME and DOCKER_PASSWORD secrets in repository settings.
##[error]Process completed with exit code 1.
```

Those secrets aren't set on the redis-org repo (likely lost in the `redis-performance` → `redis` org move), so the post-merge publish fails on **every** commit. A perpetually-red master hides real regressions.

## Fix

The credentials check now sets a `has_creds` step **output** instead of failing. The `login` / `metadata` / `build-push` / `dockerhub-description` steps are gated on `if: steps.check.outputs.has_creds == 'true'`, and the summary reports the skip.

- **Secrets configured** → publishes exactly as before.
- **Secrets absent** → workflow **succeeds** with a clear summary: *"Docker Publish skipped — set `DOCKER_USERNAME`/`DOCKER_PASSWORD` to enable it."*

So master goes green while still publishing once the secrets are added — no behavior change when they exist.

(`docker-publish-release.yml` has the same `exit 1` pattern but only runs on release tags; left as-is, since a release that can't publish arguably *should* fail loudly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)