### PR TITLE
feat(measurement): barrier-synced start + per-worker warmup across all engines (#118)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/chroma.rs
+++ b/src/bin/vector_db_benchmark/engine/chroma.rs
@@ -665,7 +665,17 @@ impl Engine for ChromaEngine {
 
         let query_idx = Arc::new(AtomicUsize::new(0));
         let pb = self.progress_bar(num_to_run);
-        let start_time = Instant::now();
+
+        // Barrier-synchronized start so per-worker HTTP client construction AND the
+        // cold first query fall OUTSIDE the measured window (mirrors redis/vertex).
+        // Every worker builds its client + primes, then blocks on `ready`; the main
+        // thread stamps the shared start instant into `start_cell` and releases `go`,
+        // so the measurement clock starts only once all workers are warm. A worker
+        // that fails to build its client MUST still pass both barriers before
+        // returning, or the run would deadlock.
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -684,6 +694,8 @@ impl Engine for ChromaEngine {
                 let tops = &tops;
                 let bodies = &bodies;
                 let query_idx = Arc::clone(&query_idx);
+                let ready = Arc::clone(&ready);
+                let go = Arc::clone(&go);
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -698,8 +710,32 @@ impl Engine for ChromaEngine {
                         .build()
                     {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            // Still cross both barriers so peers aren't stranded.
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
+
+                    // Prime this client with ONE discarded query so the cold first
+                    // round-trip (TCP/TLS setup + server JIT/caches) is not inside the
+                    // measured window. Best effort: errors are ignored and its sample
+                    // is NOT recorded.
+                    if !bodies.is_empty() {
+                        let _ = client
+                            .post(&query_url)
+                            .header("Content-Type", "application/json")
+                            .body(bodies[0].clone())
+                            .send()
+                            .and_then(|resp| resp.error_for_status())
+                            .and_then(|resp| resp.text());
+                    }
+
+                    // Signal "ready + primed", then block until the main thread stamps
+                    // the shared measurement start and releases everyone.
+                    ready.wait();
+                    go.wait();
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -745,6 +781,14 @@ impl Engine for ChromaEngine {
                     (t, p, r, mr, nd)
                 }));
             }
+
+            // All workers spawned: wait until every one has built its client and
+            // primed, stamp the shared measurement start, then release them together.
+            ready.wait();
+            let st = Instant::now();
+            start_cell.set(st).ok();
+            go.wait();
+
             for h in handles {
                 let (t, p, r, mr, nd) = h.join().unwrap();
                 times.extend(t);
@@ -756,7 +800,12 @@ impl Engine for ChromaEngine {
         });
 
         pb.finish_and_clear();
-        let total_time = start_time.elapsed().as_secs_f64();
+        // total_time excludes connection setup and the cold first query: it is
+        // measured from the barrier release (start_cell), not a pre-scope instant.
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
             &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,

--- a/src/bin/vector_db_benchmark/engine/dragonfly.rs
+++ b/src/bin/vector_db_benchmark/engine/dragonfly.rs
@@ -1014,7 +1014,17 @@ impl Engine for DragonflyEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
-        let start_time = Instant::now();
+
+        // Barrier-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window (mirrors redis.rs/vertex.rs). Every
+        // worker connects + primes, then blocks on `ready`; the main thread stamps
+        // the shared start instant into `start_cell` and releases `go`, so the
+        // measurement clock starts only once all workers are warm and poised. A
+        // worker that fails to connect MUST still pass both barriers before
+        // returning, or the run would deadlock.
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -1034,6 +1044,8 @@ impl Engine for DragonflyEngine {
                 let algorithm = algorithm.as_str();
                 let index_name = index_name.as_str();
                 let query_idx = Arc::clone(&query_idx);
+                let ready = Arc::clone(&ready);
+                let go = Arc::clone(&go);
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -1046,8 +1058,36 @@ impl Engine for DragonflyEngine {
 
                     let mut conn = match DragonflyEngine::connect(&host, port) {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            // Still cross both barriers so peers aren't stranded.
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
+
+                    // Prime this connection with ONE discarded query (index 0) so
+                    // the cold first round-trip is not inside the measured window.
+                    // Best effort: errors ignored and its sample is NOT recorded.
+                    {
+                        let prime_top = explicit_top.unwrap_or(10);
+                        let _ = ft_search_knn(
+                            &mut conn,
+                            index_name,
+                            &encoded_queries[0],
+                            &query_strs[0],
+                            prime_top,
+                            ef,
+                            algorithm,
+                            query_timeout,
+                            parsed_filters[0].as_ref(),
+                        );
+                    }
+
+                    // Signal "connected + primed", then block until the main thread
+                    // stamps the shared measurement start and releases everyone.
+                    ready.wait();
+                    go.wait();
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1108,6 +1148,13 @@ impl Engine for DragonflyEngine {
                 }));
             }
 
+            // All workers are connected + primed once they clear `ready`; stamp the
+            // shared measurement start and release them together via `go`.
+            ready.wait();
+            let st = Instant::now();
+            start_cell.set(st).ok();
+            go.wait();
+
             for h in handles {
                 let (t, p, r, mr, nd) = h.join().unwrap();
                 times.extend(t);
@@ -1119,7 +1166,11 @@ impl Engine for DragonflyEngine {
         });
 
         pb.finish_and_clear();
-        let total_time = start_time.elapsed().as_secs_f64();
+        // total_time excludes connection setup and the cold first query.
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
 
         if times.is_empty() {
             return Err("No searches completed".to_string());

--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -938,10 +938,21 @@ impl Engine for ElasticsearchEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
-        let start_time = Instant::now();
         let base_url = self.base_url.clone();
         let timeout = self.timeout;
         let index_name = self.index_name.clone();
+
+        // Barrier-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window (mirrors redis/vertex). Every worker
+        // builds its runtime + client and primes ONE discarded query, then blocks
+        // on `ready`; the main thread stamps the shared start instant into
+        // `start_cell` and releases `go`, so the measurement clock starts only once
+        // all workers are warm and poised. A worker that fails to build its runtime
+        // or client MUST still pass both barriers before returning, or the run
+        // would deadlock.
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -958,6 +969,8 @@ impl Engine for ElasticsearchEngine {
                 let tops = &tops;
                 let raw_bodies = &raw_bodies;
                 let query_idx = Arc::clone(&query_idx);
+                let ready = Arc::clone(&ready);
+                let go = Arc::clone(&go);
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -972,12 +985,33 @@ impl Engine for ElasticsearchEngine {
                         .build()
                     {
                         Ok(rt) => rt,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            // Still cross both barriers so peers aren't stranded.
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
                     let client = match create_es_client(&base_url, timeout) {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
+
+                    // Prime this client with ONE discarded query so the cold first
+                    // round-trip is not inside the measured window. Best effort:
+                    // errors are ignored and its sample is NOT recorded.
+                    if num_to_run > 0 {
+                        let _ = knn_send(&rt, &client, &index_name, &raw_bodies[0]);
+                    }
+
+                    // Signal "connected + primed", then block until the main thread
+                    // stamps the shared measurement start and releases everyone.
+                    ready.wait();
+                    go.wait();
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1019,6 +1053,13 @@ impl Engine for ElasticsearchEngine {
                 }));
             }
 
+            // All workers are spawned; wait until each is connected + primed, then
+            // stamp the shared measurement start and release everyone at once.
+            ready.wait();
+            let st = Instant::now();
+            start_cell.set(st).ok();
+            go.wait();
+
             for h in handles {
                 let (t, p, r, mr, nd) = h.join().unwrap();
                 times.extend(t);
@@ -1030,7 +1071,12 @@ impl Engine for ElasticsearchEngine {
         });
 
         pb.finish_and_clear();
-        let total_time = start_time.elapsed().as_secs_f64();
+        // total_time excludes connection setup and the cold first query — it is
+        // measured from the barrier release stamped into start_cell.
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -1033,7 +1033,17 @@ impl Engine for MilvusEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
-        let start_time = Instant::now();
+
+        // Barrier-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window (mirrors the Redis/Vertex engines).
+        // Every worker builds its client + primes one discarded query, then blocks
+        // on `ready`; the main thread stamps the shared start instant into
+        // `start_cell` and releases `go`, so the measurement clock starts only once
+        // all workers are warm and poised. A worker that fails to build its client
+        // MUST still pass both barriers before returning, or the run deadlocks.
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -1050,6 +1060,9 @@ impl Engine for MilvusEngine {
                 let tops = &tops;
                 let bodies = &bodies;
                 let query_idx = Arc::clone(&query_idx);
+                let ready = Arc::clone(&ready);
+                let go = Arc::clone(&go);
+                let start_cell = Arc::clone(&start_cell);
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -1064,8 +1077,26 @@ impl Engine for MilvusEngine {
                         .build()
                     {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            // Still cross both barriers so peers aren't stranded.
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
+
+                    // Prime this client with ONE discarded query (body 0) so the
+                    // cold first round-trip is not inside the measured window. Best
+                    // effort: errors are ignored and its sample is NOT recorded.
+                    if !bodies.is_empty() {
+                        let _ = send_search(&client, &base_url, &bodies[0]);
+                    }
+
+                    // Signal "connected + primed", then block until the main thread
+                    // stamps the shared measurement start and releases everyone.
+                    ready.wait();
+                    go.wait();
+                    let _start_time = *start_cell.get().unwrap();
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1107,6 +1138,14 @@ impl Engine for MilvusEngine {
                 }));
             }
 
+            // All workers are spawned; wait until each has connected + primed,
+            // then stamp the shared start instant and release them together so the
+            // measurement clock excludes connection setup and the cold first query.
+            ready.wait();
+            let st = Instant::now();
+            start_cell.set(st).ok();
+            go.wait();
+
             for h in handles {
                 let (t, p, r, mr, nd) = h.join().unwrap();
                 times.extend(t);
@@ -1118,7 +1157,12 @@ impl Engine for MilvusEngine {
         });
 
         pb.finish_and_clear();
-        let total_time = start_time.elapsed().as_secs_f64();
+        // total_time excludes connection setup and the cold first query: it is
+        // measured from the barrier release stamped into `start_cell`.
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -1291,7 +1291,17 @@ impl Engine for MongoDBEngine {
 
         let pb = self.create_progress_bar(num_to_run);
 
-        let start_time = Instant::now();
+        // Barrier-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window (mirrors the Redis/Vertex engines).
+        // Every worker connects + primes, then blocks on `ready`; the main thread
+        // stamps the shared start instant into `start_cell` and releases `go`, so
+        // the measurement clock starts only once all workers are warm and poised.
+        // A worker that fails to connect MUST still pass both barriers before
+        // returning, or the run would deadlock.
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+
         let uri = self.uri.clone();
         let db_name = self.db_name.clone();
         let collection_name = self.collection_name.clone();
@@ -1312,6 +1322,9 @@ impl Engine for MongoDBEngine {
                 let tops = &tops;
                 let pipelines = &pipelines;
                 let query_idx = Arc::clone(&query_idx);
+                let ready = Arc::clone(&ready);
+                let go = Arc::clone(&go);
+                let start_cell = Arc::clone(&start_cell);
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -1324,11 +1337,29 @@ impl Engine for MongoDBEngine {
 
                     let client = match Client::with_uri_str(&uri) {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            // Still cross both barriers so peers aren't stranded.
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
                     let coll = client
                         .database(&db_name)
                         .collection::<Document>(&collection_name);
+
+                    // Prime this connection with ONE discarded query so the cold
+                    // first round-trip is not inside the measured window. Best
+                    // effort: errors are ignored and its sample is NOT recorded.
+                    if let Some(prime_pipeline) = pipelines.first() {
+                        let _ = send_search(&coll, prime_pipeline);
+                    }
+
+                    // Signal "connected + primed", then block until the main thread
+                    // stamps the shared measurement start and releases everyone.
+                    ready.wait();
+                    go.wait();
+                    let _start_time = *start_cell.get().unwrap();
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1380,6 +1411,14 @@ impl Engine for MongoDBEngine {
                 }));
             }
 
+            // All workers are connected + primed and waiting on `ready`. Stamp the
+            // shared start instant, then release everyone via `go` so the measured
+            // window excludes connection setup and the cold first query.
+            ready.wait();
+            let st = Instant::now();
+            start_cell.set(st).ok();
+            go.wait();
+
             for h in handles {
                 let (t, p, r, mr, nd) = h.join().unwrap();
                 times.extend(t);
@@ -1391,7 +1430,11 @@ impl Engine for MongoDBEngine {
         });
 
         pb.finish_and_clear();
-        let total_time = start_time.elapsed().as_secs_f64();
+        // total_time excludes connection setup and the cold first query.
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -350,38 +350,11 @@ impl OpenSearchEngine {
         Ok(())
     }
 
-    /// Load the kNN index into memory before searching so the first queries
-    /// aren't penalised by cold-cache graph loading. Best-effort: a non-success
-    /// response is logged, not fatal.
-    fn warmup(&self) -> Result<(), String> {
-        use opensearch::http::headers::HeaderMap;
-        use opensearch::http::Method;
-
-        let path = format!("/_plugins/_knn/warmup/{}", self.index_name);
-        let resp = self
-            .rt
-            .block_on(self.client.transport().send(
-                Method::Get,
-                &path,
-                HeaderMap::new(),
-                Option::<&()>::None,
-                Option::<Vec<u8>>::None,
-                None,
-            ))
-            .map_err(|e| format!("kNN warmup request failed: {}", e))?;
-
-        if !resp.status_code().is_success() {
-            let text = self.rt.block_on(resp.text()).unwrap_or_default();
-            eprintln!("Warning: kNN warmup returned non-success: {}", text);
-        }
-        Ok(())
-    }
-
     /// Apply search-time settings (e.g., knn.algo_param.ef_search)
     fn setup_search(&self, params: &SearchParams) -> Result<(), String> {
-        // Warm the graph into memory before timing any queries.
-        self.warmup()?;
-
+        // Cold-cache graph loading is warmed uniformly by the per-worker prime
+        // query in `search` (mirrors redis/vertex), so no engine-specific
+        // server-side `_knn/warmup` call is needed here.
         let ef_search = params
             .extra
             .as_ref()
@@ -998,10 +971,21 @@ impl Engine for OpenSearchEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
-        let start_time = Instant::now();
         let base_url = self.base_url.clone();
         let timeout = self.timeout;
         let index_name = self.index_name.clone();
+
+        // Barrier-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window (mirrors the Redis/Vertex engines).
+        // Every worker builds its runtime + client and primes with one discarded
+        // query, then blocks on `ready`; the main thread stamps the shared start
+        // instant into `start_cell` and releases `go`, so the measurement clock
+        // starts only once all workers are warm and poised. A worker that fails to
+        // set up MUST still pass both barriers before returning, or the run would
+        // deadlock.
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -1018,6 +1002,8 @@ impl Engine for OpenSearchEngine {
                 let tops = &tops;
                 let raw_bodies = &raw_bodies;
                 let query_idx = Arc::clone(&query_idx);
+                let ready = Arc::clone(&ready);
+                let go = Arc::clone(&go);
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -1032,12 +1018,33 @@ impl Engine for OpenSearchEngine {
                         .build()
                     {
                         Ok(rt) => rt,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            // Still cross both barriers so peers aren't stranded.
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
                     let client = match create_os_client(&base_url, timeout) {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
+
+                    // Prime this connection with ONE discarded query so the cold
+                    // first round-trip is not inside the measured window. Best
+                    // effort: errors are ignored and its sample is NOT recorded.
+                    if num_to_run > 0 {
+                        let _ = knn_send(&rt, &client, &index_name, &raw_bodies[0]);
+                    }
+
+                    // Signal "connected + primed", then block until the main thread
+                    // stamps the shared measurement start and releases everyone.
+                    ready.wait();
+                    go.wait();
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1079,6 +1086,14 @@ impl Engine for OpenSearchEngine {
                 }));
             }
 
+            // All workers are connected + primed and blocked on `go`. Stamp the
+            // shared measurement start and release them simultaneously. The cold
+            // setup is already behind the barrier.
+            ready.wait();
+            let st = Instant::now();
+            start_cell.set(st).ok();
+            go.wait();
+
             for h in handles {
                 let (t, p, r, mr, nd) = h.join().unwrap();
                 times.extend(t);
@@ -1090,7 +1105,12 @@ impl Engine for OpenSearchEngine {
         });
 
         pb.finish_and_clear();
-        let total_time = start_time.elapsed().as_secs_f64();
+        // Measure from the post-barrier start stamp (workers already primed), so
+        // total_time excludes connection setup and the cold first query.
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -444,9 +444,19 @@ impl Engine for PgVectorEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
-        let start_time = Instant::now();
         let conn_str = self.connection_string();
         let distance_op = self.distance_op.clone();
+
+        // Barrier-synchronized start so per-worker connection setup AND the cold
+        // first query fall OUTSIDE the measured window (mirrors redis/vertex).
+        // Every worker connects + primes, then blocks on `ready`; the main thread
+        // stamps the shared start instant into `start_cell` and releases `go`, so
+        // the measurement clock starts only once all workers are warm and poised.
+        // A worker that fails to connect MUST still pass both barriers before
+        // returning, or the run would deadlock.
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -463,6 +473,8 @@ impl Engine for PgVectorEngine {
                 let neighbors = &neighbors;
                 let parsed_filters = &parsed_filters;
                 let query_idx = Arc::clone(&query_idx);
+                let ready = Arc::clone(&ready);
+                let go = Arc::clone(&go);
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -474,7 +486,12 @@ impl Engine for PgVectorEngine {
 
                     let mut conn = match postgres::Client::connect(&conn_str, postgres::NoTls) {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            // Still cross both barriers so peers aren't stranded.
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
 
                     // Set ef_search for this connection
@@ -488,6 +505,42 @@ impl Engine for PgVectorEngine {
                     // from the HNSW index until LIMIT is satisfied in exact order,
                     // instead of post-filtering a bounded candidate set.
                     let _ = conn.execute("SET hnsw.iterative_scan = strict_order", &[]);
+
+                    // Prime this connection with ONE discarded query (index 0) so
+                    // the cold first round-trip + plan build is not inside the
+                    // measured window. Best effort: errors ignored, no sample
+                    // recorded. Reuses the exact per-query request path below.
+                    if !queries.is_empty() {
+                        let prime_top = explicit_top.unwrap_or_else(|| {
+                            let n = neighbors[0].len();
+                            if n > 0 { n } else { 10 }
+                        });
+                        let prime_vec = pgvector::Vector::from(queries[0].clone());
+                        let prime_top_param = prime_top as i64;
+                        let prime_filter = parsed_filters[0].as_ref();
+                        let prime_where = prime_filter
+                            .map(|(tmpl, _)| format!(" WHERE {}", tmpl))
+                            .unwrap_or_default();
+                        let prime_sql = format!(
+                            "SELECT id, embedding {} $1 AS _score FROM items{} ORDER BY _score LIMIT $2::bigint",
+                            distance_op, prime_where
+                        );
+                        let mut prime_params: Vec<&(dyn ToSql + Sync)> =
+                            Vec::with_capacity(2 + prime_filter.map(|(_, v)| v.len()).unwrap_or(0));
+                        prime_params.push(&prime_vec);
+                        prime_params.push(&prime_top_param);
+                        if let Some((_, values)) = prime_filter {
+                            for v in values {
+                                prime_params.push(v.as_sql());
+                            }
+                        }
+                        let _ = conn.query(&prime_sql, &prime_params);
+                    }
+
+                    // Signal "connected + primed", then block until the main thread
+                    // stamps the shared measurement start and releases everyone.
+                    ready.wait();
+                    go.wait();
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -561,6 +614,14 @@ impl Engine for PgVectorEngine {
                 }));
             }
 
+            // All workers spawned. Wait until every one is connected + primed,
+            // stamp the shared start instant, then release them together so the
+            // measurement clock excludes connection setup and the cold first query.
+            ready.wait();
+            let st = Instant::now();
+            start_cell.set(st).ok();
+            go.wait();
+
             for h in handles {
                 let (t, p, r, mr, nd) = h.join().unwrap();
                 times.extend(t);
@@ -572,7 +633,12 @@ impl Engine for PgVectorEngine {
         });
 
         pb.finish_and_clear();
-        let total_time = start_time.elapsed().as_secs_f64();
+        // total_time excludes connection setup and the cold first query: it is
+        // measured from the barrier release stamped into `start_cell`.
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -1172,7 +1172,19 @@ impl Engine for QdrantEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
-        let start_time = Instant::now();
+
+        // Barrier-synchronized start so per-worker client/runtime setup AND the cold
+        // first query fall OUTSIDE the measured window (mirrors redis/vertex). Every
+        // worker builds its runtime + client and primes with one discarded query,
+        // then blocks on `ready`; the main thread stamps the shared start instant
+        // into `start_cell` and releases `go`, so the measurement clock starts only
+        // once all workers are warm and poised. A worker that fails to build its
+        // runtime/client MUST still pass both barriers before returning, or the run
+        // would deadlock.
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+
         // Each worker builds its own client/connection (like ES/OpenSearch) rather
         // than sharing one gRPC connection, which would serialize parallel queries.
         let grpc_url = self.grpc_url.clone();
@@ -1197,6 +1209,8 @@ impl Engine for QdrantEngine {
                 let neighbors = &neighbors;
                 let parsed_filters = &parsed_filters;
                 let query_idx = Arc::clone(&query_idx);
+                let ready = Arc::clone(&ready);
+                let go = Arc::clone(&go);
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -1206,36 +1220,10 @@ impl Engine for QdrantEngine {
                     let mut mr = Vec::new();
                     let mut nd = Vec::new();
 
-                    let rt = match tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                    {
-                        Ok(rt) => rt,
-                        Err(_) => return (t, p, r, mr, nd),
-                    };
-
-                    // Per-worker client so each thread has an independent connection.
-                    let client = match rt.block_on(async {
-                        let mut b = Qdrant::from_url(&grpc_url)
-                            .timeout(std::time::Duration::from_secs(timeout));
-                        if let Some(k) = &api_key {
-                            b = b.api_key(k.clone());
-                        }
-                        b.build()
-                    }) {
-                        Ok(c) => c,
-                        Err(e) => {
-                            eprintln!("Qdrant worker client build failed: {}", e);
-                            return (t, p, r, mr, nd);
-                        }
-                    };
-
-                    loop {
-                        let idx = query_idx.fetch_add(1, Ordering::Relaxed);
-                        if idx >= num_to_run {
-                            break;
-                        }
-
+                    // Build the fully-configured query for a given query index. Shared
+                    // by the prime (query 0, discarded) and the timed loop so both use
+                    // the exact same per-query request path.
+                    let build_query = |idx: usize| -> QueryPointsBuilder {
                         let top = explicit_top.unwrap_or_else(|| {
                             let n = neighbors[idx].len();
                             if n > 0 {
@@ -1316,6 +1304,70 @@ impl Engine for QdrantEngine {
                             query_builder = query_builder.prefetch(vec![pf.build()]);
                         }
 
+                        query_builder
+                    };
+
+                    let rt = match tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                    {
+                        Ok(rt) => rt,
+                        Err(_) => {
+                            // Still cross both barriers so peers aren't stranded.
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
+                    };
+
+                    // Per-worker client so each thread has an independent connection.
+                    let client = match rt.block_on(async {
+                        let mut b = Qdrant::from_url(&grpc_url)
+                            .timeout(std::time::Duration::from_secs(timeout));
+                        if let Some(k) = &api_key {
+                            b = b.api_key(k.clone());
+                        }
+                        b.build()
+                    }) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            eprintln!("Qdrant worker client build failed: {}", e);
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
+                    };
+
+                    // Prime this worker with ONE discarded query (query 0) so the cold
+                    // first round-trip (client warm-up + server caches/JIT) is not
+                    // inside the measured window. Best effort: errors are ignored and
+                    // its sample is NOT recorded.
+                    if num_to_run > 0 {
+                        let _ = rt.block_on(client.query(build_query(0)));
+                    }
+
+                    // Signal "runtime + client built + primed", then block until the
+                    // main thread stamps the shared measurement start and releases all.
+                    ready.wait();
+                    go.wait();
+
+                    loop {
+                        let idx = query_idx.fetch_add(1, Ordering::Relaxed);
+                        if idx >= num_to_run {
+                            break;
+                        }
+
+                        let top = explicit_top.unwrap_or_else(|| {
+                            let n = neighbors[idx].len();
+                            if n > 0 {
+                                n
+                            } else {
+                                10
+                            }
+                        });
+
+                        let query_builder = build_query(idx);
+
                         let query_start = Instant::now();
                         let result = rt.block_on(client.query(query_builder));
                         let query_time = query_start.elapsed().as_secs_f64();
@@ -1360,6 +1412,14 @@ impl Engine for QdrantEngine {
                 }));
             }
 
+            // All workers are built + primed and blocked on `go`. Stamp the shared
+            // measurement start and release them simultaneously, so connection setup
+            // and the cold first query are already behind the barrier.
+            ready.wait();
+            let st = Instant::now();
+            start_cell.set(st).ok();
+            go.wait();
+
             for h in handles {
                 let (t, p, r, mr, nd) = h.join().unwrap();
                 times.extend(t);
@@ -1371,7 +1431,12 @@ impl Engine for QdrantEngine {
         });
 
         pb.finish_and_clear();
-        let total_time = start_time.elapsed().as_secs_f64();
+        // Measure from the post-barrier start stamp (workers already primed), so
+        // total_time excludes connection setup and the cold first query.
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -1774,6 +1774,9 @@ impl Engine for ValkeyEngine {
         let query_path = dataset.get_path()?;
         println!("\tReading queries from {}...", query_path.display());
         let (queries, neighbors, conditions) = dataset.read_queries()?;
+        if queries.is_empty() {
+            return Err("dataset contains no search queries".to_string());
+        }
 
         let parsed_filters: Vec<Option<ParsedFilter>> = conditions
             .iter()
@@ -1805,7 +1808,17 @@ impl Engine for ValkeyEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
-        let start_time = Instant::now();
+
+        // Barrier-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window (mirrors redis.rs/vertex.rs). Every
+        // worker connects + primes, then blocks on `ready`; the main thread stamps
+        // the shared start instant into `start_cell` and releases `go`, so the
+        // measurement clock starts only once all workers are warm and poised. A
+        // worker that fails to connect MUST still pass both barriers before
+        // returning, or the run would deadlock.
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -1829,6 +1842,8 @@ impl Engine for ValkeyEngine {
                 let query_strs = &query_strs;
                 let query_idx = Arc::clone(&query_idx);
                 let index_name = index_name.as_str();
+                let ready = Arc::clone(&ready);
+                let go = Arc::clone(&go);
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -1855,12 +1870,45 @@ impl Engine for ValkeyEngine {
                     );
                     let client = match redis::Client::open(url.as_str()) {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            // Still cross both barriers so peers aren't stranded.
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
                     let mut conn = match client.get_connection() {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
+
+                    // Prime this connection with ONE discarded query so the cold
+                    // first round-trip is not inside the measured window. Best
+                    // effort: errors are ignored and its sample is NOT recorded.
+                    {
+                        let prime_top = explicit_top.unwrap_or(10);
+                        let _ = ft_search_knn(
+                            &mut conn,
+                            index_name,
+                            &encoded_queries[0],
+                            &query_strs[0],
+                            prime_top,
+                            ef,
+                            &algorithm,
+                            &hybrid_policy,
+                            query_timeout,
+                            parsed_filters[0].as_ref(),
+                        );
+                    }
+
+                    // Signal "connected + primed", then block until the main thread
+                    // stamps the shared measurement start and releases everyone.
+                    ready.wait();
+                    go.wait();
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1928,6 +1976,13 @@ impl Engine for ValkeyEngine {
                 }));
             }
 
+            // All workers are spawned; wait until every one has connected + primed,
+            // then stamp the shared measurement start and release them together.
+            ready.wait();
+            let st = Instant::now();
+            start_cell.set(st).ok();
+            go.wait();
+
             for h in handles {
                 let (t, p, r, mr, nd) = h.join().unwrap();
                 times.extend(t);
@@ -1939,7 +1994,11 @@ impl Engine for ValkeyEngine {
         });
 
         pb.finish_and_clear();
-        let total_time = start_time.elapsed().as_secs_f64();
+        // total_time excludes connection setup and the cold first query.
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
 
         if times.is_empty() {
             return Err("No searches completed".to_string());

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -571,7 +571,17 @@ impl Engine for VectorSetsEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
 
         let pb = self.create_progress_bar(num_to_run);
-        let start_time = Instant::now();
+
+        // Barrier-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window (mirrors the Redis/Vertex engines).
+        // Every worker connects + primes, then blocks on `ready`; the main thread
+        // stamps the shared start instant into `start_cell` and releases `go`, so
+        // the measurement clock starts only once all workers are warm and poised.
+        // A worker that fails to connect MUST still pass both barriers before
+        // returning, or the run would deadlock.
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -587,6 +597,8 @@ impl Engine for VectorSetsEngine {
                 let filters = &filters;
                 let encoded_queries = &encoded_queries;
                 let query_idx = Arc::clone(&query_idx);
+                let ready = Arc::clone(&ready);
+                let go = Arc::clone(&go);
                 let pb = &pb;
 
                 handles.push(s.spawn(move || {
@@ -599,12 +611,41 @@ impl Engine for VectorSetsEngine {
 
                     let client = match redis::Client::open(redis_url.as_str()) {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            // Still cross both barriers so peers aren't stranded.
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
                     let mut conn = match client.get_connection() {
                         Ok(c) => c,
-                        Err(_) => return (t, p, r, mr, nd),
+                        Err(_) => {
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
                     };
+
+                    // Prime this connection with ONE discarded query so the cold
+                    // first round-trip is not inside the measured window. Best
+                    // effort: errors are ignored and its sample is NOT recorded.
+                    if !encoded_queries.is_empty() {
+                        let prime_top = explicit_top.unwrap_or(10);
+                        let _ = vsim_search(
+                            &mut conn,
+                            &encoded_queries[0],
+                            prime_top,
+                            ef,
+                            filters[0].as_deref(),
+                            filter_ef,
+                        );
+                    }
+
+                    // Signal "connected + primed", then block until the main thread
+                    // stamps the shared measurement start and releases everyone.
+                    ready.wait();
+                    go.wait();
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -671,6 +712,13 @@ impl Engine for VectorSetsEngine {
                 }));
             }
 
+            // All workers are spawned; wait until each has connected + primed,
+            // stamp the shared measurement start, then release them together.
+            ready.wait();
+            let st = Instant::now();
+            start_cell.set(st).ok();
+            go.wait();
+
             for h in handles {
                 let (t, p, r, mr, nd) = h.join().unwrap();
                 times.extend(t);
@@ -682,7 +730,12 @@ impl Engine for VectorSetsEngine {
         });
 
         pb.finish_and_clear();
-        let total_time = start_time.elapsed().as_secs_f64();
+        // total_time excludes connection setup and the cold first query — it is
+        // measured from the barrier release stamped into `start_cell`.
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
 
         if times.is_empty() {
             return Err("No searches completed".to_string());

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -1474,7 +1474,19 @@ impl Engine for WeaviateEngine {
         let graphql_bodies = Arc::new(graphql_bodies);
         let grpc_requests = Arc::new(grpc_requests);
 
-        let start_time = Instant::now();
+        // Barrier-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window (mirrors redis.rs / vertex.rs). Every
+        // worker connects + primes one discarded query, then blocks on `ready`;
+        // the main thread stamps the shared start instant into `start_cell` and
+        // releases `go`, so the measurement clock starts only once all workers are
+        // warm and poised. A worker that fails to connect MUST still cross both
+        // barriers before returning, or the run would deadlock. `total_time` is
+        // read from `start_cell` below, so it excludes connection setup and the
+        // cold first query. Both transports (gRPC tasks / GraphQL threads) use the
+        // same `parallel + 1` barrier counts (main thread is the +1).
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
 
         // Per-thread sample buffers merged after the workers finish — no per-query
         // Mutex<Vec> contention in the timed loop (see redis.rs::search). Both the
@@ -1493,7 +1505,12 @@ impl Engine for WeaviateEngine {
             //     connection, awaiting searches off a shared atomic work queue.
             //     This scales with concurrency (unlike thread-per-block_on). ──
             let endpoint = grpc_ep.unwrap();
+            // Size the pool at `parallel + 1` so every worker task can block on the
+            // std start-barrier concurrently (the main future is the +1). With the
+            // default (num-CPU) pool a `parallel` larger than the CPU count would
+            // strand un-scheduled tasks behind barrier-blocked threads and deadlock.
             let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(parallel + 1)
                 .enable_all()
                 .build()
                 .map_err(|e| format!("failed to build tokio runtime: {}", e))?;
@@ -1506,6 +1523,8 @@ impl Engine for WeaviateEngine {
                     let neighbors = Arc::clone(&neighbors);
                     let tops = Arc::clone(&tops);
                     let query_idx = Arc::clone(&query_idx);
+                    let ready = Arc::clone(&ready);
+                    let go = Arc::clone(&go);
                     let pb = pb.clone();
                     tasks.push(tokio::spawn(async move {
                         let mut t = Vec::new();
@@ -1518,10 +1537,28 @@ impl Engine for WeaviateEngine {
                             Ok(c) => c,
                             Err(e) => {
                                 eprintln!("gRPC connect failed: {}", e);
+                                // Still cross both barriers so peers + main aren't
+                                // stranded (the barrier count includes this task).
+                                ready.wait();
+                                go.wait();
                                 return (t, p, r, mr, nd);
                             }
                         };
                         let mut client = WeaviateClient::new(channel);
+
+                        // Prime this connection with ONE discarded search (query 0)
+                        // so the cold first round-trip + server JIT/cache warm-up is
+                        // outside the measured window. Best effort: result ignored,
+                        // no sample recorded. Reuses the normal per-query RPC path.
+                        if !grpc_requests.is_empty() {
+                            let prime = grpc_requests[0].clone();
+                            let _ = grpc_search(&mut client, prime, api_key.as_deref()).await;
+                        }
+
+                        // Signal "connected + primed", then block until the main
+                        // thread stamps the shared start and releases everyone.
+                        ready.wait();
+                        go.wait();
                         loop {
                             let idx = query_idx.fetch_add(1, Ordering::Relaxed);
                             if idx >= num_to_run {
@@ -1558,6 +1595,12 @@ impl Engine for WeaviateEngine {
                         (t, p, r, mr, nd)
                     }));
                 }
+                // All tasks have connected + primed and are poised on `ready`.
+                // Stamp the measurement start, then release everyone via `go`; the
+                // barrier count includes this main future (the +1).
+                ready.wait();
+                start_cell.set(Instant::now()).ok();
+                go.wait();
                 let mut out = Vec::with_capacity(tasks.len());
                 for task in tasks {
                     match task.await {
@@ -1587,6 +1630,8 @@ impl Engine for WeaviateEngine {
                     let tops = Arc::clone(&tops);
                     let graphql_bodies = Arc::clone(&graphql_bodies);
                     let query_idx = Arc::clone(&query_idx);
+                    let ready = Arc::clone(&ready);
+                    let go = Arc::clone(&go);
                     let pb = &pb;
 
                     handles.push(s.spawn(move || {
@@ -1601,8 +1646,32 @@ impl Engine for WeaviateEngine {
                             .build()
                         {
                             Ok(c) => c,
-                            Err(_) => return (t, p, r, mr, nd),
+                            Err(_) => {
+                                // Still cross both barriers so peers + main aren't
+                                // stranded (the barrier count includes this worker).
+                                ready.wait();
+                                go.wait();
+                                return (t, p, r, mr, nd);
+                            }
                         };
+
+                        // Prime this client with ONE discarded search (query 0) so
+                        // the cold first round-trip (TCP/TLS + server warm-up) is
+                        // outside the measured window. Best effort: result ignored,
+                        // no sample recorded. Reuses the normal per-query HTTP path.
+                        if !graphql_bodies.is_empty() {
+                            let _ = send_graphql(
+                                &client,
+                                &base_url,
+                                api_key.as_deref(),
+                                &graphql_bodies[0],
+                            );
+                        }
+
+                        // Signal "connected + primed", then block until the main
+                        // thread stamps the shared start and releases everyone.
+                        ready.wait();
+                        go.wait();
                         loop {
                             let idx = query_idx.fetch_add(1, Ordering::Relaxed);
                             if idx >= num_to_run {
@@ -1644,6 +1713,12 @@ impl Engine for WeaviateEngine {
                         (t, p, r, mr, nd)
                     }));
                 }
+                // All workers have connected + primed and are poised on `ready`.
+                // Stamp the measurement start, then release everyone via `go`; the
+                // barrier count includes this main thread (the +1).
+                ready.wait();
+                start_cell.set(Instant::now()).ok();
+                go.wait();
                 for h in handles {
                     let (t, p, r, mr, nd) = h.join().unwrap();
                     times.extend(t);
@@ -1656,7 +1731,12 @@ impl Engine for WeaviateEngine {
         }
 
         pb.finish_and_clear();
-        let total_time = start_time.elapsed().as_secs_f64();
+        // total_time is measured from the barrier release (start_cell), so it
+        // excludes connection setup and the cold first (primed) query.
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(


### PR DESCRIPTION
## What

Brings the **11 remaining locally-testable engines** (valkey, vectorsets, elasticsearch, opensearch, qdrant, pgvector, weaviate, milvus, mongodb, dragonfly, chroma) to the measurement-fidelity pattern **redis.rs and vertex.rs already use** — INV-5 (uniform warmup) + INV-7 (connection barrier) from #118.

Previously each engine opened its per-worker connection **inside** the timed region and paid a cold first query, so (a) N handshakes were folded into RPS (`total_time`) — charging connect-per-thread/TLS engines more than cheap-clone ones, worst at low query counts / high parallelism — and (b) the first `parallel` queries paid cold-start, biasing tail latency. Only OpenSearch had a server-side warmup, making its p99 an uneven comparison.

## How (mirrors redis.rs exactly)

- Two barriers (`ready`/`go`, size `parallel+1`) + a shared `OnceLock<Instant>` start stamp.
- Each worker opens its connection/client, **primes one discarded query** (warms socket + server caches/JIT), then blocks on `ready`. The main thread stamps the start instant and releases `go` — so the clock starts only once **every worker is connected + warm**.
- `total_time` (the RPS denominator) is measured from the **barrier release**, excluding connection setup + the cold first query.
- **OpenSearch's special server-side kNN warmup is removed** so all engines rely on the same uniform per-worker prime.

## Correctness

- **Deadlock-safe**: every worker crosses **both** barriers exactly once on **every** path, including connection-failure early returns (verified per-engine).
- **Timing/RPS only** — result sets (recall/precision/mrr/ndcg) are unchanged.

## Validation

Full unit suite (**531**) + every engine's integration suite pass **with no hangs** (a barrier deadlock would time out → fail):

| engine | tests | | engine | tests |
|---|---|---|---|---|
| valkey | 24 ✓ | | qdrant | 18 ✓ |
| dragonfly | 15 ✓ | | milvus | 13 ✓ |
| chroma | 9 ✓ | | weaviate | 15 ✓ |
| pgvector | 19 ✓ | | mongodb | 15 ✓ |
| elasticsearch | 25 ✓ | | opensearch | 15 ✓ |

vectorsets is validated in CI (its local server port isn't provisioned in my env); its change mirrors the passing redis/valkey pattern. `build`/`fmt`/`clippy` clean.

Turbopuffer (cloud-only, untestable locally) is a documented follow-up — every other engine now shares the redis/vertex measurement boundary.

Implemented via an 11-agent workflow (redis.rs as the exact reference), then independently re-validated end-to-end.

Fixes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)