### PR TITLE
fix(vectorsets): datetime range filters ran UNFILTERED — recall 0.520 → 1.000 (closes #220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,23 @@ memory is reported per-index via `FT.INFO` (issue #151-4).
   the sweep finishes. Unset (the default) keeps full per-config isolation — no
   behavior change.
 
+### VectorSets: datetime corpora written before #230 must be re-uploaded
+
+VSIM `FILTER` has no date type and its comparison operators are numeric, so since
+PR #230 a datetime metadata value is stored as an **epoch-seconds number** on
+`VADD … SETATTR`, and range/equality filters compare against epoch numbers. A
+corpus uploaded by any **pre-#230** binary holds ISO-8601 **strings** instead, and
+VSIM coerces a non-numeric attribute to `0` in a numeric comparison — so a
+`--skip-upload` search against such a corpus silently returns the wrong documents
+(a two-sided range matches nothing → recall 0; a one-sided `lt`/`lte` matches
+everything). **Re-upload before searching.**
+
+Unlike Redis/Valkey — where `--skip-upload` against a missing or mismatched index
+hard-errors (`redis_utils::ensure_index_exists`) — VectorSets has **no such
+guard**: it uses a single hardcoded key (`idx`), so there is not even a name
+change for the tool to detect. The stale corpus is found, the run succeeds, and
+only the recall number is wrong.
+
 ### Charts
 
 Render a QPS-vs-precision trade-off plot (SVG, no dependencies) from existing `*-summary.json` results — one colored series per engine, filtered by `--engines`/`--datasets`:

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -2,6 +2,7 @@
 //!
 //! Implements the Engine trait for Redis VectorSets (VADD/VSIM commands).
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -16,6 +17,7 @@ use super::redis_utils;
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::{Engine, SearchResults, UpdateSearchRatio, UploadStats};
+use vector_db_benchmark::parsers::datetime_to_epoch_secs;
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
 
 /// VectorSets engine configuration
@@ -27,6 +29,12 @@ pub struct VectorSetsConfig {
     pub cas: bool,
     pub batch_size: usize,
     pub parallel: usize,
+    /// Schema fields declared `datetime`, primed from the dataset schema. Their
+    /// ISO-8601 string values are stored as epoch-seconds NUMBERS on VADD so the
+    /// numeric VSIM range filter (`.ts >= <epoch>`) compares like with like.
+    /// `Arc`-wrapped because `VectorSetsConfig` is cloned into each upload
+    /// worker thread. Mirrors `redis::RedisEngineConfig::datetime_fields`.
+    pub datetime_fields: Arc<HashSet<String>>,
 }
 
 pub struct VectorSetsEngine {
@@ -94,6 +102,7 @@ impl VectorSetsEngine {
                 cas,
                 batch_size,
                 parallel,
+                datetime_fields: Arc::new(HashSet::new()),
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             commandstats_baseline: None,
@@ -246,39 +255,11 @@ fn vadd_batch(
         }
 
         // Attach metadata as JSON attributes for FILTER support
-        if let Some(meta) = &metadata[i] {
-            if !meta.fields.is_empty() {
-                let mut map = serde_json::Map::new();
-                for (k, v) in &meta.fields {
-                    match v {
-                        MetadataValue::String(s) => {
-                            map.insert(k.clone(), serde_json::Value::String(s.clone()));
-                        }
-                        MetadataValue::Int(n) => {
-                            map.insert(k.clone(), serde_json::Value::from(*n));
-                        }
-                        MetadataValue::Float(f) => {
-                            map.insert(k.clone(), serde_json::json!(*f));
-                        }
-                        MetadataValue::Labels(labels) => {
-                            map.insert(
-                                k.clone(),
-                                serde_json::Value::Array(
-                                    labels
-                                        .iter()
-                                        .map(|l| serde_json::Value::String(l.clone()))
-                                        .collect(),
-                                ),
-                            );
-                        }
-                        MetadataValue::Geo { lon, lat } => {
-                            map.insert(k.clone(), serde_json::json!({"lon": lon, "lat": lat}));
-                        }
-                    }
-                }
-                let json_str = serde_json::Value::Object(map).to_string();
-                cmd.arg("SETATTR").arg(json_str);
-            }
+        if let Some(json_str) = metadata[i]
+            .as_ref()
+            .and_then(|m| metadata_to_attr_json(config, m))
+        {
+            cmd.arg("SETATTR").arg(json_str);
         }
 
         pipe.add_command(cmd);
@@ -287,6 +268,69 @@ fn vadd_batch(
     pipe.query::<()>(conn)
         .map_err(|e| format!("VADD batch error: {}", e))?;
     Ok(())
+}
+
+/// Render one document's metadata as the JSON object attached by
+/// `VADD … SETATTR`, or `None` when there is nothing to attach. Shared by the
+/// upload batch and the mixed-workload update path so BOTH store the identical
+/// representation (notably datetime → epoch seconds, see [`encode_string_attr`]).
+fn metadata_to_attr_json(config: &VectorSetsConfig, meta: &MetadataItem) -> Option<String> {
+    if meta.fields.is_empty() {
+        return None;
+    }
+    let mut map = serde_json::Map::new();
+    for (k, v) in &meta.fields {
+        let value = match v {
+            MetadataValue::String(s) => encode_string_attr(config, k, s),
+            MetadataValue::Int(n) => serde_json::Value::from(*n),
+            MetadataValue::Float(f) => serde_json::json!(*f),
+            MetadataValue::Labels(labels) => serde_json::Value::Array(
+                labels
+                    .iter()
+                    .map(|l| serde_json::Value::String(l.clone()))
+                    .collect(),
+            ),
+            MetadataValue::Geo { lon, lat } => serde_json::json!({"lon": lon, "lat": lat}),
+        };
+        map.insert(k.clone(), value);
+    }
+    Some(serde_json::Value::Object(map).to_string())
+}
+
+/// Render a string metadata field as the JSON attribute value stored by
+/// `VADD … SETATTR`.
+///
+/// A field the dataset schema declares `datetime` carries an ISO-8601 string
+/// (e.g. `"2021-04-11T00:00:00+00:00"`), but VSIM `FILTER` has no date type and
+/// its comparison operators are NUMERIC — so the value is stored as an
+/// epoch-seconds NUMBER, exactly what [`build_range_clause`] emits for an ISO
+/// bound. Storing the ISO string instead would make every datetime range filter
+/// match nothing. Mirrors `redis::encode_string_field` (and milvus/chroma, which
+/// likewise store datetimes as epoch ints). A value that is not parseable as a
+/// datetime (already an epoch, or a non-datetime field) is stored verbatim.
+fn encode_string_attr(config: &VectorSetsConfig, key: &str, value: &str) -> serde_json::Value {
+    if config.datetime_fields.contains(key) {
+        if let Some(epoch) = datetime_to_epoch_secs(value) {
+            return serde_json::Value::from(epoch as i64);
+        }
+    }
+    serde_json::Value::String(value.to_string())
+}
+
+/// Collect the schema field names typed `datetime`. Pure so it can be primed
+/// from `configure()` (upload path) and from `search()`/`search_mixed()` (the
+/// `--skip-upload` path, where `configure()` never runs) and unit-tested without
+/// a full `Dataset`. Mirrors `redis::prime_datetime_fields`.
+fn prime_datetime_fields(schema: Option<&serde_json::Value>) -> HashSet<String> {
+    let mut set = HashSet::new();
+    if let Some(schema) = schema.and_then(|s| s.as_object()) {
+        for (field, ty) in schema {
+            if ty.as_str() == Some("datetime") {
+                set.insert(field.clone());
+            }
+        }
+    }
+    set
 }
 
 /// Encode a query vector to the FP32 little-endian blob VSIM expects.
@@ -397,39 +441,8 @@ fn vadd_single(
         cmd.arg("CAS");
     }
 
-    if let Some(meta) = metadata {
-        if !meta.fields.is_empty() {
-            let mut map = serde_json::Map::new();
-            for (k, v) in &meta.fields {
-                match v {
-                    MetadataValue::String(s) => {
-                        map.insert(k.clone(), serde_json::Value::String(s.clone()));
-                    }
-                    MetadataValue::Int(n) => {
-                        map.insert(k.clone(), serde_json::Value::from(*n));
-                    }
-                    MetadataValue::Float(f) => {
-                        map.insert(k.clone(), serde_json::json!(*f));
-                    }
-                    MetadataValue::Labels(labels) => {
-                        map.insert(
-                            k.clone(),
-                            serde_json::Value::Array(
-                                labels
-                                    .iter()
-                                    .map(|l| serde_json::Value::String(l.clone()))
-                                    .collect(),
-                            ),
-                        );
-                    }
-                    MetadataValue::Geo { lon, lat } => {
-                        map.insert(k.clone(), serde_json::json!({"lon": lon, "lat": lat}));
-                    }
-                }
-            }
-            let json_str = serde_json::Value::Object(map).to_string();
-            cmd.arg("SETATTR").arg(json_str);
-        }
+    if let Some(json_str) = metadata.and_then(|m| metadata_to_attr_json(config, m)) {
+        cmd.arg("SETATTR").arg(json_str);
     }
 
     cmd.query::<()>(conn)
@@ -445,7 +458,12 @@ impl Engine for VectorSetsEngine {
         &self.search_params
     }
 
-    fn configure(&mut self, _dataset: &Dataset) -> Result<(), String> {
+    fn configure(&mut self, dataset: &Dataset) -> Result<(), String> {
+        // Record which schema fields are `datetime` so upload stores them as
+        // epoch seconds (see `encode_string_attr`).
+        self.config.datetime_fields =
+            Arc::new(prime_datetime_fields(dataset.config.schema.as_ref()));
+
         let mut conn = self.get_connection()?;
 
         println!(
@@ -524,6 +542,10 @@ impl Engine for VectorSetsEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // Re-prime for the `--skip-upload` path, where `configure()` never ran
+        // (the mixed harness re-uploads/updates docs from `search_mixed`).
+        self.config.datetime_fields =
+            Arc::new(prime_datetime_fields(dataset.config.schema.as_ref()));
         let ef = params
             .search_params
             .as_ref()
@@ -763,6 +785,10 @@ impl Engine for VectorSetsEngine {
         num_queries: i64,
         ratio: &UpdateSearchRatio,
     ) -> Result<SearchResults, String> {
+        // Mixed re-VADDs documents, so the datetime→epoch encoding must be primed
+        // here too (this path also runs under `--skip-upload`).
+        self.config.datetime_fields =
+            Arc::new(prime_datetime_fields(dataset.config.schema.as_ref()));
         let ef = params
             .search_params
             .as_ref()
@@ -1065,7 +1091,15 @@ fn build_filter_expression(conditions: &serde_json::Value) -> Option<String> {
     if obj.is_empty() {
         return None;
     }
+    build_group(obj)
+}
 
+/// Build one boolean GROUP (a `{and:[…], or:[…]}` object) into a VSIM FILTER
+/// sub-expression: `and` entries joined by `and`, `or` entries joined by `or`
+/// inside parentheses, the two then ANDed. Recursive — an entry inside `and`/`or`
+/// may itself be a group, so this and [`build_clauses`] call each other. Mirrors
+/// `redis::build_group` / `build_subfilters`.
+fn build_group(obj: &serde_json::Map<String, serde_json::Value>) -> Option<String> {
     let and_entries = obj.get("and").and_then(|v| v.as_array());
     let or_entries = obj.get("or").and_then(|v| v.as_array());
 
@@ -1096,6 +1130,18 @@ fn build_clauses(entries: &[serde_json::Value]) -> Vec<String> {
     let mut clauses = Vec::new();
     for entry in entries {
         if let Some(entry_obj) = entry.as_object() {
+            // Nested GROUP: an entry carrying an `and`/`or` key is a sub-tree,
+            // not a field leaf. Recurse and keep it as ONE parenthesised clause
+            // so `{"or":[{"and":[…]},{"and":[…]}]}` keeps its shape. Without this
+            // arm the entry matched no field leaf, every clause was dropped, and
+            // a nested condition left VSIM with NO FILTER — a full unfiltered
+            // search (same silent-wrong class as the datetime bug, issue #220).
+            if entry_obj.contains_key("and") || entry_obj.contains_key("or") {
+                if let Some(expr) = build_group(entry_obj) {
+                    clauses.push(format!("({})", expr));
+                }
+                continue;
+            }
             for (field_name, field_filters) in entry_obj {
                 if let Some(filter_obj) = field_filters.as_object() {
                     for (condition_type, criteria) in filter_obj {
@@ -1245,20 +1291,14 @@ fn never_match_clause(field_name: &str) -> String {
 fn build_range_clause(field_name: &str, criteria: &serde_json::Value) -> Option<String> {
     let mut parts = Vec::new();
 
-    // Only numeric bounds constrain the range; a null/non-numeric bound carries no
-    // constraint and is skipped (matching redis/valkey/qdrant/es/os/weaviate/milvus/
-    // pgvector) — otherwise `format_number` would fall back to "0" and emit `.n > 0`.
-    if let Some(gt) = criteria.get("gt").filter(|v| v.is_number()) {
-        parts.push(format!(".{} > {}", field_name, format_number(gt)));
-    }
-    if let Some(gte) = criteria.get("gte").filter(|v| v.is_number()) {
-        parts.push(format!(".{} >= {}", field_name, format_number(gte)));
-    }
-    if let Some(lt) = criteria.get("lt").filter(|v| v.is_number()) {
-        parts.push(format!(".{} < {}", field_name, format_number(lt)));
-    }
-    if let Some(lte) = criteria.get("lte").filter(|v| v.is_number()) {
-        parts.push(format!(".{} <= {}", field_name, format_number(lte)));
+    // Only representable bounds constrain the range; a null / non-numeric,
+    // non-datetime bound carries no constraint and is skipped (matching
+    // redis/valkey/qdrant/es/os/weaviate/milvus/pgvector) — otherwise
+    // `number_literal` would have to invent a "0" and emit `.n > 0`.
+    for (key, op) in [("gt", ">"), ("gte", ">="), ("lt", "<"), ("lte", "<=")] {
+        if let Some(lit) = criteria.get(key).and_then(number_literal) {
+            parts.push(format!(".{} {} {}", field_name, op, lit));
+        }
     }
 
     if parts.is_empty() {
@@ -1268,13 +1308,35 @@ fn build_range_clause(field_name: &str, criteria: &serde_json::Value) -> Option<
     }
 }
 
-fn format_number(value: &serde_json::Value) -> String {
+/// Render a range bound as a VSIM numeric literal.
+///
+/// VSIM `FILTER` comparison operators are NUMERIC — there is no date type — so an
+/// ISO-8601 / RFC-3339 bound is converted to epoch seconds, the same
+/// representation `encode_string_attr` stores for a `datetime` schema field. A
+/// numeric string is passed through as a number too (so a raw-epoch bound works).
+/// Mirrors `valkey::number_literal` / `redis::insert_number_param`, both of which
+/// route through the shared `parsers::datetime_to_epoch_secs`.
+///
+/// Without the datetime arm BOTH bounds of a `{"gte":"<iso>","lt":"<iso>"}` range
+/// were dropped, `build_range_clause` returned `None`, and VSIM ran with NO
+/// `FILTER` argument — a full unfiltered search scored against filtered ground
+/// truth (issue #220; 1 in 4 queries of the shipped `synthetic-filter-32`).
+fn number_literal(value: &serde_json::Value) -> Option<String> {
     if let Some(i) = value.as_i64() {
-        i.to_string()
+        Some(i.to_string())
     } else if let Some(f) = value.as_f64() {
-        f.to_string()
+        Some(f.to_string())
+    } else if let Some(s) = value.as_str() {
+        if let Some(epoch) = datetime_to_epoch_secs(s) {
+            // Epoch is whole seconds — emit as an integer literal.
+            Some((epoch as i64).to_string())
+        } else if s.parse::<f64>().is_ok() {
+            Some(s.to_string())
+        } else {
+            None
+        }
     } else {
-        "0".to_string()
+        None
     }
 }
 
@@ -1367,8 +1429,12 @@ mod vsim_parse_tests {
 
 #[cfg(test)]
 mod filter_expr_tests {
-    use super::build_filter_expression;
+    use super::{
+        build_filter_expression, encode_string_attr, prime_datetime_fields, VectorSetsConfig,
+    };
     use serde_json::json;
+    use std::collections::HashSet;
+    use std::sync::Arc;
 
     // ── scalar match / range (grammar baseline) ──
 
@@ -1630,6 +1696,130 @@ mod filter_expr_tests {
         // A non-scalar (array) value matches no scalar arm → clause dropped → None.
         assert!(
             build_filter_expression(&json!({"and":[{"n":{"match":{"value":[1,2]}}}]})).is_none()
+        );
+    }
+
+    // ── issue #220: datetime range bounds ──────────────────────────────────
+
+    #[test]
+    fn range_iso_datetime_bounds_become_epoch_seconds() {
+        // Both bounds used to be rejected by `.filter(|v| v.is_number())`, so the
+        // whole clause was None and VSIM ran with NO FILTER (full unfiltered
+        // search scored against filtered ground truth). Now each ISO bound is
+        // converted to epoch seconds, matching how upload stores the attribute.
+        assert_eq!(
+            range_expr(json!({"gte":"2021-04-11T00:00:00+00:00","lt":"2021-10-28T00:00:00+00:00"}))
+                .unwrap(),
+            ".n >= 1618099200 and .n < 1635379200"
+        );
+    }
+
+    #[test]
+    fn range_epoch_string_bound_passes_through() {
+        // A raw-epoch string bound is a valid numeric literal (mirrors
+        // valkey::number_literal), so it is NOT dropped either.
+        assert_eq!(
+            range_expr(json!({"gte":"1609459200"})).unwrap(),
+            ".n >= 1609459200"
+        );
+    }
+
+    #[test]
+    fn range_non_datetime_string_bound_is_skipped() {
+        // An unparseable string still carries no constraint → clause skipped.
+        assert!(range_expr(json!({"gte":"not-a-date"})).is_none());
+    }
+
+    #[test]
+    fn datetime_range_condition_emits_a_filter() {
+        // End-to-end shape of the shipped synthetic-filter-32 datetime query.
+        assert_eq!(
+            build_filter_expression(&json!({"and":[
+                {"ts":{"range":{"gte":"2021-01-01T00:00:00Z","lt":"2021-01-02T00:00:00Z"}}}
+            ]})),
+            Some(".ts >= 1609459200 and .ts < 1609545600".to_string())
+        );
+    }
+
+    #[test]
+    fn datetime_schema_field_is_stored_as_epoch_number() {
+        // Upload MUST store the same representation the filter compares against;
+        // an ISO string attribute would never satisfy `.ts >= <epoch>`.
+        let mut config = test_config();
+        config.datetime_fields = Arc::new(HashSet::from(["ts".to_string()]));
+        assert_eq!(
+            encode_string_attr(&config, "ts", "2021-01-01T00:00:00Z"),
+            json!(1609459200i64)
+        );
+        // Non-datetime field → verbatim string.
+        assert_eq!(
+            encode_string_attr(&config, "color", "2021-01-01T00:00:00Z"),
+            json!("2021-01-01T00:00:00Z")
+        );
+        // Datetime-typed field holding a non-ISO value → verbatim (already epoch).
+        assert_eq!(
+            encode_string_attr(&config, "ts", "1609459200"),
+            json!("1609459200")
+        );
+    }
+
+    #[test]
+    fn prime_datetime_fields_selects_only_datetime_schema_fields() {
+        let schema = json!({"ts":"datetime","price":"int","brand":"keyword"});
+        let got = prime_datetime_fields(Some(&schema));
+        assert_eq!(got, HashSet::from(["ts".to_string()]));
+        assert!(prime_datetime_fields(None).is_empty());
+    }
+
+    fn test_config() -> VectorSetsConfig {
+        VectorSetsConfig {
+            quant: "NOQUANT".to_string(),
+            m: 16,
+            ef_construction: 200,
+            cas: true,
+            batch_size: 64,
+            parallel: 1,
+            datetime_fields: Arc::new(HashSet::new()),
+        }
+    }
+
+    // ── issue #220 follow-on: nested boolean groups ────────────────────────
+
+    #[test]
+    fn nested_or_of_and_groups_keeps_its_shape() {
+        // `(color == red AND size >= 50) OR (color == blue AND size < 10)`.
+        // Each `{"and":[…]}` entry used to match no field leaf → every clause
+        // dropped → None → VSIM ran UNFILTERED.
+        let cond = json!({"or":[
+            {"and":[{"color":{"match":{"value":"red"}}},{"size":{"range":{"gte":50}}}]},
+            {"and":[{"color":{"match":{"value":"blue"}}},{"size":{"range":{"lt":10}}}]},
+        ]});
+        assert_eq!(
+            build_filter_expression(&cond),
+            Some(
+                "((.color == \"red\" and .size >= 50) or (.color == \"blue\" and .size < 10))"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn flat_condition_string_is_unchanged_by_the_nesting_support() {
+        // Regression guard: adding the recursion must not perturb the flat
+        // top-level emission (no extra parentheses).
+        assert_eq!(
+            build_filter_expression(&json!({"and":[
+                {"brand":{"match":{"value":"apple"}}},
+                {"price":{"range":{"gte":100}}},
+            ]})),
+            Some(".brand == \"apple\" and .price >= 100".to_string())
+        );
+        assert_eq!(
+            build_filter_expression(&json!({"or":[
+                {"brand":{"match":{"value":"apple"}}},
+                {"price":{"range":{"gte":100}}},
+            ]})),
+            Some("(.brand == \"apple\" or .price >= 100)".to_string())
         );
     }
 }

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -2,7 +2,6 @@
 //!
 //! Implements the Engine trait for Redis VectorSets (VADD/VSIM commands).
 
-use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -29,12 +28,6 @@ pub struct VectorSetsConfig {
     pub cas: bool,
     pub batch_size: usize,
     pub parallel: usize,
-    /// Schema fields declared `datetime`, primed from the dataset schema. Their
-    /// ISO-8601 string values are stored as epoch-seconds NUMBERS on VADD so the
-    /// numeric VSIM range filter (`.ts >= <epoch>`) compares like with like.
-    /// `Arc`-wrapped because `VectorSetsConfig` is cloned into each upload
-    /// worker thread. Mirrors `redis::RedisEngineConfig::datetime_fields`.
-    pub datetime_fields: Arc<HashSet<String>>,
 }
 
 pub struct VectorSetsEngine {
@@ -102,7 +95,6 @@ impl VectorSetsEngine {
                 cas,
                 batch_size,
                 parallel,
-                datetime_fields: Arc::new(HashSet::new()),
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             commandstats_baseline: None,
@@ -255,10 +247,7 @@ fn vadd_batch(
         }
 
         // Attach metadata as JSON attributes for FILTER support
-        if let Some(json_str) = metadata[i]
-            .as_ref()
-            .and_then(|m| metadata_to_attr_json(config, m))
-        {
+        if let Some(json_str) = metadata[i].as_ref().and_then(metadata_to_attr_json) {
             cmd.arg("SETATTR").arg(json_str);
         }
 
@@ -274,14 +263,14 @@ fn vadd_batch(
 /// `VADD … SETATTR`, or `None` when there is nothing to attach. Shared by the
 /// upload batch and the mixed-workload update path so BOTH store the identical
 /// representation (notably datetime → epoch seconds, see [`encode_string_attr`]).
-fn metadata_to_attr_json(config: &VectorSetsConfig, meta: &MetadataItem) -> Option<String> {
+fn metadata_to_attr_json(meta: &MetadataItem) -> Option<String> {
     if meta.fields.is_empty() {
         return None;
     }
     let mut map = serde_json::Map::new();
     for (k, v) in &meta.fields {
         let value = match v {
-            MetadataValue::String(s) => encode_string_attr(config, k, s),
+            MetadataValue::String(s) => encode_string_attr(s),
             MetadataValue::Int(n) => serde_json::Value::from(*n),
             MetadataValue::Float(f) => serde_json::json!(*f),
             MetadataValue::Labels(labels) => serde_json::Value::Array(
@@ -297,40 +286,48 @@ fn metadata_to_attr_json(config: &VectorSetsConfig, meta: &MetadataItem) -> Opti
     Some(serde_json::Value::Object(map).to_string())
 }
 
+/// THE datetime representation decision for this engine, in ONE place.
+///
+/// VSIM `FILTER` has no date type and its comparison operators are NUMERIC, so a
+/// datetime has to live as an epoch-seconds NUMBER. Both halves of the engine —
+/// what `VADD … SETATTR` WRITES ([`encode_string_attr`]) and what the query
+/// builders COMPARE AGAINST ([`number_literal`], [`build_match_clause`],
+/// [`build_match_any_clause`]) — route through this single predicate, so they can
+/// never disagree about whether a given string is a datetime.
+///
+/// It is deliberately **schema-free**. An earlier version gated only the storage
+/// half on `dataset.config.schema` while the query half converted any ISO-looking
+/// bound unconditionally; the two then disagreed for every datetime-carrying field
+/// NOT declared `datetime` (declared `keyword`, or no schema at all) and produced
+/// SILENT wrong recall: VSIM coerces a non-numeric string attribute to `0` in a
+/// numeric comparison (verified live on redis 8.8), so a two-sided range matched
+/// NOTHING while a one-sided `lt`/`lte` matched EVERYTHING — issue #220's exact
+/// failure class, reached by another route. Deciding from the VALUE alone makes
+/// the two halves agree by construction, with or without a schema.
+///
+/// Trade-off: a `keyword` field whose values happen to be ISO-8601 timestamps is
+/// stored numerically too. Range and equality filters stay correct (both sides
+/// convert), but the best-effort full-text form `"<text>" in .field` cannot match
+/// such a field. That is strictly better than the silent recall corruption above.
+fn epoch_literal(value: &str) -> Option<i64> {
+    datetime_to_epoch_secs(value).map(|secs| secs as i64)
+}
+
 /// Render a string metadata field as the JSON attribute value stored by
 /// `VADD … SETATTR`.
 ///
-/// A field the dataset schema declares `datetime` carries an ISO-8601 string
-/// (e.g. `"2021-04-11T00:00:00+00:00"`), but VSIM `FILTER` has no date type and
-/// its comparison operators are NUMERIC — so the value is stored as an
-/// epoch-seconds NUMBER, exactly what [`build_range_clause`] emits for an ISO
-/// bound. Storing the ISO string instead would make every datetime range filter
-/// match nothing. Mirrors `redis::encode_string_field` (and milvus/chroma, which
-/// likewise store datetimes as epoch ints). A value that is not parseable as a
-/// datetime (already an epoch, or a non-datetime field) is stored verbatim.
-fn encode_string_attr(config: &VectorSetsConfig, key: &str, value: &str) -> serde_json::Value {
-    if config.datetime_fields.contains(key) {
-        if let Some(epoch) = datetime_to_epoch_secs(value) {
-            return serde_json::Value::from(epoch as i64);
-        }
+/// An ISO-8601 / RFC-3339 value is stored as an epoch-seconds NUMBER, exactly
+/// what [`build_range_clause`] emits for an ISO bound — see [`epoch_literal`] for
+/// why the decision is made from the value rather than from the schema. Storing
+/// the ISO string instead would make every datetime range filter match nothing.
+/// Mirrors `redis::encode_string_field` (and milvus/chroma, which likewise store
+/// datetimes as epoch ints). Anything not parseable as a datetime (already an
+/// epoch, a keyword, a bool token) is stored verbatim.
+fn encode_string_attr(value: &str) -> serde_json::Value {
+    match epoch_literal(value) {
+        Some(epoch) => serde_json::Value::from(epoch),
+        None => serde_json::Value::String(value.to_string()),
     }
-    serde_json::Value::String(value.to_string())
-}
-
-/// Collect the schema field names typed `datetime`. Pure so it can be primed
-/// from `configure()` (upload path) and from `search()`/`search_mixed()` (the
-/// `--skip-upload` path, where `configure()` never runs) and unit-tested without
-/// a full `Dataset`. Mirrors `redis::prime_datetime_fields`.
-fn prime_datetime_fields(schema: Option<&serde_json::Value>) -> HashSet<String> {
-    let mut set = HashSet::new();
-    if let Some(schema) = schema.and_then(|s| s.as_object()) {
-        for (field, ty) in schema {
-            if ty.as_str() == Some("datetime") {
-                set.insert(field.clone());
-            }
-        }
-    }
-    set
 }
 
 /// Encode a query vector to the FP32 little-endian blob VSIM expects.
@@ -441,7 +438,7 @@ fn vadd_single(
         cmd.arg("CAS");
     }
 
-    if let Some(json_str) = metadata.and_then(|m| metadata_to_attr_json(config, m)) {
+    if let Some(json_str) = metadata.and_then(metadata_to_attr_json) {
         cmd.arg("SETATTR").arg(json_str);
     }
 
@@ -458,12 +455,11 @@ impl Engine for VectorSetsEngine {
         &self.search_params
     }
 
-    fn configure(&mut self, dataset: &Dataset) -> Result<(), String> {
-        // Record which schema fields are `datetime` so upload stores them as
-        // epoch seconds (see `encode_string_attr`).
-        self.config.datetime_fields =
-            Arc::new(prime_datetime_fields(dataset.config.schema.as_ref()));
-
+    fn configure(&mut self, _dataset: &Dataset) -> Result<(), String> {
+        // NOTE: nothing schema-derived is cached here. The datetime
+        // representation is decided per VALUE by `epoch_literal`, which both the
+        // storage and the query half consult, so there is no schema state that
+        // could go stale on the `--skip-upload` path.
         let mut conn = self.get_connection()?;
 
         println!(
@@ -542,10 +538,6 @@ impl Engine for VectorSetsEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
-        // Re-prime for the `--skip-upload` path, where `configure()` never ran
-        // (the mixed harness re-uploads/updates docs from `search_mixed`).
-        self.config.datetime_fields =
-            Arc::new(prime_datetime_fields(dataset.config.schema.as_ref()));
         let ef = params
             .search_params
             .as_ref()
@@ -785,10 +777,6 @@ impl Engine for VectorSetsEngine {
         num_queries: i64,
         ratio: &UpdateSearchRatio,
     ) -> Result<SearchResults, String> {
-        // Mixed re-VADDs documents, so the datetime→epoch encoding must be primed
-        // here too (this path also runs under `--skip-upload`).
-        self.config.datetime_fields =
-            Arc::new(prime_datetime_fields(dataset.config.schema.as_ref()));
         let ef = params
             .search_params
             .as_ref()
@@ -1130,19 +1118,37 @@ fn build_clauses(entries: &[serde_json::Value]) -> Vec<String> {
     let mut clauses = Vec::new();
     for entry in entries {
         if let Some(entry_obj) = entry.as_object() {
-            // Nested GROUP: an entry carrying an `and`/`or` key is a sub-tree,
-            // not a field leaf. Recurse and keep it as ONE parenthesised clause
-            // so `{"or":[{"and":[…]},{"and":[…]}]}` keeps its shape. Without this
-            // arm the entry matched no field leaf, every clause was dropped, and
-            // a nested condition left VSIM with NO FILTER — a full unfiltered
-            // search (same silent-wrong class as the datetime bug, issue #220).
-            if entry_obj.contains_key("and") || entry_obj.contains_key("or") {
+            // Nested GROUP: an entry carrying an `and`/`or` key whose value is an
+            // ARRAY is a sub-tree, not a field leaf. Recurse and keep it as ONE
+            // parenthesised clause so `{"or":[{"and":[…]},{"and":[…]}]}` keeps its
+            // shape. Without this arm the entry matched no field leaf, every
+            // clause was dropped, and a nested condition left VSIM with NO FILTER
+            // — a full unfiltered search (same silent-wrong class as issue #220).
+            //
+            // Two things this arm must NOT do, both of which would re-introduce
+            // exactly that failure mode:
+            //  * Key off mere key PRESENCE. A field literally named `and`/`or`
+            //    carries a condition object (`{"and":{"match":{"value":"x"}}}`),
+            //    not an array; treating it as a group yields no clause at all and
+            //    the query runs UNFILTERED. `as_array()` distinguishes them.
+            //  * `continue` past the field-leaf loop. A mixed entry such as
+            //    `{"and":[…], "color":{"match":{"value":"red"}}}` would silently
+            //    DROP `color` and under-constrain the filter, so we fall through
+            //    and emit the sibling leaves as well. `build_group` itself only
+            //    ever consults the `and`/`or` keys, so nothing is double-emitted.
+            let is_group_key = |name: &str, value: &serde_json::Value| {
+                (name == "and" || name == "or") && value.is_array()
+            };
+            if entry_obj.iter().any(|(k, v)| is_group_key(k, v)) {
                 if let Some(expr) = build_group(entry_obj) {
                     clauses.push(format!("({})", expr));
                 }
-                continue;
             }
             for (field_name, field_filters) in entry_obj {
+                // Skip the group keys consumed above; every other key is a field.
+                if is_group_key(field_name, field_filters) {
+                    continue;
+                }
                 if let Some(filter_obj) = field_filters.as_object() {
                     for (condition_type, criteria) in filter_obj {
                         if let Some(expr) = build_clause(field_name, condition_type, criteria) {
@@ -1164,6 +1170,14 @@ fn build_clause(
     match condition_type {
         "match" => build_match_clause(field_name, criteria),
         "range" => build_range_clause(field_name, criteria),
+        // STILL OPEN, same silent-wrong class as issue #220: an unhandled
+        // condition type is DROPPED, and when it is the only condition VSIM runs
+        // with no FILTER at all. `"geo"` is the live instance — the point IS
+        // uploaded (see `metadata_to_attr_json`) but has no clause here, so every
+        // query of the shipped `random-geo-radius-{100,2048}-angular-filters`
+        // runs unfiltered against geo-filtered ground truth (issue #223). The
+        // generic guard that would turn "parsed to nothing" into a loud failure
+        // instead of an unfiltered search is issue #219.
         _ => None,
     }
 }
@@ -1211,7 +1225,10 @@ fn build_match_clause(field_name: &str, criteria: &serde_json::Value) -> Option<
         return Some(format!(".{} == \"{}\"", field_name, token));
     }
     if let Some(s) = value.as_str() {
-        Some(format!(".{} == \"{}\"", field_name, escape_str(s)))
+        // A datetime is stored as an epoch NUMBER (see `epoch_literal`), so the
+        // equality must be numeric too — a quoted ISO literal would compare a
+        // string against a number and match NOTHING.
+        Some(equality_clause(field_name, s))
     } else if let Some(n) = value.as_i64() {
         Some(format!(".{} == {}", field_name, n))
     } else {
@@ -1223,6 +1240,18 @@ fn build_match_clause(field_name: &str, criteria: &serde_json::Value) -> Option<
 /// then double quote).
 fn escape_str(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// `.field == <literal>` for a STRING query value, matching how upload stored it:
+/// an ISO-8601 value lives as an epoch NUMBER (see [`epoch_literal`]) and needs a
+/// BARE numeric literal, everything else needs a quoted string. Getting this wrong
+/// is silent — `.ts == "2021-01-01T00:00:00Z"` against epoch storage returns an
+/// empty result set with no error (verified live on redis 8.8).
+fn equality_clause(field_name: &str, value: &str) -> String {
+    match epoch_literal(value) {
+        Some(epoch) => format!(".{} == {}", field_name, epoch),
+        None => format!(".{} == \"{}\"", field_name, escape_str(value)),
+    }
 }
 
 /// Build a `match_any` (IN-list) clause as a per-element OR, covering keyword,
@@ -1259,9 +1288,12 @@ fn build_match_any_clause(field_name: &str, any: &[serde_json::Value]) -> String
                 if s.is_empty() {
                     None
                 } else if is_array_field {
+                    // `labels` is stored as a JSON array of raw strings — never
+                    // epoch-converted — so membership stays a string test.
                     Some(format!("\"{}\" in .{}", escape_str(s), field_name))
                 } else {
-                    Some(format!(".{} == \"{}\"", field_name, escape_str(s)))
+                    // Scalar: epoch-aware, matching the stored representation.
+                    Some(equality_clause(field_name, s))
                 }
             } else if let Some(i) = v.as_i64() {
                 Some(format!(".{} == {}", field_name, i))
@@ -1301,10 +1333,15 @@ fn build_range_clause(field_name: &str, criteria: &serde_json::Value) -> Option<
         }
     }
 
-    if parts.is_empty() {
-        None
-    } else {
-        Some(parts.join(" and "))
+    match parts.len() {
+        0 => None,
+        1 => parts.pop(),
+        // Parenthesise a multi-bound range. VSIM binds `and` tighter than `or`
+        // (verified live on redis 8.8), so a bare `A and B` is correct TODAY even
+        // when this clause lands inside an `or` list — but that is an implicit
+        // dependency on the server's operator precedence. The parentheses make the
+        // grouping explicit and cost nothing.
+        _ => Some(format!("({})", parts.join(" and "))),
     }
 }
 
@@ -1312,32 +1349,53 @@ fn build_range_clause(field_name: &str, criteria: &serde_json::Value) -> Option<
 ///
 /// VSIM `FILTER` comparison operators are NUMERIC — there is no date type — so an
 /// ISO-8601 / RFC-3339 bound is converted to epoch seconds, the same
-/// representation `encode_string_attr` stores for a `datetime` schema field. A
-/// numeric string is passed through as a number too (so a raw-epoch bound works).
-/// Mirrors `valkey::number_literal` / `redis::insert_number_param`, both of which
-/// route through the shared `parsers::datetime_to_epoch_secs`.
+/// representation `encode_string_attr` stores (see [`epoch_literal`]). A numeric
+/// string is passed through as a number too (so a raw-epoch bound works). Mirrors
+/// `valkey::number_literal` / `redis::insert_number_param`, both of which route
+/// through the shared `parsers::datetime_to_epoch_secs`.
 ///
 /// Without the datetime arm BOTH bounds of a `{"gte":"<iso>","lt":"<iso>"}` range
 /// were dropped, `build_range_clause` returned `None`, and VSIM ran with NO
 /// `FILTER` argument — a full unfiltered search scored against filtered ground
 /// truth (issue #220; 1 in 4 queries of the shipped `synthetic-filter-32`).
+///
+/// CRITICAL: the numeric-string arm emits the PARSED number, never the original
+/// string. Rust's parsers accept spellings the VSIM FILTER grammar does not, and
+/// re-emitting the raw text produced two distinct failures (both verified live on
+/// redis 8.8):
+///   * `"inf"` / `"NaN"` / `"+7"` → `ERR syntax error in FILTER expression`. A
+///     failed query is only `eprintln!`d and is then DROPPED from the recall and
+///     latency vectors, so the reported mean is quietly computed over fewer
+///     queries rather than scored 0 — a loud error that lands silently.
+///   * `".5"` → NO error and ZERO results: VSIM parses a leading `.` as a FIELD
+///     SELECTOR, so `.n >= .5` compares two fields. Wrong recall, no diagnostic.
+///
+/// Non-finite values have no VSIM literal at all and are rejected outright.
 fn number_literal(value: &serde_json::Value) -> Option<String> {
     if let Some(i) = value.as_i64() {
         Some(i.to_string())
     } else if let Some(f) = value.as_f64() {
-        Some(f.to_string())
+        finite_literal(f)
     } else if let Some(s) = value.as_str() {
-        if let Some(epoch) = datetime_to_epoch_secs(s) {
+        if let Some(epoch) = epoch_literal(s) {
             // Epoch is whole seconds — emit as an integer literal.
-            Some((epoch as i64).to_string())
-        } else if s.parse::<f64>().is_ok() {
-            Some(s.to_string())
+            Some(epoch.to_string())
+        } else if let Ok(i) = s.parse::<i64>() {
+            // Integer-first, so a 19-digit epoch/ID keeps every digit (an f64
+            // round-trip would silently round it).
+            Some(i.to_string())
         } else {
-            None
+            s.parse::<f64>().ok().and_then(finite_literal)
         }
     } else {
         None
     }
+}
+
+/// Render an `f64` as a VSIM numeric literal, rejecting the non-finite values
+/// (`inf`, `-inf`, `NaN`) that the FILTER grammar has no spelling for.
+fn finite_literal(f: f64) -> Option<String> {
+    f.is_finite().then(|| f.to_string())
 }
 
 #[cfg(test)]
@@ -1429,12 +1487,8 @@ mod vsim_parse_tests {
 
 #[cfg(test)]
 mod filter_expr_tests {
-    use super::{
-        build_filter_expression, encode_string_attr, prime_datetime_fields, VectorSetsConfig,
-    };
+    use super::{build_filter_expression, encode_string_attr};
     use serde_json::json;
-    use std::collections::HashSet;
-    use std::sync::Arc;
 
     // ── scalar match / range (grammar baseline) ──
 
@@ -1466,9 +1520,11 @@ mod filter_expr_tests {
     #[test]
     fn range_bounds_joined_with_and() {
         let cond = json!({"and": [{"age": {"range": {"gt": 1, "gte": 2, "lt": 9, "lte": 8}}}]});
+        // Parenthesised: a multi-bound range is ONE clause and must stay one when
+        // it lands inside an `or` list, without leaning on VSIM's precedence.
         assert_eq!(
             build_filter_expression(&cond),
-            Some(".age > 1 and .age >= 2 and .age < 9 and .age <= 8".to_string())
+            Some("(.age > 1 and .age >= 2 and .age < 9 and .age <= 8)".to_string())
         );
     }
 
@@ -1660,10 +1716,11 @@ mod filter_expr_tests {
 
     #[test]
     fn range_two_sided_gte_lt() {
-        // Fixed order gt, gte, lt, lte joined by ` and `.
+        // Fixed order gt, gte, lt, lte joined by ` and `, parenthesised as one
+        // clause so the grouping survives being nested inside an `or`.
         assert_eq!(
             range_expr(json!({"gte":10,"lt":20})).unwrap(),
-            ".n >= 10 and .n < 20"
+            "(.n >= 10 and .n < 20)"
         );
     }
 
@@ -1710,7 +1767,7 @@ mod filter_expr_tests {
         assert_eq!(
             range_expr(json!({"gte":"2021-04-11T00:00:00+00:00","lt":"2021-10-28T00:00:00+00:00"}))
                 .unwrap(),
-            ".n >= 1618099200 and .n < 1635379200"
+            "(.n >= 1618099200 and .n < 1635379200)"
         );
     }
 
@@ -1737,50 +1794,131 @@ mod filter_expr_tests {
             build_filter_expression(&json!({"and":[
                 {"ts":{"range":{"gte":"2021-01-01T00:00:00Z","lt":"2021-01-02T00:00:00Z"}}}
             ]})),
-            Some(".ts >= 1609459200 and .ts < 1609545600".to_string())
+            Some("(.ts >= 1609459200 and .ts < 1609545600)".to_string())
         );
     }
 
     #[test]
-    fn datetime_schema_field_is_stored_as_epoch_number() {
+    fn datetime_value_is_stored_as_epoch_number() {
         // Upload MUST store the same representation the filter compares against;
         // an ISO string attribute would never satisfy `.ts >= <epoch>`.
-        let mut config = test_config();
-        config.datetime_fields = Arc::new(HashSet::from(["ts".to_string()]));
         assert_eq!(
-            encode_string_attr(&config, "ts", "2021-01-01T00:00:00Z"),
+            encode_string_attr("2021-01-01T00:00:00Z"),
             json!(1609459200i64)
         );
-        // Non-datetime field → verbatim string.
+        // A non-datetime string → verbatim.
+        assert_eq!(encode_string_attr("red"), json!("red"));
+        // Already an epoch (not ISO) → verbatim string, as before.
+        assert_eq!(encode_string_attr("1609459200"), json!("1609459200"));
+        // Bool tokens (readers store bools as "true"/"false" strings) → verbatim,
+        // so `.flag == "true"` keeps matching.
+        assert_eq!(encode_string_attr("true"), json!("true"));
+    }
+
+    // ── review M2: the storage half and the filter half must agree WITHOUT a
+    // schema. `encode_string_attr` used to be gated on `config.datetime_fields`
+    // (primed from `dataset.config.schema`) while the filter half converted any
+    // ISO bound unconditionally. For a datetime-carrying field NOT declared
+    // `datetime` the two disagreed and recall went silently wrong: VSIM coerces a
+    // non-numeric string attribute to `0`, so a two-sided range matched NOTHING
+    // and a one-sided `lt`/`lte` matched EVERYTHING (verified live, redis 8.8 —
+    // measured 0.800 on the schema-gated build). Both halves now decide from the
+    // VALUE alone, so they agree for `keyword`, for `datetime`, and for no schema
+    // at all.
+
+    #[test]
+    fn storage_and_filter_agree_on_datetime_without_any_schema() {
+        // The exact pair the engine emits for one document + one query bound.
+        // Before the fix the left side was `"2021-04-11T00:00:00+00:00"` (a
+        // string) while the right side was already `1618099200` (a number).
         assert_eq!(
-            encode_string_attr(&config, "color", "2021-01-01T00:00:00Z"),
-            json!("2021-01-01T00:00:00Z")
+            encode_string_attr("2021-04-11T00:00:00+00:00"),
+            json!(1618099200i64)
         );
-        // Datetime-typed field holding a non-ISO value → verbatim (already epoch).
         assert_eq!(
-            encode_string_attr(&config, "ts", "1609459200"),
-            json!("1609459200")
+            range_expr(json!({"gte":"2021-04-11T00:00:00+00:00"})).unwrap(),
+            ".n >= 1618099200"
         );
     }
 
     #[test]
-    fn prime_datetime_fields_selects_only_datetime_schema_fields() {
-        let schema = json!({"ts":"datetime","price":"int","brand":"keyword"});
-        let got = prime_datetime_fields(Some(&schema));
-        assert_eq!(got, HashSet::from(["ts".to_string()]));
-        assert!(prime_datetime_fields(None).is_empty());
+    fn one_sided_datetime_bound_cannot_silently_match_everything() {
+        // The inversion that made this HIGH severity: with ISO-string storage a
+        // `lt`-only bound returned EVERY document (string coerced to 0 < epoch),
+        // exit code 0, no warning. Pinning both halves to the numeric
+        // representation is what prevents it, so assert them together.
+        assert_eq!(
+            range_expr(json!({"lt":"2021-10-28T00:00:00+00:00"})).unwrap(),
+            ".n < 1635379200"
+        );
+        let stored = encode_string_attr("2021-04-11T00:00:00+00:00");
+        assert!(
+            stored.is_number(),
+            "datetime must be stored numerically or `.n < <epoch>` matches ALL docs"
+        );
     }
 
-    fn test_config() -> VectorSetsConfig {
-        VectorSetsConfig {
-            quant: "NOQUANT".to_string(),
-            m: 16,
-            ef_construction: 200,
-            cas: true,
-            batch_size: 64,
-            parallel: 1,
-            datetime_fields: Arc::new(HashSet::new()),
+    #[test]
+    fn datetime_equality_matches_the_stored_epoch_number() {
+        // review S2: the equality builders were schema-blind and emitted a QUOTED
+        // ISO literal against epoch-number storage → zero hits, no error.
+        assert_eq!(
+            build_filter_expression(&json!({"and":[
+                {"ts":{"match":{"value":"2021-01-01T00:00:00Z"}}}
+            ]})),
+            Some(".ts == 1609459200".to_string())
+        );
+        // match_any on a scalar datetime field, same rule.
+        assert_eq!(
+            build_filter_expression(&json!({"and":[
+                {"ts":{"match":{"any":["2021-01-01T00:00:00Z","2021-01-02T00:00:00Z"]}}}
+            ]})),
+            Some("(.ts == 1609459200 or .ts == 1609545600)".to_string())
+        );
+        // `labels` is a JSON array of raw strings — never epoch-converted, so its
+        // membership test must stay a STRING test.
+        assert_eq!(
+            build_filter_expression(&json!({"and":[
+                {"labels":{"match":{"any":["2021-01-01T00:00:00Z"]}}}
+            ]})),
+            Some("\"2021-01-01T00:00:00Z\" in .labels".to_string())
+        );
+    }
+
+    // ── review M1: a numeric-string bound must be emitted as the PARSED number.
+    // Rust's `f64`/`i64` parsers accept spellings the VSIM FILTER grammar does
+    // not; re-emitting the raw string produced a hard `ERR syntax error in FILTER
+    // expression` (and a failed query is only `eprintln!`d, then DROPPED from the
+    // recall/latency vectors — so the mean is quietly taken over fewer queries),
+    // or, for `".5"`, ZERO results with no error at all because VSIM reads a
+    // leading `.` as a FIELD SELECTOR. All verified live on redis 8.8.
+
+    #[test]
+    fn non_finite_string_bounds_are_rejected_not_emitted_raw() {
+        for bad in ["inf", "-inf", "infinity", "Infinity", "NaN", "nan"] {
+            assert!(
+                range_expr(json!({ "gte": bad })).is_none(),
+                "{bad:?} has no VSIM literal and must be dropped, not emitted"
+            );
         }
+    }
+
+    #[test]
+    fn rust_only_numeric_spellings_are_normalised_to_vsim_literals() {
+        // `+7` and `.5` are valid Rust f64 syntax but NOT valid VSIM literals —
+        // `.n >= +7` is a syntax ERROR and `.n >= .5` silently compares against a
+        // field named `5`. Emit the parsed value instead.
+        assert_eq!(range_expr(json!({"gte":"+7"})).unwrap(), ".n >= 7");
+        assert_eq!(range_expr(json!({"gte":".5"})).unwrap(), ".n >= 0.5");
+        assert_eq!(range_expr(json!({"gte":"-.5"})).unwrap(), ".n >= -0.5");
+        // Forms VSIM DOES accept must not regress (both verified live).
+        assert_eq!(range_expr(json!({"gte":"1e5"})).unwrap(), ".n >= 100000");
+        assert_eq!(range_expr(json!({"gte":"0100"})).unwrap(), ".n >= 100");
+        // A 19-digit id must keep every digit (an f64 round-trip would round it).
+        assert_eq!(
+            range_expr(json!({"gte":"9007199254740993"})).unwrap(),
+            ".n >= 9007199254740993"
+        );
     }
 
     // ── issue #220 follow-on: nested boolean groups ────────────────────────
@@ -1820,6 +1958,46 @@ mod filter_expr_tests {
                 {"price":{"range":{"gte":100}}},
             ]})),
             Some("(.brand == \"apple\" or .price >= 100)".to_string())
+        );
+    }
+
+    // ── review M3: the nested-group arm must not swallow the rest of the entry.
+
+    #[test]
+    fn nested_group_entry_keeps_its_sibling_field_leaves() {
+        // The arm used to `continue` after recursing, so a mixed entry silently
+        // DROPPED `color` — an under-constrained filter, the same silent-wrong
+        // class this file is being fixed for. The group and the sibling leaf must
+        // BOTH be emitted.
+        let expr = build_filter_expression(&json!({"and":[
+            {
+                "and":[{"a":{"match":{"value":"x"}}},{"b":{"match":{"value":"y"}}}],
+                "color":{"match":{"value":"red"}},
+            }
+        ]}))
+        .expect("mixed group+leaf entry must produce a filter");
+        assert!(
+            expr.contains(".color == \"red\""),
+            "sibling leaf dropped: {expr}"
+        );
+        assert!(
+            expr.contains(".a == \"x\" and .b == \"y\""),
+            "nested group dropped: {expr}"
+        );
+    }
+
+    #[test]
+    fn field_literally_named_and_or_or_is_still_a_field_leaf() {
+        // Keying off key PRESENCE mistook a FIELD named `and`/`or` for a boolean
+        // group; `build_group` then found no array, returned None, every clause
+        // was dropped and VSIM ran UNFILTERED. Array-ness is the discriminator.
+        assert_eq!(
+            build_filter_expression(&json!({"and":[{"and":{"match":{"value":"x"}}}]})),
+            Some(".and == \"x\"".to_string())
+        );
+        assert_eq!(
+            build_filter_expression(&json!({"and":[{"or":{"range":{"gte":5}}}]})),
+            Some(".or >= 5".to_string())
         );
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -754,6 +754,25 @@ pub fn write_datetime_project(
     engine_configs_json: &str,
     dim: usize,
 ) -> FilterProject {
+    write_datetime_project_metric(dataset_name, engine_configs_json, dim, GtMetric::L2)
+}
+
+/// Cosine-ground-truth variant of [`write_datetime_project`] for engines that
+/// rank by cosine similarity (VectorSets).
+pub fn write_datetime_cosine_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+) -> FilterProject {
+    write_datetime_project_metric(dataset_name, engine_configs_json, dim, GtMetric::Cosine)
+}
+
+fn write_datetime_project_metric(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+    metric: GtMetric,
+) -> FilterProject {
     use chrono::{Duration, TimeZone, Utc};
     let base = Utc.timestamp_opt(1_609_459_200, 0).unwrap(); // 2021-01-01T00:00:00Z
     let iso_for = move |day: i64| (base + Duration::days(day)).to_rfc3339();
@@ -763,7 +782,7 @@ pub fn write_datetime_project(
         dataset_name,
         engine_configs_json,
         dim,
-        GtMetric::L2,
+        metric,
         serde_json::json!({ "ts": "datetime" }),
         move |id| serde_json::json!({ "ts": iso_for(id as i64) }),
         serde_json::json!({ "and": [ { "ts": { "range": { "gte": gte, "lt": lt } } } ] }),
@@ -894,11 +913,30 @@ pub fn write_nested_filter_project(
     engine_configs_json: &str,
     dim: usize,
 ) -> FilterProject {
+    write_nested_filter_project_metric(dataset_name, engine_configs_json, dim, GtMetric::L2)
+}
+
+/// Cosine-ground-truth variant of [`write_nested_filter_project`] for engines
+/// that rank by cosine similarity (VectorSets).
+pub fn write_nested_filter_cosine_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+) -> FilterProject {
+    write_nested_filter_project_metric(dataset_name, engine_configs_json, dim, GtMetric::Cosine)
+}
+
+fn write_nested_filter_project_metric(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+    metric: GtMetric,
+) -> FilterProject {
     write_filter_project(
         dataset_name,
         engine_configs_json,
         dim,
-        GtMetric::L2,
+        metric,
         serde_json::json!({ "color": "keyword", "size": "int" }),
         move |id| {
             serde_json::json!({

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -790,6 +790,43 @@ fn write_datetime_project_metric(
     )
 }
 
+/// Same ISO-8601 timestamps as [`write_datetime_project`], but the schema
+/// declares `ts` as **`keyword`**, not `datetime`, and the query carries a
+/// **one-sided** `lt` bound.
+///
+/// This is the fixture for the storage-vs-filter DISAGREEMENT (PR #230 review
+/// M2): an engine that decides "is this a datetime?" from the SCHEMA on the
+/// storage side but from the VALUE on the filter side stores an ISO string here
+/// while comparing against an epoch number. VectorSets coerces a non-numeric
+/// attribute to `0` in a numeric comparison, so `.ts < <epoch>` then matches
+/// EVERY document — the query runs effectively unfiltered, with exit code 0 and
+/// no warning. Only recall detects it (measured live on redis 8.8: 0.800
+/// schema-gated vs 1.000 once both halves agree).
+///
+/// The one-sided bound is deliberate: a two-sided range degrades to zero hits,
+/// which is far more likely to be noticed. This is the quiet direction.
+pub fn write_datetime_keyword_schema_cosine_project(
+    dataset_name: &str,
+    engine_configs_json: &str,
+    dim: usize,
+) -> FilterProject {
+    use chrono::{Duration, TimeZone, Utc};
+    let base = Utc.timestamp_opt(1_609_459_200, 0).unwrap(); // 2021-01-01T00:00:00Z
+    let iso_for = move |day: i64| (base + Duration::days(day)).to_rfc3339();
+    let lt = iso_for(200);
+    write_filter_project(
+        dataset_name,
+        engine_configs_json,
+        dim,
+        GtMetric::Cosine,
+        // NOT "datetime" — the whole point of the fixture.
+        serde_json::json!({ "ts": "keyword" }),
+        move |id| serde_json::json!({ "ts": iso_for(id as i64) }),
+        serde_json::json!({ "and": [ { "ts": { "range": { "lt": lt } } } ] }),
+        |id| id < 200,
+    )
+}
+
 /// Great-circle distance in metres (haversine, R=6_371_000 m). Used to
 /// brute-force geo-radius ground truth. The ~55 m margin baked into
 /// [`write_geo_project`] keeps every doc clearly inside or outside the radius

--- a/tests/integration_vectorsets.rs
+++ b/tests/integration_vectorsets.rs
@@ -267,6 +267,56 @@ fn test_binary_vectorsets_nested_filter() {
     );
 }
 
+/// End-to-end DATETIME range filter whose schema declares `ts` as **`keyword`**,
+/// with a **one-sided** `lt` bound (PR #230 review M2).
+///
+/// This is the regression test for the storage/filter DISAGREEMENT, a second
+/// silent-wrong route into issue #220's failure class. The first fix for #220
+/// decided "is this field a datetime?" from `dataset.config.schema` on the
+/// STORAGE side but from the VALUE on the FILTER side. Whenever the schema does
+/// not say `datetime` the two disagree: upload writes the ISO string, the filter
+/// compares against an epoch number, and VSIM coerces the non-numeric attribute
+/// to `0` — so `.ts < <epoch>` matches EVERY document and the query is
+/// effectively UNFILTERED. Exit code 0, no error, no warning; recall is the only
+/// detector (measured live on redis:8.8.0: 0.800 schema-gated vs 1.000 once both
+/// halves derive the representation from the value alone).
+///
+/// The one-sided bound is the point. A two-sided range collapses to zero hits,
+/// which is loud; `lt`/`lte` alone silently returns the whole corpus.
+#[test]
+fn test_binary_vectorsets_datetime_keyword_schema() {
+    wait_for_vectorsets();
+
+    let name = "vectorsets-dt-kw";
+    let proj = common::write_datetime_keyword_schema_cosine_project(
+        "vs-dt-kw",
+        &vectorsets_config(name),
+        8,
+    );
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = test_port().to_string();
+    assert!(
+        common::run_binary(
+            &proj.root,
+            name,
+            "vs-dt-kw",
+            TEST_HOST,
+            &[("REDIS_PORT", port.as_str())],
+        ),
+        "vectorsets keyword-schema datetime run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, name);
+    println!("vectorsets keyword-schema datetime recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "vectorsets keyword-schema datetime recall {:.3} < 0.9 \
+         (storage stored ISO strings while the filter compared epochs → `.ts < N` matched everything?)",
+        recall
+    );
+}
+
 /// End-to-end MIXED harness (`--update-search-ratio`) at `parallel: 4`: drives
 /// the VectorSets mixed path (VSIM search + VADD update) with a real multi-worker
 /// join-merge of the thread-local sample buffers. Cosine ground truth (VectorSets

--- a/tests/integration_vectorsets.rs
+++ b/tests/integration_vectorsets.rs
@@ -187,6 +187,86 @@ fn test_binary_vectorsets_bool_filter() {
     );
 }
 
+/// End-to-end DATETIME range filter: `ts IN [day 100, day 300)` over ISO-8601
+/// bounds (issue #220). This is the regression test for a LIVE WRONG NUMBER: the
+/// range builder rejected every non-numeric bound, so both ISO bounds were
+/// dropped, the clause became `None`, and VSIM ran with **no FILTER argument** —
+/// a full UNFILTERED search scored against datetime-filtered ground truth. That
+/// failure returns plenty of results and no error, so this asserts RECALL (a
+/// "query succeeded" assertion would have passed against the bug — measured on a
+/// live redis:8.8.0: recall 0.520 unfiltered vs 1.000 fixed).
+///
+/// It pins BOTH halves of the fix, which must agree on the stored representation:
+/// upload writes the `datetime`-typed attribute as epoch seconds, and the filter
+/// emits epoch-second bounds. Reverting either half turns this test red.
+#[test]
+fn test_binary_vectorsets_datetime() {
+    wait_for_vectorsets();
+
+    let name = "vectorsets-dt";
+    let proj = common::write_datetime_cosine_project("vs-dt", &vectorsets_config(name), 8);
+    assert!(
+        proj.matching_docs >= proj.top,
+        "fixture must have >= top matching docs (got {})",
+        proj.matching_docs
+    );
+
+    let port = test_port().to_string();
+    assert!(
+        common::run_binary(
+            &proj.root,
+            name,
+            "vs-dt",
+            TEST_HOST,
+            &[("REDIS_PORT", port.as_str())],
+        ),
+        "vectorsets datetime run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, name);
+    println!("vectorsets datetime range recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "vectorsets datetime range recall {:.3} < 0.9 (ISO bounds dropped → unfiltered VSIM?)",
+        recall
+    );
+}
+
+/// End-to-end NESTED boolean group: `(color == red AND size >= 50) OR
+/// (color == blue AND size < 10)`. `build_clauses` had no `and`/`or` recursion
+/// branch, so each `{"and":[…]}` entry matched no field leaf, every clause was
+/// dropped and — exactly as with the datetime bug — VSIM ran UNFILTERED. Recall
+/// is the only detector: the unfiltered nearest neighbours differ from the
+/// ~120-doc nested set (measured live: 0.260 broken vs 1.000 fixed).
+#[test]
+fn test_binary_vectorsets_nested_filter() {
+    wait_for_vectorsets();
+
+    let name = "vectorsets-nested";
+    let proj = common::write_nested_filter_cosine_project("vs-nested", &vectorsets_config(name), 8);
+    assert!(proj.matching_docs >= proj.top);
+
+    let port = test_port().to_string();
+    assert!(
+        common::run_binary(
+            &proj.root,
+            name,
+            "vs-nested",
+            TEST_HOST,
+            &[("REDIS_PORT", port.as_str())],
+        ),
+        "vectorsets nested filter run failed"
+    );
+
+    let recall = common::read_recall(&proj.root, name);
+    println!("vectorsets nested filter recall={:.3}", recall);
+    assert!(
+        recall >= 0.9,
+        "vectorsets nested filter recall {:.3} < 0.9 (nested group dropped → unfiltered VSIM?)",
+        recall
+    );
+}
+
 /// End-to-end MIXED harness (`--update-search-ratio`) at `parallel: 4`: drives
 /// the VectorSets mixed path (VSIM search + VADD update) with a real multi-worker
 /// join-merge of the thread-local sample buffers. Cosine ground truth (VectorSets


### PR DESCRIPTION
## Measured before → after (live `redis:8.8.0`, VectorSets)

| what | before | after |
|---|---|---|
| datetime range filter, new integration test (cosine GT, 400 docs / 10 queries) | **recall 0.520** | **recall 1.000** |
| nested boolean group, new integration test (same fixture shape) | **recall 0.260** | **recall 1.000** |
| datetime range whose schema says `keyword`, one-sided `lt` bound (new, review M2) | **recall 0.530** | **recall 1.000** |
| shipped `synthetic-filter-32`, end-to-end benchmark run (12 queries, 3 of them datetime) | **mean recall 0.6833** | **mean recall 0.7750** |

`synthetic-filter-32` does not reach 1.000 either way because it declares `"distance": "l2"` while VectorSets ranks by cosine intrinsically (VADD/VSIM take no metric arg) — that caps recall for *every* query type on that dataset and is unrelated to this bug. That metric mismatch is exactly why the VectorSets integration tests use cosine ground-truth fixtures, where the datetime filter now measures a clean 1.000.

Closes #220

## The bug

`src/bin/vector_db_benchmark/engine/vectorsets.rs` `build_range_clause` guarded every bound with `.filter(|v| v.is_number())`, and VectorSets had no datetime handling at all (`grep -c datetime …` → 0), unlike redis (`redis.rs:1476`), valkey, milvus, chroma and pgvector.

`generate_dataset.rs` emits `{"ts":{"range":{"gte":"<rfc3339>","lt":"<rfc3339>"}}}` for **1 in every 4** queries of the shipped `synthetic-filter-32`. Both bounds were rejected as non-numeric → `parts.is_empty()` → `None` → `if let Some(filter_expr) = filter` in `vsim_search` **has no else** → VSIM ran with **no `FILTER` argument**: a full unfiltered search, scored against datetime-filtered ground truth. Silent — no error, plenty of results, wrong number.

## The fix

VSIM `FILTER` has no date type and its comparison operators are NUMERIC, so a datetime has to live as an **epoch-seconds number**. Both halves of the engine now route through **one** predicate, `epoch_literal`, so they can never disagree:

- **Storage side** (`encode_string_attr` ← `metadata_to_attr_json`) — an ISO-8601/RFC-3339 metadata value is written as an epoch number on `VADD … SETATTR` (same choice as milvus/chroma). Previously upload stored the ISO **string**, so filtering numerically would have matched nothing.
- **Filter side** (`number_literal`, `build_match_clause`, `build_match_any_clause`) — an ISO bound/value becomes the same epoch number. Reuses the shared `parsers::datetime_to_epoch_secs` rather than adding a second copy. Null and unparseable bounds are still skipped, so the existing `.n > 0` regression guard stays green.
- The decision is made from the **value**, not the schema — see review item M2 below for why that matters.
- The metadata→SETATTR JSON block was duplicated verbatim in `vadd_batch` and `vadd_single`; it is folded into one `metadata_to_attr_json` so the mixed-workload **update** path stores epochs too rather than silently drifting from the upload path.

## Nested groups — yes, fixed here too

The issue asked whether the same file's nested-group hole was addressed: **it was.** `build_clauses` had no `and`/`or` recursion branch (unlike chroma/milvus/mongodb/pgvector/qdrant/elasticsearch), so an entry like `{"and":[…]}` inside a top-level `or` matched no field leaf, every clause was dropped, and the query ran **UNFILTERED — the same silent-wrong failure mode**. `build_group` is now recursive (mirroring `redis::build_group`/`build_subfilters`) and each nested group is emitted as one parenthesised clause.

This also corrects a claim in #221 ("Turbopuffer is the **only** engine without nested recursion"): VectorSets lacked it too. The VectorSets half is done here; #221's three Turbopuffer items are untouched and stay open.

The flat top-level emission is byte-identical to before, pinned by `flat_condition_string_is_unchanged_by_the_nesting_support`. Scope is confined to `vectorsets.rs`; no other engine and no shared builder behaviour is touched.

## Post-review revision

Seven adversarial reviewers ran this live. The core fix was reproduced independently (`redis-cli MONITOR` showed 33 VSIM commands with **zero** `FILTER` arguments pre-fix) and is unchanged. Six findings are addressed on top:

- **M1 — `number_literal` re-emitted the raw bound string.** It gated on `s.parse::<f64>().is_ok()` and then emitted `s`. Rust accepts spellings VSIM does not, splitting two ways on a live 8.8: `"inf"`/`"NaN"`/`"+7"` → `ERR syntax error in FILTER expression`, and `".5"` → **zero results, no error** (VSIM reads a leading `.` as a field selector). The syntax error is not loud either: a failed query is only `eprintln!`d and is then dropped from the recall/latency vectors, so the mean is quietly computed over fewer queries instead of being scored 0. Fixed by emitting the **parsed** number (i64 first, so a 19-digit id keeps every digit) and rejecting non-finite values. `"1e5"` and `"0100"`, which VSIM does accept, are pinned by test.
- **M2 — the two halves disagreed whenever the schema did not say `datetime`.** `encode_string_attr` was gated on `config.datetime_fields` (primed from `dataset.config.schema`) while the filter half converted any ISO-looking bound unconditionally. For a datetime-carrying field declared `keyword`, or with no schema at all, upload stored the ISO string and the filter compared against an epoch — and VSIM coerces a non-numeric attribute to `0`, so a two-sided range matched **nothing** and a one-sided `lt`/`lte` matched **everything**. A reviewer measured 0.800 on their fixture; the fixture added here measures **0.530** with the storage half reverted, and the two-sided `test_binary_vectorsets_datetime` collapses to **0.000**. Rewriting an uploaded corpus back to ISO and re-running `--skip-upload` moved `synthetic-filter-32` from 0.775 to **0.600** — exit code 0, no warning. The schema gate is gone: `epoch_literal` decides from the value, so the halves agree by construction with or without a schema. `datetime_fields` / `prime_datetime_fields` are deleted along with it.
- **M3 — the new nested branch dropped sibling leaves and mis-read a field named `and`/`or`.** It keyed off `contains_key` and then `continue`d, so `{"and":[…], "color":{…}}` silently dropped `color` (which pre-PR *was* emitted), and a field literally named `and`/`or` produced no clause at all → UNFILTERED. Both were new instances of the exact class this PR fixes. It now requires the value to be an **array** and falls through to the field-leaf loop.
- **S1 — the `datetime_fields` re-prime in `search()` was dead code** (`search()` issues no VADD; the query side is schema-independent). Removed — and with M2 the whole schema-priming mechanism is gone, so `configure()`/`search_mixed()` lose it too.
- **S2 — `match`/`match_any` on a datetime field matched zero documents.** The equality builders were schema-blind and emitted a quoted ISO literal against epoch-number storage. Fixed rather than documented: the shared `equality_clause` uses the same `epoch_literal` decision, so equality is numeric exactly when storage is. (`labels` stays a string membership test — it is stored as a raw JSON array and is never epoch-converted.) `redis.rs:1345-1347` has the analogous hole; out of scope here.
- **S3 — multi-bound ranges are now parenthesised.** VSIM binds `and` tighter than `or` (verified live), so the bare `A and B` was correct today; the parens remove the implicit dependency on the server grammar.

## Still open in this file — the class is NOT closed

This PR fixes the datetime and nested-group instances. Two more remain live in `vectorsets.rs`, both flagged in `build_clause`:

- **#223** — `"geo"` has no arm, so the leaf is dropped and the query runs unfiltered. This is live on the shipped `random-geo-radius-{100,2048}-angular-filters`, where **every** query is scored against geo-filtered ground truth.
- **#219** — the generic root cause: nothing distinguishes "no filter" from "filter that parsed to nothing", so a dropped clause becomes an unfiltered search instead of a loud failure.

## Tests

`tests/integration_vectorsets.rs` gains `test_binary_vectorsets_datetime`, `test_binary_vectorsets_nested_filter` and `test_binary_vectorsets_datetime_keyword_schema` (review M2 — `{"ts":"keyword"}` schema with a **one-sided** `lt` bound, the quiet direction where the filter returns the whole corpus rather than nothing). All assert **recall**, not merely that a query returns something — a "no error" assertion would have passed against every one of these bugs, which is precisely why they were never caught.

`tests/common/mod.rs` gains cosine-ground-truth variants of the datetime and nested fixtures plus `write_datetime_keyword_schema_cosine_project`; the L2 entry points other engines use are unchanged.

Unit tests cover the ISO→epoch bound coercion on both halves, the schema-free agreement (M2), non-finite and Rust-only numeric spellings (M1, including the silent `".5"`), datetime equality and `match_any`, the sibling-leaf and `and`-named-field nested cases (M3), and the parenthesised multi-bound range.

## Docs

README gains a VectorSets section: a corpus written by a **pre-#230** binary stores datetimes as ISO strings and must be re-uploaded — `--skip-upload` against it silently yields the wrong documents. Redis/Valkey hard-error on the analogous break (`redis_utils::ensure_index_exists`); VectorSets uses a single hardcoded key (`idx`), so there is not even a name change to detect.

## Checks

- `cargo test --lib --bins` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `VECTORSETS_PORT=<port> cargo test --test integration_vectorsets -- --test-threads=1` — 7 passed live against `redis:8.8.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
