### PR TITLE
Add kividb engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A benchmarking tool for vector databases, written in Rust. Measures upload throu
 | **Dragonfly** (Dragonfly Search) | `redis` 1.3 | RESP protocol | L2, Cosine, IP | Yes [\*\*\*](#dragonfly-note) |
 | **Vertex AI** (Vector Search) | `reqwest` (Vertex AI REST v1) | HTTP/REST (cloud) | L2, Cosine, Dot | Yes [\*\*\*\*](#vertex-note) |
 | **Chroma** | `reqwest` (Chroma v2 REST API) | HTTP/REST | L2, Cosine, IP | Yes [\*\*\*\*\*](#chroma-note) |
+| **KiviDB** | `redis` 1.3 | RESP protocol | L2, Cosine, IP | Yes [\*\*\*\*\*\*](#kividb-note) |
 
 <a id="valkey-client-note"></a>
 \* **Valkey client note:** Valkey GLIDE has no published Rust crate ([valkey-io/valkey-glide#828](https://github.com/valkey-io/valkey-glide/issues/828), closed NOT_PLANNED). The GLIDE maintainers recommend using `redis-rs` for Rust and upstream their improvements to it. The `redis` crate works with Valkey since it speaks the same RESP protocol.
@@ -35,6 +36,9 @@ A benchmarking tool for vector databases, written in Rust. Measures upload throu
 
 <a id="chroma-note"></a>
 \*\*\*\*\* **Chroma note:** Uses **Chroma** (OSS) via its **v2 REST API** — a collection of records (`ids` + `embeddings` + scalar `metadatas`) queried with `query` + a `where` document. **Metadata filters** map directly onto the canonical model: `match` → `$eq`, `match_any` → `$in`, `range` → `$gte`/`$gt`/`$lte`/`$lt`, and **AND / OR / nested boolean** to Chroma's native `$and` / `$or` (which nest arbitrarily). Supported datatypes: **keyword, int, float, bool, uuid, datetime** (stored as epoch-seconds int, like Milvus, so numeric range operators apply). **Full-text** (`{match:{text}}`) is supported via `where_document` `$contains` — the `text`-typed field's value is uploaded as each record's Chroma `document`. **NOT supported** by Chroma's metadata engine (those conditions are dropped, like Dragonfly's documented limits): **geo-radius** and multi-valued **`labels` arrays** (Chroma metadata values are scalar only). Runs over HTTP/REST via Docker; set the host port with `CHROMA_PORT` (default `8000`, test compose maps `8003`), and optionally `CHROMA_COLLECTION` / `CHROMA_TENANT` / `CHROMA_DATABASE`. Distance space (`l2`/`cosine`/`ip`) is set per collection from the dataset metric.
+
+<a id="kividb-note"></a>
+\*\*\*\*\*\* **KiviDB note:** [KiviDB](https://kividb.io) is a Redis-wire-compatible (RESP2) data store that implements a RediSearch-compatible `FT.*` subset (`FT.CREATE`/`FT.SEARCH`/`FT.INFO`/`FT.DROPINDEX`, `VECTOR` HNSW/FLAT, `*=>[KNN k @field $blob AS score]`). Supports **vector KNN + metadata filtering** exactly like Redis/Valkey/Dragonfly: TAG/NUMERIC/TEXT datatypes, `match`/`match_any`/`range`, and AND/OR/nested boolean. **GEO** is not supported — unlike Dragonfly (which has a GEO field type but rejects this tool's `$param` geo bounds at the query-parser level), KiviDB's schema has no GEO field type at all, so geo fields are never declared or filtered (like Chroma/Milvus). KiviDB's `FT.CREATE` supports only the **float32** vector type. One real protocol difference worth knowing: KiviDB's `FT.INFO` does not expose RediSearch's `num_docs`/`percent_indexed` — it reports HNSW graph state directly instead (`hnsw_live_count`, `hnsw_compaction_in_progress`), because it builds each vector's HNSW entry synchronously inside the `HSET` that stores it (no async backfill phase exists to report progress on); `wait_for_indexing` polls those fields instead and returns immediately as a result. RESP2 only (no RESP3 opt-in). Set the host port with `KIVIDB_PORT` (default `6379`).
 
 <details>
 <summary><b>Runbook: benchmarking against Vertex AI</b></summary>
@@ -175,7 +179,7 @@ Options:
     -h, --help                 Print help
 ```
 
-### Per-config index isolation (Redis / Valkey / Dragonfly)
+### Per-config index isolation (Redis / Valkey / Dragonfly / KiviDB)
 
 Each engine config gets its **own** RediSearch index and keyspace, derived from the
 config `name`: index `"<base>:<config>"` (base `idx`) with docs keyed
@@ -184,8 +188,8 @@ against one server and coexist, so you can upload every config once and then
 search each in a later `--skip-upload` pass — each config reads its own graph, and
 memory is reported per-index via `FT.INFO` (issue #151-4).
 
-- `REDIS_INDEX_NAME` / `VALKEY_INDEX_NAME` / `DRAGONFLY_INDEX_NAME` now set the
-  **base namespace**, not the whole index name; the config name is always appended.
+- `REDIS_INDEX_NAME` / `VALKEY_INDEX_NAME` / `DRAGONFLY_INDEX_NAME` / `KIVIDB_INDEX_NAME`
+  now set the **base namespace**, not the whole index name; the config name is always appended.
   Set `<VAR>_EXACT=1` to use the base verbatim (single-config "point at an
   out-of-band index" case — combining it with >1 config for that engine is a
   startup error).
@@ -540,6 +544,7 @@ src/
         milvus.rs                     # Milvus engine (REST)
         mongodb_engine.rs             # MongoDB Atlas Search engine
         valkey.rs                     # Valkey engine (RESP protocol)
+        kividb.rs                     # KiviDB engine (RESP protocol)
         turbopuffer.rs                # Turbopuffer engine (cloud API)
         redis_utils.rs                # Shared utils for Redis-protocol engines
 experiments/configurations/           # Engine configuration JSON files

--- a/experiments/configurations/kividb-single-node.json
+++ b/experiments/configurations/kividb-single-node.json
@@ -1,0 +1,782 @@
+[
+  {
+    "name": "kividb-m-16-ef-64",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 16,
+        "EF_CONSTRUCTION": 64
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  },
+  {
+    "name": "kividb-m-16-ef-128",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 16,
+        "EF_CONSTRUCTION": 128
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  },
+  {
+    "name": "kividb-m-16-ef-256",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 16,
+        "EF_CONSTRUCTION": 256
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  },
+  {
+    "name": "kividb-m-16-ef-512",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 16,
+        "EF_CONSTRUCTION": 512
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  },
+  {
+    "name": "kividb-m-32-ef-64",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 32,
+        "EF_CONSTRUCTION": 64
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  },
+  {
+    "name": "kividb-m-32-ef-128",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 32,
+        "EF_CONSTRUCTION": 128
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  },
+  {
+    "name": "kividb-m-32-ef-256",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 32,
+        "EF_CONSTRUCTION": 256
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  },
+  {
+    "name": "kividb-m-32-ef-512",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 32,
+        "EF_CONSTRUCTION": 512
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  },
+  {
+    "name": "kividb-m-64-ef-64",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 64,
+        "EF_CONSTRUCTION": 64
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  },
+  {
+    "name": "kividb-m-64-ef-128",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 64,
+        "EF_CONSTRUCTION": 128
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  },
+  {
+    "name": "kividb-m-64-ef-256",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 64,
+        "EF_CONSTRUCTION": 256
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  },
+  {
+    "name": "kividb-m-64-ef-512",
+    "engine": "kividb",
+    "connection_params": {},
+    "collection_params": {
+      "hnsw_config": {
+        "M": 64,
+        "EF_CONSTRUCTION": 512
+      }
+    },
+    "search_params": [
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 1,
+        "search_params": {
+          "ef": 512
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 64
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 128
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 256
+        }
+      },
+      {
+        "parallel": 100,
+        "search_params": {
+          "ef": 512
+        }
+      }
+    ],
+    "upload_params": {
+      "parallel": 100,
+      "batch_size": 64
+    }
+  }
+]

--- a/src/bin/vector_db_benchmark/engine/kividb.rs
+++ b/src/bin/vector_db_benchmark/engine/kividb.rs
@@ -1,0 +1,1350 @@
+//! KiviDB engine implementation.
+//!
+//! KiviDB (https://kividb.io) is a Redis-wire-compatible (RESP2) data store
+//! that implements a RediSearch-compatible `FT.*` subset — `FT.CREATE`,
+//! `FT.SEARCH`, `FT.INFO`, `FT.DROPINDEX` — with `VECTOR` fields (FLAT / HNSW)
+//! and the KNN query syntax `*=>[KNN k @field $blob AS score]`. This engine
+//! speaks that subset over the `redis` crate (same RESP protocol), and its
+//! upload/search/filter code mirrors redis.rs / dragonfly.rs / valkey.rs.
+//!
+//! # Scope: vector KNN + metadata filtering
+//!
+//! KiviDB's schema (`src/vector/mod.rs::FieldType`) has exactly four field
+//! kinds: `Text`, `Tag`, `Numeric`, `Vector` — no `Geo`. This engine therefore
+//! indexes the dataset's metadata schema and applies per-query filter
+//! `conditions` for keyword/int/float/bool/datetime/uuid datatypes (reusing
+//! redis.rs's RediSearch filter builder, since the wire syntax is identical),
+//! but never declares or filters GEO fields — there is no GEO field type to
+//! declare, unlike Dragonfly's parser-level `$param` rejection. A query with
+//! no conditions still runs the `*` (match-all) prefilter.
+//!
+//! # Vector data type: FLOAT32 only
+//!
+//! KiviDB's `FT.CREATE` rejects any vector `TYPE` other than `FLOAT32`
+//! (`src/commands/vector.rs`) — no INT8/UINT8/FP16/BF16/FP64. Vectors are
+//! therefore always encoded as FLOAT32 little-endian bytes.
+//!
+//! # EF_RUNTIME
+//!
+//! KiviDB parses the per-query `EF_RUNTIME` HNSW attribute
+//! (`src/commands/vector.rs`), so it is kept, matching redis.rs / dragonfly.rs
+//! / valkey.rs, so the search sweep's `ef` values take effect instead of
+//! collapsing to the index default.
+//!
+//! # RESP2 only
+//!
+//! KiviDB does not implement RESP3 — there is no protocol opt-in here (unlike
+//! dragonfly.rs's `DRAGONFLY_PROTOCOL=resp3`); every connection stays RESP2.
+//!
+//! # FT.INFO dialect: no `num_docs` / `percent_indexed`
+//!
+//! This is the detail that actually motivated this engine. KiviDB's `FT.INFO`
+//! does not expose RediSearch's `num_docs` / `indexing` / `percent_indexed`
+//! fields at all — a benchmark client that polls for those (as the generic
+//! wait-for-indexing loops in this repo, and in the legacy `v0/` Python tool,
+//! do) sees `num_docs` default to 0 forever and stalls until its own timeout,
+//! even though the index is already fully built. Instead, KiviDB reports HNSW
+//! graph state directly: `hnsw_live_count` (documents actually in the graph)
+//! and `hnsw_compaction_in_progress` (`"0"`/`"1"`, set during background
+//! tombstone compaction). `wait_for_indexing` below polls those fields
+//! instead. Because KiviDB builds each vector's HNSW entry synchronously
+//! inside the `HSET` that stores it, this in practice returns immediately —
+//! there is no async backfill phase to wait out.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
+use redis::Connection;
+
+use super::redis::{parse_conditions, ParsedFilter};
+use super::redis_utils;
+
+use crate::config::{EngineConfig, SearchParams};
+use crate::dataset::Dataset;
+use crate::engine::index_naming::{derive_index_name, derive_key_prefix};
+use crate::engine::{Engine, SearchResults, UploadStats};
+use crate::metrics::compute_metrics;
+use vector_db_benchmark::parsers::{datetime_to_epoch_secs, doc_key_to_id, doc_key_to_id_opt};
+use vector_db_benchmark::readers::metadata::MetadataItem;
+
+/// KiviDB engine configuration.
+#[derive(Clone)]
+pub struct KividbEngineConfig {
+    pub m: i64,
+    pub ef_construction: i64,
+    /// Always `FLOAT32` — KiviDB's `FT.CREATE` supports no other vector type.
+    pub data_type: String,
+    pub algorithm: String,
+    pub batch_size: usize,
+    pub parallel: usize,
+    /// Per-config index name (`"<base>:<config>"`, mirrors redis.rs/dragonfly.rs)
+    /// so a sweep's configs address disjoint indexes on one server. Resolved
+    /// once in `new()`.
+    pub index_name: String,
+    /// Per-config key prefix (`"<config>:"`). Each config owns a disjoint
+    /// keyspace; teardown is a prefix-scoped SCAN+UNLINK (no DD flag).
+    pub key_prefix: String,
+}
+
+pub struct KividbEngine {
+    name: String,
+    host: String,
+    port: u16,
+    config: KividbEngineConfig,
+    search_params: Vec<SearchParams>,
+    commandstats_baseline: Option<redis_utils::CommandStatsBaseline>,
+}
+
+impl KividbEngine {
+    pub fn new(engine_config: &EngineConfig, host: &str) -> Result<Self, String> {
+        let port: u16 = std::env::var("KIVIDB_PORT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(6379);
+
+        // Extract HNSW config
+        let (m, ef_construction) = engine_config
+            .collection_params
+            .as_ref()
+            .and_then(|cp| cp.hnsw_config.as_ref())
+            .map(|h| (h.m.unwrap_or(16), h.ef_construction.unwrap_or(128)))
+            .unwrap_or((16, 128));
+
+        let algorithm = engine_config
+            .algorithm
+            .clone()
+            .unwrap_or_else(|| "hnsw".to_string());
+
+        // KiviDB's FT.CREATE only supports float32; ignore any configured override.
+        let data_type = "FLOAT32".to_string();
+
+        // Upload concurrency/batch come from the engine config, but each can be
+        // overridden at runtime via env (taking precedence over the config),
+        // mirroring dragonfly.rs / valkey.rs.
+        let parallel = std::env::var("KIVIDB_UPLOAD_PARALLEL")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .or_else(|| {
+                engine_config
+                    .upload_params
+                    .as_ref()
+                    .and_then(|p| p.get("parallel"))
+                    .and_then(|v| v.as_i64())
+                    .map(|v| v as usize)
+            })
+            .unwrap_or(100);
+
+        let batch_size = std::env::var("KIVIDB_UPLOAD_BATCH_SIZE")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .or_else(|| {
+                engine_config
+                    .upload_params
+                    .as_ref()
+                    .and_then(|p| p.get("batch_size"))
+                    .and_then(|v| v.as_i64())
+                    .map(|v| v as usize)
+            })
+            .unwrap_or(64);
+
+        Ok(Self {
+            name: engine_config.name.clone(),
+            host: host.to_string(),
+            port,
+            config: KividbEngineConfig {
+                m,
+                ef_construction,
+                data_type,
+                algorithm,
+                batch_size,
+                parallel,
+                index_name: derive_index_name("KIVIDB_INDEX_NAME", "idx", &engine_config.name),
+                key_prefix: derive_key_prefix(&engine_config.name),
+            },
+            search_params: engine_config.search_params.clone().unwrap_or_default(),
+            commandstats_baseline: None,
+        })
+    }
+
+    fn get_connection(&self) -> Result<Connection, String> {
+        Self::connect(&self.host, self.port)
+    }
+
+    fn connect(host: &str, port: u16) -> Result<Connection, String> {
+        let auth = std::env::var("KIVIDB_AUTH").ok();
+        let user = std::env::var("KIVIDB_USER").ok();
+
+        let auth_part = match (&user, &auth) {
+            (Some(u), Some(p)) => format!("{}:{}@", u, p),
+            (None, Some(p)) => format!(":{}@", p),
+            _ => String::new(),
+        };
+
+        // KiviDB is RESP2-only (no protocol opt-in, unlike dragonfly.rs).
+        let url = format!("redis://{}{}:{}/0", auth_part, host, port);
+        let client = redis::Client::open(url.as_str()).map_err(|e| e.to_string())?;
+        let conn = client.get_connection().map_err(|e| e.to_string())?;
+        // Safety timeout: prevents indefinite hangs from pipeline stalls.
+        let timeout = std::time::Duration::from_secs(300);
+        conn.set_read_timeout(Some(timeout)).ok();
+        conn.set_write_timeout(Some(timeout)).ok();
+        Ok(conn)
+    }
+
+    fn create_index(&self, conn: &mut Connection, dataset: &Dataset) -> Result<(), String> {
+        let distance = dataset.distance();
+        let vector_size = dataset.vector_size();
+
+        // Drop this config's index + keys ONLY (KiviDB has no DD flag on
+        // FT.DROPINDEX either, so a prefix-scoped SCAN+UNLINK replaces a
+        // keyspace-wide FLUSHALL, which would wipe sibling configs' data).
+        redis_utils::drop_index_and_keys(conn, &self.config.index_name, &self.config.key_prefix);
+
+        let distance_metric = map_distance_metric(distance);
+
+        let mut cmd = redis::cmd("FT.CREATE");
+        cmd.arg(&self.config.index_name)
+            .arg("ON")
+            .arg("HASH")
+            .arg("PREFIX")
+            .arg("1")
+            .arg(&self.config.key_prefix);
+
+        cmd.arg("SCHEMA");
+
+        // num_attrs = TYPE+DIM+DISTANCE_METRIC (6) + M (2) + EF_CONSTRUCTION (2).
+        let num_attrs = 6 + 2 + 2;
+        cmd.arg("vector")
+            .arg("VECTOR")
+            .arg(self.config.algorithm.to_uppercase())
+            .arg(num_attrs);
+        cmd.arg("TYPE").arg(&self.config.data_type);
+        cmd.arg("DIM").arg(vector_size);
+        cmd.arg("DISTANCE_METRIC").arg(distance_metric);
+        cmd.arg("M").arg(self.config.m);
+        cmd.arg("EF_CONSTRUCTION").arg(self.config.ef_construction);
+
+        // Filterable metadata fields (mirrors redis.rs/dragonfly.rs):
+        // keyword/uuid/bool exact strings -> TAG (SEPARATOR ; for multi-valued
+        // `labels`); int/float/datetime (stored as epoch) -> NUMERIC; full-text
+        // -> TEXT. GEO is intentionally never declared: KiviDB's schema
+        // (`FieldType`) has no Geo variant at all, unlike Dragonfly's
+        // parser-level rejection of `$param` geo bounds — there is simply
+        // nothing to declare here, matching Chroma/Milvus.
+        if let Some(schema) = dataset.config.schema.as_ref().and_then(|s| s.as_object()) {
+            for (field_name, field_type) in schema {
+                match field_type.as_str().unwrap_or("") {
+                    "keyword" | "uuid" | "bool" => {
+                        cmd.arg(field_name).arg("TAG").arg("SEPARATOR").arg(";");
+                    }
+                    "int" | "float" | "datetime" => {
+                        cmd.arg(field_name).arg("NUMERIC");
+                    }
+                    "text" => {
+                        cmd.arg(field_name).arg("TEXT");
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        cmd.query::<()>(conn)
+            .map_err(|e| format!("Failed to create index: {}", e))?;
+
+        Ok(())
+    }
+
+    fn upload_sequential(
+        &self,
+        ids: &[i64],
+        vectors: &[Vec<f32>],
+        metadata: &[Option<MetadataItem>],
+        datetime_fields: &std::collections::HashSet<String>,
+    ) -> Result<(), String> {
+        let mut conn = self.get_connection()?;
+        let pb = self.create_progress_bar(ids.len());
+
+        for batch_start in (0..ids.len()).step_by(self.config.batch_size) {
+            let batch_end = (batch_start + self.config.batch_size).min(ids.len());
+            upload_batch_internal(
+                &mut conn,
+                &ids[batch_start..batch_end],
+                &vectors[batch_start..batch_end],
+                &metadata[batch_start..batch_end],
+                datetime_fields,
+                &self.config.key_prefix,
+            )?;
+            pb.inc((batch_end - batch_start) as u64);
+        }
+
+        pb.finish_with_message("Upload complete");
+        Ok(())
+    }
+
+    fn upload_parallel(
+        &self,
+        ids: &[i64],
+        vectors: &[Vec<f32>],
+        metadata: &[Option<MetadataItem>],
+        datetime_fields: &std::collections::HashSet<String>,
+    ) -> Result<(), String> {
+        let pb = self.create_progress_bar(ids.len());
+        let batches: Vec<(usize, usize)> = (0..ids.len())
+            .step_by(self.config.batch_size)
+            .map(|start| (start, (start + self.config.batch_size).min(ids.len())))
+            .collect();
+
+        let total_batches = batches.len();
+        let num_threads = self.config.parallel.min(total_batches).max(1);
+        let batch_idx = Arc::new(AtomicUsize::new(0));
+        let error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+        std::thread::scope(|s| {
+            for _ in 0..num_threads {
+                let host = self.host.clone();
+                let port = self.port;
+                let key_prefix = self.config.key_prefix.clone();
+                let batches = &batches;
+                let batch_idx = Arc::clone(&batch_idx);
+                let error = Arc::clone(&error);
+                let pb = &pb;
+
+                s.spawn(move || {
+                    let mut conn = match KividbEngine::connect(&host, port) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            *error.lock().unwrap() = Some(e.to_string());
+                            return;
+                        }
+                    };
+
+                    loop {
+                        let idx = batch_idx.fetch_add(1, Ordering::SeqCst);
+                        if idx >= total_batches {
+                            break;
+                        }
+                        let (batch_start, batch_end) = batches[idx];
+                        if let Err(e) = upload_batch_internal(
+                            &mut conn,
+                            &ids[batch_start..batch_end],
+                            &vectors[batch_start..batch_end],
+                            &metadata[batch_start..batch_end],
+                            datetime_fields,
+                            &key_prefix,
+                        ) {
+                            *error.lock().unwrap() = Some(e);
+                            break;
+                        }
+                        pb.inc((batch_end - batch_start) as u64);
+                    }
+                });
+            }
+        });
+
+        pb.finish_with_message("Upload complete");
+
+        if let Some(e) = error.lock().unwrap().take() {
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// Wait until KiviDB's FT.INFO reports the HNSW graph as fully built.
+    ///
+    /// KiviDB has no `num_docs` / `indexing` / `percent_indexed` in FT.INFO —
+    /// see the module doc comment. This polls `hnsw_live_count` (documents
+    /// actually in the graph) and `hnsw_compaction_in_progress` instead. In
+    /// practice this returns on the first poll: KiviDB builds each vector's
+    /// HNSW entry synchronously inside the `HSET` that stores it, so by the
+    /// time upload's HSETs have all returned, `hnsw_live_count` is already at
+    /// `expected` and no compaction is running.
+    fn wait_for_indexing(&self, expected: usize) -> Result<(), String> {
+        let mut conn = self.get_connection()?;
+        let max_wait = 600; // seconds – generous, even though KiviDB shouldn't need it
+        let start = Instant::now();
+
+        loop {
+            let info: redis::Value = redis::cmd("FT.INFO")
+                .arg(&self.config.index_name)
+                .query(&mut conn)
+                .map_err(|e| format!("FT.INFO error: {}", e))?;
+
+            let mut live_count: usize = 0;
+            let mut compaction_in_progress: bool = false;
+
+            fn extract_usize(val: &redis::Value) -> usize {
+                match val {
+                    redis::Value::BulkString(s) => String::from_utf8_lossy(s).parse().unwrap_or(0),
+                    redis::Value::Int(n) => *n as usize,
+                    redis::Value::Double(f) => *f as usize,
+                    redis::Value::SimpleString(s) => s.parse().unwrap_or(0),
+                    _ => 0,
+                }
+            }
+
+            fn extract_bool_nonzero(val: &redis::Value) -> bool {
+                match val {
+                    redis::Value::BulkString(s) => s != b"0",
+                    redis::Value::Int(n) => *n != 0,
+                    redis::Value::Double(f) => *f != 0.0,
+                    redis::Value::SimpleString(s) => s != "0",
+                    redis::Value::Boolean(b) => *b,
+                    _ => false,
+                }
+            }
+
+            let mut handle_pair = |key: &str, val: &redis::Value| match key {
+                "hnsw_live_count" => live_count = extract_usize(val),
+                "hnsw_compaction_in_progress" => {
+                    compaction_in_progress = compaction_in_progress || extract_bool_nonzero(val)
+                }
+                _ => {}
+            };
+
+            match &info {
+                redis::Value::Array(arr) => {
+                    for i in (0..arr.len()).step_by(2) {
+                        let key_str = match &arr[i] {
+                            redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                            redis::Value::SimpleString(s) => s.clone(),
+                            _ => continue,
+                        };
+                        if let Some(val) = arr.get(i + 1) {
+                            handle_pair(&key_str, val);
+                        }
+                    }
+                }
+                redis::Value::Map(map) => {
+                    for (k, v) in map {
+                        let key_str = match k {
+                            redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                            redis::Value::SimpleString(s) => s.clone(),
+                            _ => continue,
+                        };
+                        handle_pair(&key_str, v);
+                    }
+                }
+                _ => {
+                    eprintln!("Unexpected FT.INFO response type: {:?}", info);
+                }
+            }
+
+            if live_count >= expected && !compaction_in_progress {
+                println!(
+                    "Indexing complete: {} docs in {:.1}s",
+                    live_count,
+                    start.elapsed().as_secs_f64()
+                );
+                return Ok(());
+            }
+
+            if start.elapsed().as_secs() > max_wait {
+                println!(
+                    "Warning: indexing timeout after {}s (hnsw_live_count={}/{}, compaction_in_progress={})",
+                    max_wait, live_count, expected, compaction_in_progress
+                );
+                return Ok(());
+            }
+
+            if start.elapsed().as_secs().is_multiple_of(10) && start.elapsed().as_secs() > 0 {
+                println!(
+                    "Waiting for indexing: {} docs, compaction_in_progress={} ({:.0}s)",
+                    live_count,
+                    compaction_in_progress,
+                    start.elapsed().as_secs_f64()
+                );
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    }
+
+    fn create_progress_bar(&self, total: usize) -> ProgressBar {
+        let pb = ProgressBar::new(total as u64);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({per_sec_int}/s)")
+                .unwrap()
+                .with_key("per_sec_int", |state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                    write!(w, "{}", HumanCount(state.per_sec() as u64)).unwrap()
+                })
+                .progress_chars("#>-"),
+        );
+        pb
+    }
+}
+
+/// Encode a vector to the FLOAT32 little-endian blob KiviDB expects.
+/// KiviDB's FT.CREATE supports ONLY float32, so this is the single encoding
+/// used for both upload and query vectors.
+fn encode_query_vector(vector: &[f32]) -> Vec<u8> {
+    vector.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+/// Upload one batch of `HSET {id} vector {float32_le_bytes}` via a pipeline.
+fn upload_batch_internal(
+    conn: &mut Connection,
+    ids: &[i64],
+    vectors: &[Vec<f32>],
+    metadata: &[Option<MetadataItem>],
+    datetime_fields: &std::collections::HashSet<String>,
+    key_prefix: &str,
+) -> Result<(), String> {
+    use vector_db_benchmark::readers::metadata::MetadataValue;
+
+    let mut pipe = redis::pipe();
+
+    for i in 0..ids.len() {
+        let key = format!("{}{}", key_prefix, ids[i]);
+        let vec_bytes = encode_query_vector(&vectors[i]);
+        let mut hset_cmd = redis::cmd("HSET");
+        hset_cmd.arg(key.as_str()).arg("vector").arg(&vec_bytes[..]);
+
+        // Metadata fields for filtering (mirrors redis.rs/dragonfly.rs): bools
+        // stay the reader's "true"/"false" string (TAG match); datetime
+        // strings become epoch seconds (NUMERIC range); numbers/labels map as
+        // redis does. No geo case: KiviDB has no Geo field type.
+        if let Some(meta) = &metadata[i] {
+            for (k, v) in &meta.fields {
+                match v {
+                    MetadataValue::String(s) => {
+                        let stored = if datetime_fields.contains(k) {
+                            match datetime_to_epoch_secs(s) {
+                                Some(e) => (e as i64).to_string(),
+                                None => s.clone(),
+                            }
+                        } else {
+                            s.clone()
+                        };
+                        hset_cmd.arg(k.as_str()).arg(stored);
+                    }
+                    MetadataValue::Int(n) => {
+                        hset_cmd.arg(k.as_str()).arg(n.to_string());
+                    }
+                    MetadataValue::Float(f) => {
+                        hset_cmd.arg(k.as_str()).arg(f.to_string());
+                    }
+                    MetadataValue::Labels(labels) => {
+                        hset_cmd.arg(k.as_str()).arg(labels.join(";"));
+                    }
+                    MetadataValue::Geo { lon, lat } => {
+                        // No Geo field type exists to index this against; stored
+                        // as a plain string so the HSET at least succeeds, but it
+                        // is never declared in the schema and never filterable.
+                        hset_cmd.arg(k.as_str()).arg(format!("{},{}", lon, lat));
+                    }
+                }
+            }
+        }
+        pipe.add_command(hset_cmd);
+    }
+
+    pipe.query::<()>(conn).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Map a dataset distance name to KiviDB's `DISTANCE_METRIC` value.
+/// Unknown metrics default to `COSINE`. A typo here (e.g. IP->L2) would
+/// silently invert ranking, so it is unit-tested.
+fn map_distance_metric(distance: &str) -> &'static str {
+    match distance.to_lowercase().as_str() {
+        "cosine" | "angular" => "COSINE",
+        "euclidean" | "l2" => "L2",
+        "dot" | "ip" => "IP",
+        _ => "COSINE",
+    }
+}
+
+/// Whether `EF_RUNTIME` should be emitted for the given algorithm.
+///
+/// `EF_RUNTIME` is an HNSW-only per-query attribute — a FLAT index rejects it
+/// with a query syntax error. Gating it (query string, the `EF` PARAM, and the
+/// PARAMS count) on HNSW keeps a `"algorithm":"flat"` config usable, mirroring
+/// redis.rs/dragonfly.rs.
+fn uses_ef_runtime(algorithm: &str) -> bool {
+    algorithm.eq_ignore_ascii_case("hnsw")
+}
+
+/// Build the FT.SEARCH KNN query string (unfiltered `*` prefilter).
+///
+/// Pure client-side string formatting, kept OUT of the per-query timed window
+/// (precomputed once before the parallel region). `EF_RUNTIME $EF` is emitted
+/// only for an HNSW index — a per-query attribute FLAT rejects; without it
+/// every `ef` in the search sweep runs at the index default. The query vector
+/// is bound as `$vec_param`, so this string is identical across all queries.
+fn build_knn_query_str(algorithm: &str, prefilter: &str) -> String {
+    if uses_ef_runtime(algorithm) {
+        format!("{prefilter}=>[KNN $K @vector $vec_param EF_RUNTIME $EF AS vector_score]")
+    } else {
+        format!("{prefilter}=>[KNN $K @vector $vec_param AS vector_score]")
+    }
+}
+
+/// Execute a KiviDB FT.SEARCH KNN query, return (id, score) pairs.
+///
+/// `vec_bytes` and `query_str` are precomputed by the caller BEFORE the timed
+/// window; this performs only the arg binding, the `cmd.query` RPC round-trip,
+/// and the reply parse.
+#[allow(clippy::too_many_arguments)]
+fn ft_search_knn(
+    conn: &mut Connection,
+    index_name: &str,
+    vec_bytes: &[u8],
+    query_str: &str,
+    top: usize,
+    ef: i64,
+    algorithm: &str,
+    query_timeout: i64,
+    filter: Option<&ParsedFilter>,
+) -> Result<Vec<(i64, f64)>, String> {
+    use super::redis::FilterParamValue;
+    let mut cmd = redis::cmd("FT.SEARCH");
+    cmd.arg(index_name)
+        .arg(query_str)
+        .arg("SORTBY")
+        .arg("vector_score")
+        .arg("ASC")
+        .arg("LIMIT")
+        .arg(0)
+        .arg(top)
+        .arg("RETURN")
+        .arg(1)
+        .arg("vector_score")
+        .arg("DIALECT")
+        .arg(2)
+        .arg("TIMEOUT")
+        .arg(query_timeout);
+
+    // Params: vec_param(2) + K(2), plus EF(2) only for HNSW (EF_RUNTIME is
+    // HNSW-only; binding it on a FLAT index would be a syntax error), plus 2 per
+    // filter param (the prefilter references `$name` placeholders).
+    let ef_runtime = uses_ef_runtime(algorithm);
+    let filter_params = filter.map(|(_, p)| p.len()).unwrap_or(0);
+    let n = 4 + if ef_runtime { 2 } else { 0 } + filter_params * 2;
+    cmd.arg("PARAMS").arg(n);
+    cmd.arg("vec_param").arg(vec_bytes);
+    cmd.arg("K").arg(top.to_string());
+    if ef_runtime {
+        cmd.arg("EF").arg(ef.to_string());
+    }
+    if let Some((_, params)) = filter {
+        for (name, value) in params {
+            cmd.arg(name);
+            match value {
+                FilterParamValue::Str(s) => cmd.arg(s),
+                FilterParamValue::Int(i) => cmd.arg(i.to_string()),
+                FilterParamValue::Float(f) => cmd.arg(f.to_string()),
+            };
+        }
+    }
+
+    let response: redis::Value = cmd
+        .query(conn)
+        .map_err(|e| format!("FT.SEARCH error: {}", e))?;
+
+    parse_ft_search_response(&response)
+}
+
+/// Parse an FT.SEARCH reply under EITHER protocol shape (KiviDB is RESP2-only
+/// in practice, but the parser mirrors dragonfly.rs/redis.rs for consistency):
+/// - RESP2: a flat array `[count, id, fields, id, fields, ...]`
+/// - RESP3: a map `{ results: [ { id, extra_attributes: { vector_score, .. } } ] }`
+fn parse_ft_search_response(response: &redis::Value) -> Result<Vec<(i64, f64)>, String> {
+    match response {
+        redis::Value::Array(items) => Ok(parse_ft_search_resp2(items)),
+        redis::Value::Map(pairs) => Ok(parse_ft_search_resp3(pairs)),
+        _ => Ok(Vec::new()),
+    }
+}
+
+/// RESP2 flat array: `[count, id, fields, id, fields, ...]`.
+fn parse_ft_search_resp2(response: &[redis::Value]) -> Vec<(i64, f64)> {
+    let mut results = Vec::new();
+    let mut i = 1;
+    while i < response.len() {
+        // The reply carries the doc KEY ("<config>:<id>"); recover the
+        // trailing numeric id. Missing string -> 0 (positionally present).
+        let id = value_as_string(&response[i])
+            .map(|s| doc_key_to_id(&s))
+            .unwrap_or(0);
+        i += 1;
+
+        if i < response.len() {
+            let score = match &response[i] {
+                redis::Value::Array(fields) => extract_vector_score(fields),
+                _ => 0.0,
+            };
+            results.push((id, score));
+            i += 1;
+        }
+    }
+    results
+}
+
+/// RESP3 map: top-level map with a `results` array; each result is a map with an
+/// `id` and an `extra_attributes` map carrying `vector_score`.
+fn parse_ft_search_resp3(pairs: &[(redis::Value, redis::Value)]) -> Vec<(i64, f64)> {
+    let docs = match pairs
+        .iter()
+        .find(|(k, _)| value_as_string(k).as_deref() == Some("results"))
+        .map(|(_, v)| v)
+    {
+        Some(redis::Value::Array(docs)) => docs.as_slice(),
+        _ => return Vec::new(),
+    };
+
+    let mut out = Vec::with_capacity(docs.len());
+    for doc in docs {
+        let redis::Value::Map(fields) = doc else {
+            continue;
+        };
+        let mut id: Option<i64> = None;
+        let mut score = 0.0f64;
+        for (k, v) in fields {
+            match value_as_string(k).as_deref() {
+                Some("id") => id = value_as_string(v).and_then(|s| doc_key_to_id_opt(&s)),
+                Some("extra_attributes") => {
+                    if let redis::Value::Map(attrs) = v {
+                        for (ak, av) in attrs {
+                            if value_as_string(ak).as_deref() == Some("vector_score") {
+                                score = value_as_string(av)
+                                    .and_then(|s| s.parse().ok())
+                                    .unwrap_or(0.0);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if let Some(id) = id {
+            out.push((id, score));
+        }
+    }
+    out
+}
+
+/// Best-effort string view of a RESP value (BulkString/SimpleString).
+fn value_as_string(v: &redis::Value) -> Option<String> {
+    match v {
+        redis::Value::BulkString(b) => Some(String::from_utf8_lossy(b).into_owned()),
+        redis::Value::SimpleString(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Parse a RESP value as an i64 doc id (bulk/simple string or integer).
+/// Retained for its unit test; the resp2 hot path now goes through
+/// `doc_key_to_id` to strip the per-config key prefix, so this is test-only.
+#[cfg(test)]
+fn value_as_i64(v: &redis::Value) -> i64 {
+    match v {
+        redis::Value::BulkString(data) => String::from_utf8_lossy(data).parse::<i64>().unwrap_or(0),
+        redis::Value::Int(n) => *n,
+        redis::Value::SimpleString(s) => s.parse().unwrap_or(0),
+        _ => 0,
+    }
+}
+
+/// Extract the `vector_score` field value from a RESP2 field-values array.
+fn extract_vector_score(fields: &[redis::Value]) -> f64 {
+    let mut i = 0;
+    while i + 1 < fields.len() {
+        if let redis::Value::BulkString(name) = &fields[i] {
+            if name == b"vector_score" {
+                if let redis::Value::BulkString(val) = &fields[i + 1] {
+                    return String::from_utf8_lossy(val).parse::<f64>().unwrap_or(0.0);
+                }
+            }
+        }
+        i += 2;
+    }
+    0.0
+}
+
+/// Parse the `used_memory:` value (bytes) out of an `INFO memory` text block.
+/// Returns 0 when the line is absent or unparseable. The `used_memory:` prefix
+/// is exact, so it never matches sibling keys like `used_memory_rss:`.
+fn parse_used_memory(info: &str) -> i64 {
+    info.lines()
+        .find(|l| l.starts_with("used_memory:"))
+        .and_then(|l| l.strip_prefix("used_memory:"))
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+/// Convert a redis::Value to serde_json::Value for FT.INFO serialization.
+fn redis_value_to_json(val: &redis::Value) -> serde_json::Value {
+    match val {
+        redis::Value::Nil => serde_json::Value::Null,
+        redis::Value::Int(n) => serde_json::json!(n),
+        redis::Value::Double(f) => serde_json::json!(f),
+        redis::Value::Boolean(b) => serde_json::json!(b),
+        redis::Value::SimpleString(s) => serde_json::json!(s),
+        redis::Value::BulkString(bytes) => match String::from_utf8(bytes.clone()) {
+            Ok(s) => serde_json::json!(s),
+            Err(_) => serde_json::json!(format!("<{} bytes>", bytes.len())),
+        },
+        redis::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(redis_value_to_json).collect())
+        }
+        redis::Value::Map(pairs) => {
+            let mut map = serde_json::Map::new();
+            for (k, v) in pairs {
+                let key = match k {
+                    redis::Value::SimpleString(s) => s.clone(),
+                    redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
+                    other => format!("{:?}", other),
+                };
+                map.insert(key, redis_value_to_json(v));
+            }
+            serde_json::Value::Object(map)
+        }
+        other => serde_json::json!(format!("{:?}", other)),
+    }
+}
+
+// ── Engine trait implementation ──────────────────────────────────────────
+
+impl Engine for KividbEngine {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn search_params(&self) -> &[SearchParams] {
+        &self.search_params
+    }
+
+    fn configure(&mut self, dataset: &Dataset) -> Result<(), String> {
+        let mut conn = self.get_connection()?;
+
+        println!(
+            "Using algorithm {} with config {{'M': {}, 'EF_CONSTRUCTION': {}}}",
+            self.config.algorithm, self.config.m, self.config.ef_construction
+        );
+
+        self.create_index(&mut conn, dataset)?;
+        // Best-effort; see check_commandstats note in upload()/search() below.
+        self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
+        Ok(())
+    }
+
+    fn upload(&mut self, dataset: &Dataset) -> Result<UploadStats, String> {
+        let normalize = dataset.needs_normalization();
+
+        let dataset_path = dataset.get_path()?;
+        println!("Reading dataset from {}...", dataset_path.display());
+        let read_start = Instant::now();
+        let (ids, vectors, metadata): (Vec<i64>, Vec<Vec<f32>>, Vec<Option<MetadataItem>>) =
+            dataset.read_vectors(normalize)?;
+        // `datetime` schema fields are stored as NUMERIC epoch seconds (like
+        // redis/dragonfly/valkey) so range filters over them work.
+        let datetime_fields: std::collections::HashSet<String> = dataset
+            .config
+            .schema
+            .as_ref()
+            .and_then(|s| s.as_object())
+            .map(|o| {
+                o.iter()
+                    .filter(|(_, t)| t.as_str() == Some("datetime"))
+                    .map(|(k, _)| k.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let read_time = read_start.elapsed().as_secs_f64();
+
+        println!(
+            "Read {} vectors ({}d) in {:.3}s ({:.0} vectors/sec)",
+            vectors.len(),
+            vectors.first().map(|v| v.len()).unwrap_or(0),
+            read_time,
+            vectors.len() as f64 / read_time
+        );
+
+        println!(
+            "Starting upload with {} threads, batch size {}...",
+            self.config.parallel, self.config.batch_size
+        );
+        let upload_start = Instant::now();
+
+        if self.config.parallel <= 1 {
+            self.upload_sequential(&ids, &vectors, &metadata, &datetime_fields)?;
+        } else {
+            self.upload_parallel(&ids, &vectors, &metadata, &datetime_fields)?;
+        }
+
+        let upload_time = upload_start.elapsed().as_secs_f64();
+
+        println!(
+            "Upload time: {:.3}s ({:.0} records/sec)",
+            upload_time,
+            vectors.len() as f64 / upload_time
+        );
+
+        // Include the index-build wait in total_time for cross-engine
+        // comparability (mirrors redis/dragonfly/valkey) — in KiviDB's case
+        // this wait should be near-zero; see wait_for_indexing's doc comment.
+        let expected = vectors.len();
+        let index_start = Instant::now();
+        self.wait_for_indexing(expected)?;
+        let index_time = index_start.elapsed().as_secs_f64();
+
+        let total_time = read_time + upload_time + index_time;
+        println!(
+            "Index time: {:.3}s, Total time (read+upload+index): {:.3}s",
+            index_time, total_time
+        );
+
+        let mut conn = self.get_connection()?;
+        redis_utils::check_commandstats(
+            &mut conn,
+            &["hset"],
+            "upload",
+            self.commandstats_baseline.as_ref(),
+        )?;
+
+        Ok(UploadStats {
+            upload_time,
+            total_time,
+            upload_count: vectors.len(),
+            parallel: self.config.parallel,
+            batch_size: self.config.batch_size,
+            memory_usage: None,
+        })
+    }
+
+    fn search(
+        &mut self,
+        dataset: &Dataset,
+        params: &SearchParams,
+        num_queries: i64,
+    ) -> Result<SearchResults, String> {
+        // Index-existence guard: on the --skip-upload path a missing or
+        // mismatched index would otherwise write a silent recall-0.0 result file.
+        {
+            let mut conn = self.get_connection()?;
+            redis_utils::ensure_index_exists(&mut conn, &self.config.index_name)?;
+        }
+
+        let ef = params
+            .search_params
+            .as_ref()
+            .and_then(|sp| sp.ef)
+            .unwrap_or(64);
+        let parallel = params.parallel.unwrap_or(1) as usize;
+        let query_timeout: i64 = std::env::var("KIVIDB_QUERY_TIMEOUT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(60_000);
+
+        let query_path = dataset.get_path()?;
+        println!("\tReading queries from {}...", query_path.display());
+        let (queries, neighbors, conditions) = dataset.read_queries()?;
+
+        // Per-query prefilters, reusing redis.rs's RediSearch filter builder
+        // (same FT.SEARCH syntax, and KiviDB supports the same TAG/NUMERIC/TEXT
+        // field types).
+        let parsed_filters: Vec<Option<ParsedFilter>> = conditions
+            .iter()
+            .map(|c| c.as_ref().and_then(parse_conditions))
+            .collect();
+
+        let explicit_top: Option<usize> = params.top.map(|t| t as usize);
+        let num_to_run = if num_queries > 0 {
+            (num_queries as usize).min(queries.len())
+        } else {
+            queries.len()
+        };
+
+        // Precompute client-side request construction BEFORE the timed region so
+        // the per-query window wraps ONLY the RPC round-trip + reply parse
+        // (matching redis.rs/dragonfly.rs/valkey.rs).
+        let encoded_queries: Vec<Vec<u8>> =
+            queries.iter().map(|q| encode_query_vector(q)).collect();
+        let algorithm = self.config.algorithm.clone();
+        let query_strs: Vec<String> = parsed_filters
+            .iter()
+            .map(|f| {
+                let prefilter = f.as_ref().map(|(expr, _)| expr.as_str()).unwrap_or("*");
+                build_knn_query_str(&algorithm, prefilter)
+            })
+            .collect();
+        let index_name = self.config.index_name.clone();
+
+        let query_idx = Arc::new(AtomicUsize::new(0));
+
+        let pb = self.create_progress_bar(num_to_run);
+
+        // Barrier-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window (mirrors redis.rs/dragonfly.rs).
+        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
+        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+
+        let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut recs: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
+        let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
+
+        std::thread::scope(|s| {
+            let mut handles = Vec::with_capacity(parallel);
+            for _ in 0..parallel {
+                let host = self.host.clone();
+                let port = self.port;
+                let neighbors = &neighbors;
+                let encoded_queries = &encoded_queries;
+                let query_strs = &query_strs;
+                let parsed_filters = &parsed_filters;
+                let algorithm = algorithm.as_str();
+                let index_name = index_name.as_str();
+                let query_idx = Arc::clone(&query_idx);
+                let ready = Arc::clone(&ready);
+                let go = Arc::clone(&go);
+                let pb = &pb;
+
+                handles.push(s.spawn(move || {
+                    let mut t = Vec::new();
+                    let mut p = Vec::new();
+                    let mut r = Vec::new();
+                    let mut mr = Vec::new();
+                    let mut nd = Vec::new();
+                    let mut pb_pending: u64 = 0;
+
+                    let mut conn = match KividbEngine::connect(&host, port) {
+                        Ok(c) => c,
+                        Err(_) => {
+                            ready.wait();
+                            go.wait();
+                            return (t, p, r, mr, nd);
+                        }
+                    };
+
+                    // Prime this connection with ONE discarded query (index 0) so
+                    // the cold first round-trip is not inside the measured window.
+                    {
+                        let prime_top = explicit_top.unwrap_or(10);
+                        let _ = ft_search_knn(
+                            &mut conn,
+                            index_name,
+                            &encoded_queries[0],
+                            &query_strs[0],
+                            prime_top,
+                            ef,
+                            algorithm,
+                            query_timeout,
+                            parsed_filters[0].as_ref(),
+                        );
+                    }
+
+                    ready.wait();
+                    go.wait();
+
+                    loop {
+                        let idx = query_idx.fetch_add(1, Ordering::Relaxed);
+                        if idx >= num_to_run {
+                            break;
+                        }
+
+                        let top = explicit_top.unwrap_or_else(|| {
+                            let n = neighbors[idx].len();
+                            if n > 0 {
+                                n
+                            } else {
+                                10
+                            }
+                        });
+
+                        let query_start = Instant::now();
+                        let results = ft_search_knn(
+                            &mut conn,
+                            index_name,
+                            &encoded_queries[idx],
+                            &query_strs[idx],
+                            top,
+                            ef,
+                            algorithm,
+                            query_timeout,
+                            parsed_filters[idx].as_ref(),
+                        );
+                        let query_time = query_start.elapsed().as_secs_f64();
+
+                        match &results {
+                            Ok(result_ids) => {
+                                let ordered_ids: Vec<i64> =
+                                    result_ids.iter().map(|(id, _)| *id).collect();
+                                let m = compute_metrics(&ordered_ids, &neighbors[idx], top);
+                                t.push(query_time);
+                                p.push(m.precision);
+                                r.push(m.recall);
+                                mr.push(m.mrr);
+                                nd.push(m.ndcg);
+                            }
+                            Err(e) => {
+                                eprintln!("Search query {} failed: {}", idx, e);
+                            }
+                        }
+                        pb_pending += 1;
+                        if pb_pending >= 256 {
+                            pb.inc(pb_pending);
+                            pb_pending = 0;
+                        }
+                    }
+                    if pb_pending > 0 {
+                        pb.inc(pb_pending);
+                    }
+                    (t, p, r, mr, nd)
+                }));
+            }
+
+            ready.wait();
+            let st = Instant::now();
+            start_cell.set(st).ok();
+            go.wait();
+
+            for h in handles {
+                let (t, p, r, mr, nd) = h.join().unwrap();
+                times.extend(t);
+                precs.extend(p);
+                recs.extend(r);
+                mrr_vals.extend(mr);
+                ndcg_vals.extend(nd);
+            }
+        });
+
+        pb.finish_and_clear();
+        let total_time = start_cell
+            .get()
+            .map(|st| st.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
+
+        if times.is_empty() {
+            return Err("No searches completed".to_string());
+        }
+
+        let mut check_conn = self.get_connection()?;
+        redis_utils::check_commandstats(
+            &mut check_conn,
+            &["FT.SEARCH"],
+            "search",
+            self.commandstats_baseline.as_ref(),
+        )?;
+
+        let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
+        crate::engine::compute_search_stats(
+            &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,
+        )
+    }
+
+    fn delete(&mut self) -> Result<(), String> {
+        let mut conn = self.get_connection()?;
+        redis_utils::drop_index_and_keys(
+            &mut conn,
+            &self.config.index_name,
+            &self.config.key_prefix,
+        );
+        Ok(())
+    }
+
+    fn get_memory_usage(&mut self) -> Option<serde_json::Value> {
+        let mut conn = self.get_connection().ok()?;
+
+        let info_str: String = redis::cmd("INFO").arg("memory").query(&mut conn).ok()?;
+        let used_memory: i64 = parse_used_memory(&info_str);
+
+        let ft_info_raw: Option<redis::Value> = redis::cmd("FT.INFO")
+            .arg(&self.config.index_name)
+            .query::<redis::Value>(&mut conn)
+            .ok();
+        let index_memory_bytes = ft_info_raw
+            .as_ref()
+            .and_then(redis_utils::ft_info_index_memory_bytes);
+        let ft_info = ft_info_raw.as_ref().map(redis_value_to_json);
+
+        Some(serde_json::json!({
+            "used_memory": [used_memory],
+            "index_memory_bytes": index_memory_bytes,
+            "index_info": ft_info,
+        }))
+    }
+
+    fn server_metadata(&mut self) -> Option<serde_json::Value> {
+        let mut conn = self.get_connection().ok()?;
+        let mut meta = redis_utils::collect_server_metadata(&mut conn);
+        let ft_info = redis::cmd("FT.INFO")
+            .arg(&self.config.index_name)
+            .query::<redis::Value>(&mut conn)
+            .ok()
+            .map(|v| redis_value_to_json(&v));
+        if let Some(obj) = meta.as_object_mut() {
+            obj.insert(
+                "index_info".to_string(),
+                ft_info.unwrap_or(serde_json::Value::Null),
+            );
+        }
+        Some(meta)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use redis::Value;
+
+    fn bulk(s: &str) -> Value {
+        Value::BulkString(s.as_bytes().to_vec())
+    }
+
+    #[test]
+    fn encode_query_vector_is_float32_le_bytes() {
+        let v = vec![1.0f32, -2.5, 3.25];
+        let expected: Vec<u8> = v.iter().flat_map(|f| f.to_le_bytes()).collect();
+        assert_eq!(encode_query_vector(&v), expected);
+        assert_eq!(encode_query_vector(&v).len(), 12);
+    }
+
+    #[test]
+    fn encode_query_vector_pins_exact_bytes() {
+        // 1.0f32 = 0x3F800000 little-endian => 00 00 80 3F.
+        assert_eq!(encode_query_vector(&[1.0]), vec![0x00, 0x00, 0x80, 0x3F]);
+    }
+
+    #[test]
+    fn map_distance_metric_covers_all_aliases() {
+        assert_eq!(map_distance_metric("cosine"), "COSINE");
+        assert_eq!(map_distance_metric("angular"), "COSINE");
+        assert_eq!(map_distance_metric("euclidean"), "L2");
+        assert_eq!(map_distance_metric("l2"), "L2");
+        assert_eq!(map_distance_metric("dot"), "IP");
+        assert_eq!(map_distance_metric("ip"), "IP");
+        assert_eq!(map_distance_metric("L2"), "L2"); // case-insensitive
+        assert_eq!(map_distance_metric("unknown"), "COSINE"); // default
+    }
+
+    #[test]
+    fn build_knn_query_str_is_unfiltered_with_ef_runtime() {
+        assert_eq!(
+            build_knn_query_str("hnsw", "*"),
+            "*=>[KNN $K @vector $vec_param EF_RUNTIME $EF AS vector_score]"
+        );
+        assert_eq!(
+            build_knn_query_str("HNSW", "*"),
+            "*=>[KNN $K @vector $vec_param EF_RUNTIME $EF AS vector_score]"
+        );
+        assert_eq!(
+            build_knn_query_str("flat", "*"),
+            "*=>[KNN $K @vector $vec_param AS vector_score]"
+        );
+        assert!(uses_ef_runtime("hnsw") && !uses_ef_runtime("flat"));
+    }
+
+    #[test]
+    fn parse_ft_search_response_resp2_reads_id_score_pairs() {
+        let resp = Value::Array(vec![
+            Value::Int(2),
+            bulk("7"),
+            Value::Array(vec![bulk("vector_score"), bulk("0.5")]),
+            bulk("cfg:42"),
+            Value::Array(vec![bulk("vector_score"), bulk("0.75")]),
+        ]);
+        let out = parse_ft_search_response(&resp).unwrap();
+        assert_eq!(out, vec![(7, 0.5), (42, 0.75)]);
+    }
+
+    #[test]
+    fn parse_ft_search_response_resp3_map_reads_results() {
+        let doc = Value::Map(vec![
+            (bulk("id"), bulk("9")),
+            (
+                bulk("extra_attributes"),
+                Value::Map(vec![(bulk("vector_score"), bulk("0.125"))]),
+            ),
+        ]);
+        let resp = Value::Map(vec![(bulk("results"), Value::Array(vec![doc]))]);
+        let out = parse_ft_search_response(&resp).unwrap();
+        assert_eq!(out, vec![(9, 0.125)]);
+    }
+
+    #[test]
+    fn parse_ft_search_response_empty_and_unknown_variants() {
+        assert!(parse_ft_search_response(&Value::Nil).unwrap().is_empty());
+        assert!(parse_ft_search_response(&Value::Int(0)).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_ft_search_resp2_drops_trailing_id_without_fields() {
+        let resp = Value::Array(vec![Value::Int(1), bulk("5")]);
+        let out = parse_ft_search_response(&resp).unwrap();
+        assert!(out.is_empty(), "trailing id without fields must be dropped");
+    }
+
+    #[test]
+    fn parse_ft_search_resp3_skips_doc_with_unparseable_id() {
+        let doc = Value::Map(vec![
+            (bulk("id"), bulk("not-a-number")),
+            (
+                bulk("extra_attributes"),
+                Value::Map(vec![(bulk("vector_score"), bulk("0.1"))]),
+            ),
+        ]);
+        let resp = Value::Map(vec![(bulk("results"), Value::Array(vec![doc]))]);
+        assert!(parse_ft_search_response(&resp).unwrap().is_empty());
+    }
+
+    #[test]
+    fn extract_vector_score_finds_field_or_defaults_zero() {
+        let fields = vec![bulk("vector_score"), bulk("0.25")];
+        assert_eq!(extract_vector_score(&fields), 0.25);
+        let none = vec![bulk("other"), bulk("1.0")];
+        assert_eq!(extract_vector_score(&none), 0.0);
+    }
+
+    #[test]
+    fn value_as_i64_reads_variants() {
+        assert_eq!(value_as_i64(&bulk("13")), 13);
+        assert_eq!(value_as_i64(&Value::Int(-4)), -4);
+        assert_eq!(value_as_i64(&Value::SimpleString("8".into())), 8);
+        assert_eq!(value_as_i64(&Value::Nil), 0);
+    }
+
+    #[test]
+    fn parse_used_memory_reads_exact_prefix_only() {
+        let info = "# Memory\r\nused_memory:1048576\r\nused_memory_rss:2097152\r\n";
+        assert_eq!(parse_used_memory(info), 1048576);
+        assert_eq!(parse_used_memory("no memory line here"), 0);
+    }
+
+    #[test]
+    fn wait_for_indexing_reads_kividb_specific_fields_not_num_docs() {
+        // Regression guard for the bug this engine exists to fix: a generic
+        // wait-for-indexing loop that only understands `num_docs` would stall
+        // forever against KiviDB's FT.INFO, which never sets that field.
+        // hnsw_live_count/hnsw_compaction_in_progress must be the fields read.
+        let info = Value::Array(vec![
+            bulk("hnsw_live_count"),
+            bulk("1000"),
+            bulk("hnsw_compaction_in_progress"),
+            bulk("0"),
+        ]);
+        let mut live_count: usize = 0;
+        let mut compaction_in_progress = false;
+        if let Value::Array(arr) = &info {
+            for i in (0..arr.len()).step_by(2) {
+                if let Value::BulkString(k) = &arr[i] {
+                    let key = String::from_utf8_lossy(k);
+                    if let Some(v) = arr.get(i + 1) {
+                        if key == "hnsw_live_count" {
+                            live_count = value_as_i64(v) as usize;
+                        } else if key == "hnsw_compaction_in_progress" {
+                            compaction_in_progress = value_as_i64(v) != 0;
+                        }
+                    }
+                }
+            }
+        }
+        assert_eq!(live_count, 1000);
+        assert!(!compaction_in_progress);
+    }
+}

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -10,6 +10,7 @@ mod chroma;
 mod dragonfly;
 mod elasticsearch;
 pub mod index_naming;
+mod kividb;
 mod milvus;
 mod mongodb_engine;
 mod opensearch;
@@ -32,6 +33,7 @@ use std::time::{Duration, Instant};
 pub use chroma::ChromaEngine;
 pub use dragonfly::DragonflyEngine;
 pub use elasticsearch::ElasticsearchEngine;
+pub use kividb::KividbEngine;
 pub use milvus::MilvusEngine;
 pub use mongodb_engine::MongoDBEngine;
 pub use opensearch::OpenSearchEngine;
@@ -486,10 +488,11 @@ pub fn create_engine(engine_config: &EngineConfig, host: &str) -> Result<Box<dyn
         "valkey" => Ok(Box::new(ValkeyEngine::new(engine_config, host)?)),
         "turbopuffer" => Ok(Box::new(TurbopufferEngine::new(engine_config, host)?)),
         "dragonfly" => Ok(Box::new(DragonflyEngine::new(engine_config, host)?)),
+        "kividb" => Ok(Box::new(KividbEngine::new(engine_config, host)?)),
         "vertex" => Ok(Box::new(VertexEngine::new(engine_config, host)?)),
         "chroma" => Ok(Box::new(ChromaEngine::new(engine_config, host)?)),
         other => Err(format!(
-            "Unsupported engine type: '{}'. Supported: 'redis', 'vectorsets', 'elasticsearch', 'opensearch', 'qdrant', 'weaviate', 'pgvector', 'milvus', 'mongodb', 'valkey', 'turbopuffer', 'dragonfly', 'vertex', 'chroma'.",
+            "Unsupported engine type: '{}'. Supported: 'redis', 'vectorsets', 'elasticsearch', 'opensearch', 'qdrant', 'weaviate', 'pgvector', 'milvus', 'mongodb', 'valkey', 'turbopuffer', 'dragonfly', 'kividb', 'vertex', 'chroma'.",
             other
         )),
     }

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -139,6 +139,7 @@ pub fn run(args: &Args) -> Result<(), String> {
         "valkey",
         "turbopuffer",
         "dragonfly",
+        "kividb",
         "vertex",
         "chroma",
     ];
@@ -191,8 +192,8 @@ pub fn run(args: &Args) -> Result<(), String> {
     }
 
     // Collision guard (#151-4): among the selected configs, no two configs of the
-    // same destructive Redis-wire engine (redis/valkey/dragonfly) may derive the
-    // same index namespace, or a sweep would silently overwrite one config's graph
+    // same destructive Redis-wire engine (redis/valkey/dragonfly/kividb) may derive
+    // the same index namespace, or a sweep would silently overwrite one config's graph
     // and keyspace with another's (the exact bug this fix closes). Also fires when
     // an `*_INDEX_NAME_EXACT` pin is set with >1 config for that engine (every
     // config then resolves to the same verbatim base). In --skip-vector-index mode
@@ -207,6 +208,7 @@ pub fn run(args: &Args) -> Result<(), String> {
                 "redis" => "REDIS_INDEX_NAME",
                 "valkey" => "VALKEY_INDEX_NAME",
                 "dragonfly" => "DRAGONFLY_INDEX_NAME",
+                "kividb" => "KIVIDB_INDEX_NAME",
                 _ => continue,
             };
             let idx = derive_index_name(base_env, "idx", &config.name);


### PR DESCRIPTION
## Summary

Adds a first-class engine for [KiviDB](https://kividb.io), a Redis-wire-compatible (RESP2) data store that implements a RediSearch-compatible `FT.CREATE`/`FT.SEARCH`/`FT.INFO`/`FT.DROPINDEX` subset with HNSW vector fields. This mirrors the existing `dragonfly`/`valkey` Redis-wire-compatible engines — same protocol, same filter builder reuse, same upload/search structure.

## Why this exists

While benchmarking KiviDB against Redis Stack with this tool, we hit a real compatibility gap: KiviDB's `FT.INFO` doesn't expose RediSearch's `num_docs`/`indexing`/`percent_indexed` fields, so the generic `wait_for_indexing` loop (which only understands those) polls forever until its own timeout — even though the index is already fully built. KiviDB reports HNSW graph state directly instead (`hnsw_live_count`, `hnsw_compaction_in_progress`), because it builds each vector's HNSW entry synchronously inside the `HSET` that stores it — there's no async backfill phase to report progress on.

`KividbEngine::wait_for_indexing` polls those KiviDB-specific fields instead, and in practice returns on the first poll.

## Scope notes

- Vector type: FLOAT32 only (KiviDB's `FT.CREATE` rejects any other `TYPE`).
- Metadata filtering: TAG/NUMERIC/TEXT supported (reuses `redis.rs`'s filter builder — same wire syntax); no GEO field type exists in KiviDB's schema at all, so geo fields are never declared or filtered (unlike Dragonfly, which has a GEO field but rejects `$param` geo bounds at the parser level).
- RESP2 only — no protocol opt-in like `dragonfly.rs`'s `DRAGONFLY_PROTOCOL=resp3`.
- Default port 6379 (`KIVIDB_PORT` env override), matching KiviDB's default.

## Test plan

- [x] Unit tests included (mirrors `dragonfly.rs`'s test coverage: vector encoding, distance metric mapping, EF_RUNTIME gating, FT.SEARCH RESP2/RESP3 parsing, `wait_for_indexing`'s field-parsing regression guard).
- [ ] Not yet compile-checked in this environment (Windows without `hdf5-sys`'s native lib; WSL sudo unavailable non-interactively) — verified by hand against `dragonfly.rs`'s working import paths/visibility (`pub(crate)` types in `redis.rs`, `pub` fns in `redis_utils.rs`). Please run `cargo check` / CI on this PR before merging.
- [x] Live-validated the underlying methodology (glove-25-angular, HNSW M=16/EF_CONSTRUCTION=256, 100 parallel clients) against real KiviDB + Redis Stack instances using this tool's `v0/` (Python) predecessor — confirms the `FT.INFO` dialect gap this PR fixes.