### PR TITLE
fix(ci): skip PR-comment step on fork PRs (read-only token reds passing builds)

### DIFF
--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -82,7 +82,15 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Post PR comment
-        if: github.event_name == 'pull_request'
+        # Only on same-repo PRs. GitHub grants the GITHUB_TOKEN read-only scope
+        # for pull_request events from forks (regardless of the job's requested
+        # permissions), so createComment fails there with "Resource not
+        # accessible by integration" and reds an otherwise-passing build. Fork
+        # PRs simply skip the cosmetic comment; the build/test steps above are
+        # the real gate. continue-on-error is a belt-and-suspenders so a comment
+        # failure never fails the job.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -98,7 +106,7 @@ jobs:
             - Integration test (random-100 dataset + Redis)
             - Multi-platform build validation (amd64 + arm64)`;
 
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Problem

The `docker-build-pr` workflow's **Post PR comment** step calls `github-script` `createComment`, which fails on `pull_request` events **from forks**:

```
Unhandled error: HttpError: Resource not accessible by integration
```

GitHub grants the `GITHUB_TOKEN` **read-only** scope for fork PRs regardless of the job's requested `permissions: pull-requests: write` (a security measure). So the comment step errors and **fails the whole job even though every build/test step passed** — Docker build (amd64), `--help`, `--describe datasets`, the Redis integration test, and the multi-platform (amd64+arm64) validation all succeed first.

Observed on the fork-based PR #195, where `docker-build-test` went red solely on this step.

## Fix

- Gate the step on `github.event.pull_request.head.repo.full_name == github.repository` so **fork PRs skip the cosmetic comment** (they can't post one anyway). Same-repo PRs still get the comment.
- Add `continue-on-error: true` as a backstop so a comment failure can never fail the job.
- `await` the `createComment` call.

The build/test steps remain the real gate; only the informational comment is affected. Same spirit as the earlier #191 graceful-skip for the master docker-publish secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)