### PR TITLE
fix(vertex): stage batch-ingest JSONL via gsutil, not a single media POST

### DIFF
--- a/src/bin/vector_db_benchmark/engine/vertex.rs
+++ b/src/bin/vector_db_benchmark/engine/vertex.rs
@@ -1238,24 +1238,22 @@ impl VertexEngine {
             object,
             jsonl.len() as f64 / (1024.0 * 1024.0)
         );
-        let token = self.access_token()?;
-        let upload_url = format!(
-            "https://storage.googleapis.com/upload/storage/v1/b/{}/o",
-            bucket
-        );
-        let resp = self
-            .client
-            .post(&upload_url)
-            .bearer_auth(&token)
-            .query(&[("uploadType", "media"), ("name", object.as_str())])
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .body(jsonl)
-            .send()
-            .map_err(|e| format!("GCS staging upload failed: {e}"))?;
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().unwrap_or_default();
-            return Err(format!("GCS staging upload returned {status}: {body}"));
+        // Stage the JSONL to GCS via `gsutil cp` (resumable + parallel-composite)
+        // rather than a single in-memory `uploadType=media` POST. Simple media
+        // upload buffers the whole body and runs under the client timeout, so a
+        // multi-GiB batch (e.g. 1M x 2048-d ~= 41 GiB) always fails with
+        // "error sending request". gsutil chunks and resumes.
+        let local_path = format!("/tmp/vdbb-batch-{}.json", self.display_name);
+        std::fs::write(&local_path, jsonl.as_bytes())
+            .map_err(|e| format!("failed writing local staging file {local_path}: {e}"))?;
+        let gcs_dest = format!("gs://{}/{}", bucket, object);
+        let gs_status = std::process::Command::new("gsutil")
+            .args(["-q", "cp", local_path.as_str(), gcs_dest.as_str()])
+            .status()
+            .map_err(|e| format!("failed to spawn gsutil for staging: {e}"))?;
+        let _ = std::fs::remove_file(&local_path);
+        if !gs_status.success() {
+            return Err(format!("gsutil cp of staging JSONL to {gcs_dest} failed: {gs_status}"));
         }
 
         // 2. Point the index at the staged folder and trigger the rebuild.

--- a/src/bin/vector_db_benchmark/engine/vertex.rs
+++ b/src/bin/vector_db_benchmark/engine/vertex.rs
@@ -1253,7 +1253,9 @@ impl VertexEngine {
             .map_err(|e| format!("failed to spawn gsutil for staging: {e}"))?;
         let _ = std::fs::remove_file(&local_path);
         if !gs_status.success() {
-            return Err(format!("gsutil cp of staging JSONL to {gcs_dest} failed: {gs_status}"));
+            return Err(format!(
+                "gsutil cp of staging JSONL to {gcs_dest} failed: {gs_status}"
+            ));
         }
 
         // 2. Point the index at the staged folder and trigger the rebuild.


### PR DESCRIPTION
## Problem

The BATCH_UPDATE bulk-ingest path (`VertexEngine::batch_upload`) serializes every datapoint into one in-memory JSONL string and uploads it with a **single `uploadType=media` POST** under the HTTP client's request timeout.

Simple media upload buffers the entire body in one request, so a realistic batch fails outright. Ingesting `dbpedia-openai-1M-2048-angular` (1M × 2048-d floats) produces **~41 GiB** of JSONL, and the upload always dies with:

```
Staging 999000 datapoints to gs://.../datapoints.json (41661.8 MiB)...
Experiment failed: GCS staging upload failed: error sending request for url (https://storage.googleapis.com/upload/storage/v1/b/.../o?uploadType=media&name=...)
```

which aborts the whole ingest. Any batch large enough to matter (the feature exists precisely for large corpora) hits this.

## Fix

Write the JSONL to a local temp file and upload it with `gsutil cp`, which chunks, resumes, and uses parallel-composite uploads for large objects. The rest of the flow (`UpdateIndex` with `contentsDeltaUri`, poll the rebuild LRO) is unchanged.

## Verification

End-to-end ingest of `dbpedia-openai-1M-2048-angular` (999,000 × 2048-d) into a BATCH_UPDATE index succeeded via this path (41 GiB staged, index rebuilt to `vectorsCount=999000`, search recall ~0.88–0.90). `cargo check` clean.

Note: assumes `gsutil` is on `PATH` (already required for the GCS staging bucket workflow).