### PR TITLE
feat(redis): opt-in shared-corpus (upload-once/build-many) sweep mode (#188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,17 @@ memory is reported per-index via `FT.INFO` (issue #151-4).
   (search each against its own index). Per-config prefixing stores N copies of
   otherwise-identical sweep docs, so keyspace bytes scale ×N — the intended trade
   for isolation.
+- **Shared-corpus (upload-once / build-many) mode — Redis, opt-in (#188):** for a
+  sweep over **one** dataset where only the index params (M / EF_construction)
+  differ, the corpus is identical across configs, so re-uploading it per config is
+  wasted work (N× ingest — dominant at 10M+). Set `REDIS_KEY_PREFIX=<shared>:` to
+  make **all** configs share ONE corpus keyspace: the first config uploads it, and
+  every later config **skips the re-upload** (detected by a corpus key-count check)
+  and just builds its own per-config index over the shared docs (the index name
+  stays per-config). In this mode the index is dropped **without `DD`** so the
+  shared corpus survives across configs; flush the DB (or the shared prefix) when
+  the sweep finishes. Unset (the default) keeps full per-config isolation — no
+  behavior change.
 
 ### Charts
 

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -53,12 +53,67 @@ pub struct RedisEngineConfig {
     /// config owns a disjoint keyspace and its `FT.DROPINDEX ... DD` teardown
     /// touches only its own docs.
     pub key_prefix: String,
+    /// Shared-corpus mode (#188): true when `REDIS_KEY_PREFIX` is set, making ALL
+    /// sweep configs share ONE key prefix (one corpus) instead of per-config
+    /// disjoint keyspaces. Lets a sweep over one dataset upload the (identical)
+    /// corpus ONCE and build many per-config indexes over it (N× ingest -> 1×).
+    /// In this mode the index is dropped WITHOUT `DD` (the shared docs survive
+    /// across configs) and a re-upload is skipped when the corpus is already
+    /// populated. Off by default -> per-config isolation is unchanged.
+    pub shared_corpus: bool,
     /// Schema field names declared as `datetime`. Values for these fields are
     /// ISO-8601 strings in the payload; they are converted to epoch seconds at
     /// HSET time so the NUMERIC index/range filters match. Populated in
     /// `configure()` from the dataset schema. Wrapped in `Arc` so the per-thread
     /// config clones share one set.
     pub datetime_fields: Arc<HashSet<String>>,
+}
+
+/// The shared corpus key prefix for #188 (upload-once / build-many), read from
+/// `REDIS_KEY_PREFIX`. When set, every sweep config shares this one prefix (a
+/// single uploaded corpus); when unset, each config keeps its own `<config>:`
+/// prefix and disjoint keyspace. A trailing `:` is appended if missing so the
+/// value is a clean key namespace. Resolved in `new()`, never in a timed window.
+fn shared_key_prefix() -> Option<String> {
+    let s = std::env::var("REDIS_KEY_PREFIX").ok()?;
+    let s = s.trim();
+    if s.is_empty() {
+        None
+    } else if s.ends_with(':') {
+        Some(s.to_string())
+    } else {
+        Some(format!("{s}:"))
+    }
+}
+
+/// Count keys matching `<prefix>*` via cursor-based SCAN (non-blocking; the
+/// prefix is sanitized so `*` is the only glob metachar). Used by shared-corpus
+/// mode (#188) to detect whether the corpus is already fully uploaded so a
+/// sweep's later configs can skip the re-upload.
+fn count_prefix_keys(conn: &mut Connection, prefix: &str) -> usize {
+    let pattern = format!("{prefix}*");
+    let mut cursor: u64 = 0;
+    let mut count = 0usize;
+    loop {
+        let res: Result<(u64, Vec<String>), redis::RedisError> = redis::cmd("SCAN")
+            .arg(cursor)
+            .arg("MATCH")
+            .arg(&pattern)
+            .arg("COUNT")
+            .arg(1000)
+            .query(conn);
+        match res {
+            Ok((next, keys)) => {
+                count += keys.len();
+                if next == 0 {
+                    break;
+                }
+                cursor = next;
+            }
+            Err(_) => break,
+        }
+    }
+    count
 }
 
 pub struct RedisEngine {
@@ -185,7 +240,13 @@ impl RedisEngine {
                 svs_compression,
                 svs_reduce,
                 index_name: derive_index_name("REDIS_INDEX_NAME", "idx", &engine_config.name),
-                key_prefix: derive_key_prefix(&engine_config.name),
+                // Shared-corpus mode (#188): REDIS_KEY_PREFIX overrides the
+                // per-config prefix with ONE shared prefix across all sweep
+                // configs. Default (unset) keeps the per-config `<config>:` prefix
+                // and full isolation.
+                key_prefix: shared_key_prefix()
+                    .unwrap_or_else(|| derive_key_prefix(&engine_config.name)),
+                shared_corpus: shared_key_prefix().is_some(),
                 datetime_fields: Arc::new(HashSet::new()),
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
@@ -202,13 +263,20 @@ impl RedisEngine {
         let distance = dataset.distance();
         let vector_size = dataset.vector_size();
 
-        // Drop existing index if any. DD deletes the indexed docs too; because the
-        // index PREFIX is now this config's `<config>:` (not `""`), DD removes only
-        // this config's keys — sibling configs' indexes/keys are untouched (#151-4).
-        let _ = redis::cmd("FT.DROPINDEX")
-            .arg(&self.config.index_name)
-            .arg("DD")
-            .query::<()>(conn);
+        // Drop existing index if any. Normally with DD, which deletes the indexed
+        // docs too; because the index PREFIX is this config's `<config>:`, DD
+        // removes only this config's keys — siblings untouched (#151-4). In
+        // shared-corpus mode (#188) the docs are SHARED across configs and
+        // uploaded once, so drop the index WITHOUT DD to preserve them for the
+        // other configs' indexes (build-many over one corpus).
+        {
+            let mut cmd = redis::cmd("FT.DROPINDEX");
+            cmd.arg(&self.config.index_name);
+            if !self.config.shared_corpus {
+                cmd.arg("DD");
+            }
+            let _ = cmd.query::<()>(conn);
+        }
 
         // Map distance metric
         let distance_metric = map_distance_metric(distance);
@@ -1736,6 +1804,35 @@ impl Engine for RedisEngine {
     }
 
     fn upload(&mut self, dataset: &Dataset) -> Result<UploadStats, String> {
+        // Shared-corpus mode (#188): if the shared prefix is already populated
+        // with the full corpus (a prior config in the sweep uploaded it), skip the
+        // re-upload entirely and just report it — this is what turns an N-config
+        // sweep's ingest from N× into 1×. The index for THIS config was already
+        // (re)built over the shared corpus in configure()/create_index. The check
+        // requires the dataset's known vector_count; without it we can't confirm a
+        // COMPLETE corpus, so we fall through and upload normally.
+        if self.config.shared_corpus {
+            if let Some(expected) = dataset.config.vector_count.filter(|&n| n > 0) {
+                let mut conn = self.get_connection()?;
+                let existing = count_prefix_keys(&mut conn, &self.config.key_prefix);
+                if existing >= expected as usize {
+                    println!(
+                        "Shared corpus already populated ({existing} keys under prefix '{}'); \
+                         skipping re-upload (#188 upload-once/build-many).",
+                        self.config.key_prefix
+                    );
+                    return Ok(UploadStats {
+                        upload_time: 0.0,
+                        total_time: 0.0,
+                        upload_count: existing,
+                        parallel: self.config.parallel,
+                        batch_size: self.config.batch_size,
+                        memory_usage: None,
+                    });
+                }
+            }
+        }
+
         let normalize = dataset.needs_normalization();
 
         let dataset_path = dataset.get_path()?;
@@ -2509,10 +2606,16 @@ impl Engine for RedisEngine {
 
     fn delete(&mut self) -> Result<(), String> {
         let mut conn = self.get_connection()?;
-        let _ = redis::cmd("FT.DROPINDEX")
-            .arg(&self.config.index_name)
-            .arg("DD")
-            .query::<()>(&mut conn);
+        // Normally DD (drop index + this config's docs). In shared-corpus mode
+        // (#188) the docs are shared across configs, so drop the index only and
+        // leave the corpus for the remaining configs / a later --skip-upload run.
+        // The shared corpus is the user's to flush when the sweep is done.
+        let mut cmd = redis::cmd("FT.DROPINDEX");
+        cmd.arg(&self.config.index_name);
+        if !self.config.shared_corpus {
+            cmd.arg("DD");
+        }
+        let _ = cmd.query::<()>(&mut conn);
         Ok(())
     }
 
@@ -2804,6 +2907,7 @@ mod tests {
             svs_reduce: None,
             index_name: "idx:test".to_string(),
             key_prefix: "test:".to_string(),
+            shared_corpus: false,
             datetime_fields: Arc::new(dt),
         };
         // datetime field → epoch seconds string

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -2370,6 +2370,91 @@ fn test_binary_redis_keep_data_sweep_frees_prior_configs() {
     flush_db(&mut conn);
 }
 
+/// #188 upload-once/build-many: with `REDIS_KEY_PREFIX` set, all sweep configs
+/// share ONE corpus keyspace, so a config after the first must SKIP the (identical)
+/// re-upload and just build its index over the shared corpus. Runs a 2-config
+/// sweep with the shared prefix and asserts (a) the second config logs the
+/// "skipping re-upload" path, (b) BOTH configs' indexes return correct results
+/// over the shared corpus (recall >= 0.9), and (c) the corpus exists once under
+/// the shared prefix. Default (no REDIS_KEY_PREFIX) keeps per-config isolation —
+/// covered by test_binary_redis_coexistence_skip_upload.
+#[test]
+fn test_binary_redis_shared_corpus_upload_once() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 8;
+    let configs = serde_json::json!([
+        {
+            "name": "redis-sc-a", "engine": "redis",
+            "search_params": [{"parallel": 1, "search_params": {"ef": 128}}],
+            "upload_params": {"parallel": 1, "batch_size": 100}
+        },
+        {
+            "name": "redis-sc-b", "engine": "redis",
+            "search_params": [{"parallel": 1, "search_params": {"ef": 128}}],
+            "upload_params": {"parallel": 1, "batch_size": 100}
+        }
+    ]);
+    let proj =
+        common::write_bool_project("sc-test", &serde_json::to_string(&configs).unwrap(), dim);
+
+    let out = Command::new(binary_path())
+        .args([
+            "--engines",
+            "redis-sc*",
+            "--datasets",
+            "sc-test",
+            "--host",
+            "localhost",
+            "--keep-data",
+            "--skip-if-exists",
+            "false",
+        ])
+        .env("REDIS_PORT", TEST_PORT.to_string())
+        .env("REDIS_KEY_PREFIX", "shared_sc:")
+        .current_dir(&proj.root)
+        .output()
+        .expect("run shared-corpus sweep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "shared-corpus sweep failed.\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The second config must have SKIPPED the re-upload (the #188 win).
+    assert!(
+        stdout.contains("skipping re-upload"),
+        "expected an upload-once skip for the 2nd config; stdout:\n{}",
+        stdout
+    );
+
+    // Both configs' indexes work over the shared corpus.
+    let ra = common::read_recall(&proj.root, "redis-sc-a");
+    let rb = common::read_recall(&proj.root, "redis-sc-b");
+    println!("shared-corpus recall a={:.3} b={:.3}", ra, rb);
+    assert!(ra >= 0.9, "redis-sc-a recall {:.3} < 0.9", ra);
+    assert!(rb >= 0.9, "redis-sc-b recall {:.3} < 0.9", rb);
+
+    // The corpus exists once under the shared prefix (400 docs), not per-config.
+    let keys: i64 = redis::cmd("EVAL")
+        .arg("return #redis.call('keys', KEYS[1])")
+        .arg(1)
+        .arg("shared_sc:*")
+        .query(&mut conn)
+        .unwrap();
+    println!("shared corpus keys={}", keys);
+    assert!(
+        keys >= 400,
+        "shared corpus should hold the 400-doc corpus (got {keys})"
+    );
+
+    flush_db(&mut conn);
+}
+
 /// Nested boolean: `(color==red AND size>=50) OR (color==blue AND size<10)` —
 /// verifies the parser recurses into grouped sub-conditions (parenthesised
 /// RediSearch clause) instead of flattening the tree. A flattening parser matches


### PR DESCRIPTION
## The problem (#188)

A multi-config sweep over **one** dataset re-uploads the **identical** corpus per config (each config owns a disjoint keyspace since #153), so an N-config sweep pays **N× the ingest** for data that never changes — only the index params (M / EF_construction) differ. ~36 min of redundant upload on a 10M 6-config sweep; dominant at scale.

## Fix (opt-in — the issue's "shared corpus keyspace" alternative)

Set **`REDIS_KEY_PREFIX=<shared>:`** → every sweep config shares **one** corpus keyspace instead of a per-config `<config>:` prefix. Then:

- the **first** config uploads the corpus;
- each **later** config detects the corpus is already populated (a prefix key-count check vs the dataset's `vector_count`) and **skips the re-upload**, just building its own **per-config index** over the shared docs (build-many — the index name stays per-config) → **N× ingest becomes 1×**;
- the index is dropped **without `DD`** (in `configure` + `delete`) so the shared corpus survives across configs. Flush the shared prefix when the sweep is done.

**Unset (default): byte-identical to before** — per-config prefix + `DD` teardown, full isolation. So per-config coexistence + `--skip-upload` (#153/#155) and the #184 `--keep-data` behaviour are **untouched** — this was the explicit reason to keep it opt-in (the same fragile keyspace area that regressed on #184).

## Coverage

- `test_binary_redis_shared_corpus_upload_once`: a 2-config sweep with the shared prefix → the 2nd config logs the re-upload skip, **both** configs' indexes recall **1.000** over the shared corpus, and the corpus is stored **once** (400 keys).
- Default-path regression checks all pass: **coexistence** (the #184-regressed feature), #184 keep-data, bool, AND.
- 531 unit tests pass; `fmt`/`clippy` clean. README documents the mode.

(Redis-specific, matching the issue. Valkey/Dragonfly share the per-config-prefix design and could get the same opt-in in a follow-up.)

Fixes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)