### PR TITLE
fix(milvus): create a scalar index on every payload column — prior filtered Milvus numbers understated the engine (#218)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -19,6 +19,138 @@ use vector_db_benchmark::readers::metadata::{is_multivalued_keyword_field, Metad
 
 const DEFAULT_COLLECTION: &str = "Benchmark";
 
+/// How one dataset schema field is materialised in Milvus: the column's
+/// `dataType`, and the SCALAR INDEX type that column must get.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MilvusFieldKind {
+    data_type: &'static str,
+    /// Milvus `indexType` for the scalar index on this column.
+    index_type: &'static str,
+}
+
+/// Map a dataset schema field to its Milvus column type AND its scalar index
+/// type, or `None` if the field is not materialised as a column at all.
+///
+/// This is the single source of truth shared by `create_collection` (which
+/// builds the columns) and `scalar_index_plan` (which indexes them). Keeping
+/// one mapping is the point: issue #218 was exactly a column that existed with
+/// no index, so every filtered query degenerated into a brute-force scalar scan
+/// behind the ANN search, and no recall check could ever notice (an unindexed
+/// scan returns the SAME rows — only slower).
+///
+/// ## Why these index types (verified live against `milvusdb/milvus:v2.6.19`,
+/// the image pinned in `tests/docker-compose.test.yml`)
+///
+/// Milvus 2.6 offers INVERTED, BITMAP, STL_SORT, Trie and NGRAM for scalar
+/// fields. Probing every (column type × index type) pair against v2.6.19 gives:
+///
+/// | column          | INVERTED | BITMAP | STL_SORT | Trie |
+/// |-----------------|----------|--------|----------|------|
+/// | VarChar         | ok       | ok     | ok       | ok   |
+/// | Int64           | ok       | ok     | ok       | ✗    |
+/// | Double          | ok       | ✗      | ok       | ✗    |
+/// | Bool            | ok       | ok     | ✗        | ✗    |
+/// | Array(VarChar)  | ok       | ok     | ✗        | ✗    |
+///
+/// (✗ = server rejects with error 1100: BITMAP is "only supported on bool, int,
+/// string and array field"; STL_SORT "only on numeric, varchar or timestamptz";
+/// Trie "only supported on varchar field".)
+///
+/// * **INVERTED for VarChar / Int64 / Double / Array** — it is the only type
+///   accepted on all four, it serves BOTH predicate shapes this benchmark emits
+///   (point: `==`, `in [...]`, `array_contains*`, `TEXT_MATCH`; and range:
+///   `<`/`>=` over `int`, `float` and the Int64-epoch `datetime` column), and
+///   it makes no cardinality assumption. That last point matters: our keyword
+///   fields span 2 distinct values (`random-100-match-kw-small-vocab-filters`)
+///   to tens of thousands (`prod_name` in `h-and-m-2048-angular-filters`).
+///   INVERTED is also precisely what Milvus's own AUTOINDEX selects for
+///   VARCHAR/INT*/FLOAT/DOUBLE, so we are not hand-tuning the engine past its
+///   own default — we are giving it the default it should always have had.
+/// * **BITMAP for Bool** — a boolean column has exactly 2 distinct values, the
+///   canonical BITMAP case, and it is under BITMAP's documented ~500-cardinality
+///   ceiling for every dataset by construction. STL_SORT is rejected on Bool.
+/// * **Not STL_SORT** for the numerics: it is a sorted-array structure aimed at
+///   ranges only, and it cannot cover the Array/Bool columns, so it would mean
+///   two structures where INVERTED covers both shapes — and it is not what
+///   AUTOINDEX picks.
+/// * **Not Trie**: VARCHAR-only and prefix-only. This benchmark never emits a
+///   prefix predicate (`like "abc%"`), so Trie would not serve `==` / `in`.
+/// * **Not a bare `create_index` with no `indexType`** (upstream's approach,
+///   i.e. AUTOINDEX): the REST `indexes/describe` reply then reports
+///   `indexType: ""`, which makes the read-back assertion in
+///   `tests/integration_milvus.rs` unable to prove WHICH index exists. Naming
+///   the type keeps the choice auditable from the server's own reply.
+///
+/// `geo` deliberately returns `None`: `milvus.rs` does not materialise a geo
+/// column and drops geo predicates (issue #223, out of scope here). Routing
+/// both the column pass and the index pass through this one function is what
+/// guarantees we never index a column that does not exist, or leave one that
+/// does unindexed.
+fn milvus_field_kind(field_name: &str, schema_type: &str) -> Option<MilvusFieldKind> {
+    // A multi-valued keyword field (`labels`) is an Array of VarChar (#88).
+    if (schema_type == "keyword" || schema_type == "text")
+        && is_multivalued_keyword_field(field_name)
+    {
+        return Some(MilvusFieldKind {
+            data_type: "Array",
+            index_type: "INVERTED",
+        });
+    }
+    let (data_type, index_type) = match schema_type {
+        "int" => ("Int64", "INVERTED"),
+        // A `uuid` is an exact-match opaque string → a plain VarChar (no
+        // analyzer), same as keyword.
+        "keyword" | "text" | "uuid" => ("VarChar", "INVERTED"),
+        "float" => ("Double", "INVERTED"),
+        // Milvus has a native Bool type; 2 distinct values → BITMAP.
+        "bool" => ("Bool", "BITMAP"),
+        // No native date type, so datetimes are stored as Int64 epoch seconds
+        // (upload + the range filter both convert via datetime_to_epoch_secs)
+        // and take the same INVERTED range index as `int`.
+        "datetime" => ("Int64", "INVERTED"),
+        _ => return None,
+    };
+    Some(MilvusFieldKind {
+        data_type,
+        index_type,
+    })
+}
+
+/// Every `(column, scalar index type)` pair that must exist for this dataset —
+/// i.e. every schema field `create_collection` materialised as a column. `id`
+/// (the primary key) and `vector` are excluded: the PK is indexed implicitly and
+/// `vector` gets the ANN index. Mirrors upstream
+/// `engine/clients/milvus/upload.py`, which loops every non-`id`/`vector` field
+/// of the collection schema and calls `create_index` on it.
+fn scalar_index_plan(dataset: &Dataset) -> Vec<(String, &'static str)> {
+    let mut plan = Vec::new();
+    if let Some(obj) = dataset.config.schema.as_ref().and_then(|s| s.as_object()) {
+        for (field_name, field_type) in obj {
+            if field_name == "id" || field_name == "vector" {
+                continue;
+            }
+            if let Some(kind) = milvus_field_kind(field_name, field_type.as_str().unwrap_or("")) {
+                plan.push((field_name.clone(), kind.index_type));
+            }
+        }
+    }
+    plan
+}
+
+/// True when a failed `indexes/create` response means "this field already has an
+/// index", which is not an error for us — mirrors upstream tolerating pymilvus
+/// error code 1 ("index already exist"). v2.6.19 returns code 0 for an identical
+/// re-create, and 1100 with one of these messages when an index of a DIFFERENT
+/// type/name already covers the field. Either way the column IS indexed, so the
+/// property we care about holds. Anything else must surface as a hard error
+/// rather than silently leaving a column unindexed.
+fn is_already_indexed_error(message: &str) -> bool {
+    let m = message.to_lowercase();
+    m.contains("already exist")
+        || m.contains("at most one distinct index is allowed per field")
+        || m.contains("creating multiple indexes on same field is not supported")
+}
+
 pub struct MilvusEngine {
     name: String,
     collection_name: String,
@@ -179,13 +311,18 @@ impl MilvusEngine {
             if let Some(schema_obj) = schema.as_object() {
                 for (field_name, field_type) in schema_obj {
                     let ft = field_type.as_str().unwrap_or("");
+                    // Single source of truth for "does this schema field become a
+                    // column, and of what Milvus type" — shared with the scalar
+                    // index pass so the two can never disagree (a column with no
+                    // index means a brute-force scan; see issue #218).
+                    let Some(kind) = milvus_field_kind(field_name, ft) else {
+                        continue;
+                    };
                     // A multi-valued keyword field (`labels`) is declared as an
                     // Array of VarChar so `array_contains_any` can match a single
                     // element; a scalar VarChar could only test whole-string
                     // equality against the joined value (issue #88).
-                    let field = if (ft == "keyword" || ft == "text")
-                        && is_multivalued_keyword_field(field_name)
-                    {
+                    let field = if kind.data_type == "Array" {
                         serde_json::json!({
                             "fieldName": field_name,
                             "dataType": "Array",
@@ -193,21 +330,7 @@ impl MilvusEngine {
                             "elementTypeParams": {"max_length": "500", "max_capacity": "128"},
                         })
                     } else {
-                        let milvus_type = match ft {
-                            "int" => "Int64",
-                            // A `uuid` is an exact-match opaque string → a plain
-                            // VarChar (no analyzer), same as keyword. Without this
-                            // arm it hit `_ => continue`, so no field was created
-                            // and every uuid filter silently broke.
-                            "keyword" | "text" | "uuid" => "VarChar",
-                            "float" => "Double",
-                            // Milvus has a native Bool type. No native date type, so
-                            // datetimes are stored as Int64 epoch seconds (upload +
-                            // filter both convert via datetime_to_epoch_secs).
-                            "bool" => "Bool",
-                            "datetime" => "Int64",
-                            _ => continue,
-                        };
+                        let milvus_type = kind.data_type;
                         let mut field = serde_json::json!({
                             "fieldName": field_name,
                             "dataType": milvus_type,
@@ -270,7 +393,11 @@ impl MilvusEngine {
         Ok(())
     }
 
-    fn create_index(&self, client: &reqwest::blocking::Client) -> Result<(), String> {
+    fn create_index(
+        &self,
+        client: &reqwest::blocking::Client,
+        dataset: &Dataset,
+    ) -> Result<(), String> {
         let body = serde_json::json!({
             "collectionName": self.collection_name,
             "indexParams": [{
@@ -301,6 +428,86 @@ impl MilvusEngine {
             ));
         }
 
+        self.create_scalar_indexes(client, dataset)
+    }
+
+    /// Create a scalar (payload) index on EVERY column built from the dataset
+    /// schema. Without this, Milvus has nothing to look up the filter with and
+    /// resolves every filtered query by scanning the scalar column behind the
+    /// ANN search — the same rows, just far slower, which is why recall-based
+    /// tests never caught it (issue #218).
+    ///
+    /// One request per field (rather than one batched request) so that an
+    /// "already indexed" field is tolerated individually instead of failing the
+    /// whole batch — the same granularity as upstream's per-field loop.
+    fn create_scalar_indexes(
+        &self,
+        client: &reqwest::blocking::Client,
+        dataset: &Dataset,
+    ) -> Result<(), String> {
+        let plan = scalar_index_plan(dataset);
+        if plan.is_empty() {
+            return Ok(());
+        }
+
+        let url = format!("{}/v2/vectordb/indexes/create", self.base_url);
+        let mut created = Vec::with_capacity(plan.len());
+        for (field_name, index_type) in &plan {
+            let body = serde_json::json!({
+                "collectionName": self.collection_name,
+                "indexParams": [{
+                    "fieldName": field_name,
+                    "indexName": format!("{}_index", field_name),
+                    "indexType": index_type,
+                }]
+            });
+            let resp = client
+                .post(&url)
+                .header("Content-Type", "application/json")
+                .json(&body)
+                .send()
+                .map_err(|e| format!("Failed to create scalar index on {}: {}", field_name, e))?;
+
+            if !resp.status().is_success() {
+                return Err(format!(
+                    "Failed to create scalar index on {}: {} {}",
+                    field_name,
+                    resp.status(),
+                    resp.text().unwrap_or_default()
+                ));
+            }
+
+            // The REST layer answers 200 with an application-level `code`, so the
+            // HTTP status alone proves nothing — an unchecked `code != 0` here is
+            // precisely how a missing index stays invisible.
+            let resp_body: serde_json::Value = resp.json().unwrap_or_default();
+            let code = resp_body.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
+            if code != 0 {
+                let msg = resp_body
+                    .get("message")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("unknown error");
+                if is_already_indexed_error(msg) {
+                    println!(
+                        "  scalar index on '{}' already exists, skipping",
+                        field_name
+                    );
+                    continue;
+                }
+                return Err(format!(
+                    "Failed to create scalar index on {}: {}",
+                    field_name, msg
+                ));
+            }
+            created.push(format!("{}({})", field_name, index_type));
+        }
+
+        println!(
+            "Created {}/{} scalar index(es): {}",
+            created.len(),
+            plan.len(),
+            created.join(", ")
+        );
         Ok(())
     }
 
@@ -937,7 +1144,7 @@ impl Engine for MilvusEngine {
             self.index_type, self.index_m, self.index_ef_construction, self.metric_type
         );
         let index_start = Instant::now();
-        self.create_index(&client)?;
+        self.create_index(&client, dataset)?;
 
         // Load collection into memory
         self.load_collection(&client)?;
@@ -1408,6 +1615,124 @@ mod tests {
             build_milvus_filter("flag", "match", &json!({"value":true})).unwrap(),
             "flag == true"
         );
+    }
+
+    // ── #218: scalar (payload) index coverage ──────────────────────────────
+    //
+    // Before the fix, `create_index` posted a single `indexParams` entry for
+    // `vector` and nothing else, so every filtered query was resolved by a
+    // brute-force scan of the unindexed scalar column. No recall assertion can
+    // see that (an unindexed scan returns the SAME rows), so these tests pin
+    // the structural property instead.
+
+    fn dataset_with_schema(schema: serde_json::Value) -> Dataset {
+        Dataset::new(crate::config::DatasetConfig {
+            name: "t".into(),
+            dataset_type: Some("tar".into()),
+            path: json!("t/"),
+            distance: Some("l2".into()),
+            vector_size: Some(8),
+            vector_count: Some(1),
+            link: None,
+            schema: Some(schema),
+            description: None,
+        })
+    }
+
+    /// THE invariant behind #218: a schema field that becomes a COLUMN must
+    /// also get an INDEX. Both passes read `milvus_field_kind`, so this asserts
+    /// the two can never diverge again for any schema type we support.
+    #[test]
+    fn every_materialised_column_is_also_indexed() {
+        let schema = json!({
+            "kw": "keyword", "txt": "text", "uid": "uuid", "n": "int",
+            "f": "float", "flag": "bool", "ts": "datetime", "labels": "keyword",
+            "loc": "geo", "weird": "not-a-type",
+        });
+        let plan = scalar_index_plan(&dataset_with_schema(schema.clone()));
+        let indexed: std::collections::BTreeSet<&str> =
+            plan.iter().map(|(f, _)| f.as_str()).collect();
+
+        for (field, ty) in schema.as_object().unwrap() {
+            let has_column = milvus_field_kind(field, ty.as_str().unwrap()).is_some();
+            assert_eq!(
+                has_column,
+                indexed.contains(field.as_str()),
+                "field '{}' ({}) has column={} but indexed={} — a column without an \
+                 index makes every filter on it a full scan (#218)",
+                field,
+                ty,
+                has_column,
+                indexed.contains(field.as_str())
+            );
+        }
+        // `geo` is not materialised at all (issue #223), so it must be in
+        // neither set — not indexed, and not silently indexed either.
+        assert!(!indexed.contains("loc"));
+        assert!(!indexed.contains("weird"));
+    }
+
+    /// The per-type index choice, verified live against milvusdb/milvus:v2.6.19
+    /// (see `milvus_field_kind`'s doc comment for the full acceptance matrix).
+    #[test]
+    fn scalar_index_types_per_field_type() {
+        let expect = |field: &str, ty: &str| milvus_field_kind(field, ty).unwrap();
+        // Point + range predicates over one structure; also what AUTOINDEX picks.
+        assert_eq!(expect("kw", "keyword").index_type, "INVERTED");
+        assert_eq!(expect("b", "text").index_type, "INVERTED");
+        assert_eq!(expect("u", "uuid").index_type, "INVERTED");
+        assert_eq!(expect("n", "int").index_type, "INVERTED");
+        assert_eq!(expect("f", "float").index_type, "INVERTED");
+        // datetime is an Int64 epoch column, filtered by range → same as int.
+        assert_eq!(expect("ts", "datetime").index_type, "INVERTED");
+        assert_eq!(expect("ts", "datetime").data_type, "Int64");
+        // Bool has exactly 2 distinct values → BITMAP (STL_SORT is rejected on
+        // Bool by the server).
+        assert_eq!(expect("flag", "bool").index_type, "BITMAP");
+        assert_eq!(expect("flag", "bool").data_type, "Bool");
+        // Multi-valued `labels` is an Array(VarChar) (#88); only INVERTED and
+        // BITMAP are accepted there, and cardinality is unbounded → INVERTED.
+        assert_eq!(expect("labels", "keyword").data_type, "Array");
+        assert_eq!(expect("labels", "keyword").index_type, "INVERTED");
+        // A scalar keyword named anything else stays a VarChar.
+        assert_eq!(expect("color", "keyword").data_type, "VarChar");
+        // Not materialised → no column, no index.
+        assert!(milvus_field_kind("loc", "geo").is_none());
+    }
+
+    /// `id`/`vector` are excluded (PK is implicitly indexed, `vector` gets the
+    /// ANN index) — mirrors upstream's `field.name not in ("id", "vector")`.
+    #[test]
+    fn scalar_index_plan_skips_id_and_vector() {
+        let plan = scalar_index_plan(&dataset_with_schema(
+            json!({"id": "int", "vector": "int", "a": "keyword"}),
+        ));
+        assert_eq!(plan, vec![("a".to_string(), "INVERTED")]);
+    }
+
+    #[test]
+    fn scalar_index_plan_empty_for_unfiltered_dataset() {
+        assert!(scalar_index_plan(&dataset_with_schema(json!({}))).is_empty());
+    }
+
+    /// Only a genuine "the field is already indexed" reply is tolerated. Both
+    /// strings are the verbatim v2.6.19 messages for re-creating an index on a
+    /// covered field; anything else must fail loudly rather than leave a column
+    /// unindexed.
+    #[test]
+    fn already_indexed_error_detection() {
+        assert!(is_already_indexed_error(
+            "at most one distinct index is allowed per field: invalid parameter"
+        ));
+        assert!(is_already_indexed_error(
+            "CreateIndex failed: creating multiple indexes on same field is not supported: invalid parameter"
+        ));
+        assert!(is_already_indexed_error("index already exist"));
+        // Real failures must NOT be swallowed.
+        assert!(!is_already_indexed_error(
+            "bitmap index are only supported on bool, int, string and array field: invalid parameter"
+        ));
+        assert!(!is_already_indexed_error("collection not found"));
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -56,25 +56,52 @@ struct MilvusFieldKind {
 /// string and array field"; STL_SORT "only on numeric, varchar or timestamptz";
 /// Trie "only supported on varchar field".)
 ///
-/// * **INVERTED for VarChar / Int64 / Double / Array** — it is the only type
-///   accepted on all four, it serves BOTH predicate shapes this benchmark emits
+/// The choice per column is not "whatever is permitted" — it is what MEASURED
+/// fastest on this version, and it happens to coincide exactly with what Milvus
+/// picks for itself:
+///
+/// * **INVERTED for VarChar / Int64 / Double / Array** — the only type accepted
+///   on all four, and it serves BOTH predicate shapes this benchmark emits
 ///   (point: `==`, `in [...]`, `array_contains*`, `TEXT_MATCH`; and range:
-///   `<`/`>=` over `int`, `float` and the Int64-epoch `datetime` column), and
-///   it makes no cardinality assumption. That last point matters: our keyword
-///   fields span 2 distinct values (`random-100-match-kw-small-vocab-filters`)
-///   to tens of thousands (`prod_name` in `h-and-m-2048-angular-filters`).
-///   INVERTED is also precisely what Milvus's own AUTOINDEX selects for
-///   VARCHAR/INT*/FLOAT/DOUBLE, so we are not hand-tuning the engine past its
-///   own default — we are giving it the default it should always have had.
-/// * **BITMAP for Bool** — a boolean column has exactly 2 distinct values, the
-///   canonical BITMAP case, and it is under BITMAP's documented ~500-cardinality
-///   ceiling for every dataset by construction. STL_SORT is rejected on Bool.
+///   `<`/`>=` over `int`, `float` and the Int64-epoch `datetime` column).
+///   BITMAP is the only real alternative on VarChar, and it does NOT beat
+///   INVERTED even where it should be strongest: on a 10-distinct-value keyword
+///   column (`random-100-match-kw-small-vocab-filters`) the measured BITMAP /
+///   INVERTED ratio is ~0.95–1.03, i.e. a coin flip. So INVERTED leaves nothing
+///   on the table, while avoiding BITMAP's degradation on the high-cardinality
+///   end (`prod_name` in `h-and-m-2048-angular-filters` has tens of thousands of
+///   distinct values).
+/// * **BITMAP for Bool** — this arm is NECESSARY, not merely permitted.
+///   Measured on a Bool column, INVERTED is worth nothing at all: INVERTED /
+///   no-index = 0.987–1.017, indistinguishable from having no index. BITMAP
+///   delivers a 20–24% improvement. Simplifying to "INVERTED everywhere" would
+///   therefore have left `synthetic-filter-32`'s `flag` filter with no benefit
+///   whatsoever. STL_SORT is rejected on Bool by the server.
+/// * **This mapping is what Milvus's own AUTOINDEX resolves to**, measured by
+///   comparing an AUTOINDEX column against explicitly-typed ones: on VarChar
+///   `auto / INVERTED = 0.937` (AUTOINDEX behaves as INVERTED); on Bool
+///   `auto / BITMAP = 1.009` while `auto / INVERTED = 0.774` (AUTOINDEX behaves
+///   as BITMAP, definitively not INVERTED). We are therefore not hand-tuning
+///   Milvus past its own defaults — we give each column exactly the index Milvus
+///   would choose for itself, which is the fairest possible setting for a
+///   competitor in a vendor benchmark.
 /// * **Not STL_SORT** for the numerics: it is a sorted-array structure aimed at
 ///   ranges only, and it cannot cover the Array/Bool columns, so it would mean
 ///   two structures where INVERTED covers both shapes — and it is not what
 ///   AUTOINDEX picks.
 /// * **Not Trie**: VARCHAR-only and prefix-only. This benchmark never emits a
 ///   prefix predicate (`like "abc%"`), so Trie would not serve `==` / `in`.
+/// * **`text` columns get an INVERTED index on top of `enable_match`.** A
+///   `text` field is already created with `enable_analyzer` + `enable_match`
+///   (see `create_collection`), which builds Milvus's tokenised match index for
+///   `TEXT_MATCH`. The explicit INVERTED index here is therefore a SECOND
+///   structure on the same column. It is kept deliberately: `text` columns are
+///   also filtered with plain `==` / `in [...]` (nothing stops a dataset from
+///   doing so), which the match index does not serve, and skipping it would
+///   reintroduce exactly the "column with no scalar index" hole for one field
+///   type. The cost is extra index build time and memory on `text` columns
+///   only — `h-and-m-2048-angular-filters`'s `detail_desc` is the sole shipped
+///   instance.
 /// * **Not a bare `create_index` with no `indexType`** (upstream's approach,
 ///   i.e. AUTOINDEX): the REST `indexes/describe` reply then reports
 ///   `indexType: ""`, which makes the read-back assertion in
@@ -138,17 +165,77 @@ fn scalar_index_plan(dataset: &Dataset) -> Vec<(String, &'static str)> {
 }
 
 /// True when a failed `indexes/create` response means "this field already has an
-/// index", which is not an error for us — mirrors upstream tolerating pymilvus
-/// error code 1 ("index already exist"). v2.6.19 returns code 0 for an identical
-/// re-create, and 1100 with one of these messages when an index of a DIFFERENT
-/// type/name already covers the field. Either way the column IS indexed, so the
-/// property we care about holds. Anything else must surface as a hard error
-/// rather than silently leaving a column unindexed.
+/// index" — mirrors upstream tolerating pymilvus error code 1 ("index already
+/// exist"). v2.6.19 returns code 0 for a byte-identical re-create, and 1100 with
+/// one of these messages when an index already covers the field.
+///
+/// This says only "an index exists", NOT "the RIGHT index exists": the same 1100
+/// reply comes back when the existing index is of a DIFFERENT type. Callers must
+/// therefore read the existing index's type back and confirm it before treating
+/// this as success (see `create_scalar_indexes`) — otherwise a stale wrong-type
+/// index would be silently accepted, which is the same class of silent-wrong as
+/// #218 itself. Unreachable today because `configure()` drops the collection
+/// first, but a future `--skip-upload` path would hit it.
 fn is_already_indexed_error(message: &str) -> bool {
     let m = message.to_lowercase();
     m.contains("already exist")
         || m.contains("at most one distinct index is allowed per field")
         || m.contains("creating multiple indexes on same field is not supported")
+}
+
+/// One index's build progress, as reported by `indexes/describe`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IndexProgress {
+    field_name: String,
+    index_type: String,
+    state: String,
+    indexed_rows: i64,
+    pending_rows: i64,
+    total_rows: i64,
+}
+
+impl IndexProgress {
+    /// An index is only actually USABLE when it is built AND covers every row.
+    ///
+    /// `state == "Finished"` alone is worthless: before the collection is
+    /// flushed, every index on v2.6.19 reports `Finished` with
+    /// `indexedRows = totalRows = 0` — "finished indexing nothing" — and stays
+    /// that way indefinitely. Queries then fall back to brute force over the
+    /// growing segments regardless of the index. `indexedRows == totalRows`
+    /// with `totalRows > 0` is the condition that actually distinguishes a
+    /// usable index from that trap, and from a still-building one
+    /// (`indexedRows < totalRows`).
+    ///
+    /// `pendingRows` is deliberately NOT part of the test. Measured on v2.6.19:
+    /// once a 1M-row collection is fully indexed it reports
+    /// `Finished, indexedRows = totalRows = 1000000, pendingRows = 847872` —
+    /// the pending counter tracks segments queued for RE-indexing by background
+    /// compaction, which runs indefinitely and does not mean the data is
+    /// unindexed. Requiring `pendingRows == 0` therefore hangs until the
+    /// timeout on exactly the large uploads that matter most.
+    fn is_built(&self, expect_rows: bool) -> bool {
+        self.state == "Finished"
+            && self.indexed_rows == self.total_rows
+            && (!expect_rows || self.total_rows > 0)
+    }
+}
+
+fn parse_index_progress(row: &serde_json::Value) -> IndexProgress {
+    let s = |k: &str| {
+        row.get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string()
+    };
+    let n = |k: &str| row.get(k).and_then(|v| v.as_i64()).unwrap_or(0);
+    IndexProgress {
+        field_name: s("fieldName"),
+        index_type: s("indexType"),
+        state: s("indexState"),
+        indexed_rows: n("indexedRows"),
+        pending_rows: n("pendingRows"),
+        total_rows: n("totalRows"),
+    }
 }
 
 pub struct MilvusEngine {
@@ -488,11 +575,37 @@ impl MilvusEngine {
                     .and_then(|m| m.as_str())
                     .unwrap_or("unknown error");
                 if is_already_indexed_error(msg) {
-                    println!(
-                        "  scalar index on '{}' already exists, skipping",
-                        field_name
-                    );
-                    continue;
+                    // "An index exists" is NOT "the RIGHT index exists" — the
+                    // same reply comes back for an index of a different type.
+                    // Confirm the existing one from the server before accepting,
+                    // or a stale wrong-type index passes silently (#218's class).
+                    let existing = self
+                        .describe_indexes(client)?
+                        .into_iter()
+                        .find(|p| p.field_name == *field_name);
+                    match existing {
+                        Some(p) if p.index_type == *index_type => {
+                            println!(
+                                "  scalar index on '{}' already exists ({}), skipping",
+                                field_name, p.index_type
+                            );
+                            continue;
+                        }
+                        Some(p) => {
+                            return Err(format!(
+                                "Field '{}' already carries a {} index but this dataset needs \
+                                 {}; drop the collection and re-upload",
+                                field_name, p.index_type, index_type
+                            ));
+                        }
+                        None => {
+                            return Err(format!(
+                                "Milvus reported an existing index on '{}' ({}) but none is \
+                                 present in the index catalogue",
+                                field_name, msg
+                            ));
+                        }
+                    }
                 }
                 return Err(format!(
                     "Failed to create scalar index on {}: {}",
@@ -509,6 +622,157 @@ impl MilvusEngine {
             created.join(", ")
         );
         Ok(())
+    }
+
+    /// Seal the growing segments so an index can actually cover the data.
+    ///
+    /// A Milvus index only ever covers SEALED segments. Freshly inserted rows
+    /// live in growing segments, which are brute-force scanned no matter what
+    /// indexes exist. Without this call every index — the HNSW vector index
+    /// included — reports `state: "Finished"` with `indexedRows: 0,
+    /// totalRows: 0` and stays that way indefinitely, so the whole corpus is
+    /// scanned and creating the scalar indexes at all is pointless.
+    ///
+    /// Verified on v2.6.19 with this engine's exact ingest order (100k rows,
+    /// insert -> create indexes -> load): at the moment `load` reports
+    /// `LoadStateLoaded`, and still 60s later, both `vector` and the scalar
+    /// column read back as `Finished, indexedRows=0, totalRows=0`; immediately
+    /// after an explicit flush they read `indexedRows=100000,
+    /// totalRows=100000`. Upstream does the same thing — `upload.py` calls
+    /// `collection.flush()` on the line directly above its `create_index` loop.
+    fn flush_collection(&self, client: &reqwest::blocking::Client) -> Result<(), String> {
+        let body = serde_json::json!({ "collectionName": self.collection_name });
+        let url = format!("{}/v2/vectordb/collections/flush", self.base_url);
+        let resp = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .map_err(|e| format!("Failed to flush collection: {}", e))?;
+
+        if !resp.status().is_success() {
+            return Err(format!(
+                "Failed to flush collection: {} {}",
+                resp.status(),
+                resp.text().unwrap_or_default()
+            ));
+        }
+        let resp_body: serde_json::Value = resp.json().unwrap_or_default();
+        let code = resp_body.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
+        if code != 0 {
+            let msg = resp_body
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
+            return Err(format!("Failed to flush collection: {}", msg));
+        }
+        Ok(())
+    }
+
+    /// Every index on the collection, with its build progress.
+    fn describe_indexes(
+        &self,
+        client: &reqwest::blocking::Client,
+    ) -> Result<Vec<IndexProgress>, String> {
+        let list_url = format!("{}/v2/vectordb/indexes/list", self.base_url);
+        let resp = client
+            .post(&list_url)
+            .header("Content-Type", "application/json")
+            .json(&serde_json::json!({ "collectionName": self.collection_name }))
+            .send()
+            .map_err(|e| format!("Failed to list indexes: {}", e))?;
+        let body: serde_json::Value = resp.json().unwrap_or_default();
+        let names: Vec<String> = body
+            .get("data")
+            .and_then(|d| d.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let describe_url = format!("{}/v2/vectordb/indexes/describe", self.base_url);
+        let mut out = Vec::with_capacity(names.len());
+        for name in names {
+            let resp = client
+                .post(&describe_url)
+                .header("Content-Type", "application/json")
+                .json(&serde_json::json!({
+                    "collectionName": self.collection_name,
+                    "indexName": name,
+                }))
+                .send()
+                .map_err(|e| format!("Failed to describe index {}: {}", name, e))?;
+            let body: serde_json::Value = resp.json().unwrap_or_default();
+            if let Some(rows) = body.get("data").and_then(|d| d.as_array()) {
+                out.extend(rows.iter().map(parse_index_progress));
+            }
+        }
+        Ok(out)
+    }
+
+    /// Block until every index covers every row, so the search phase measures an
+    /// INDEXED collection.
+    ///
+    /// `load_collection` is not sufficient: it returns `LoadStateLoaded` while
+    /// indexes cover nothing (see `flush_collection`). Upstream waits the same
+    /// way — `wait_for_index_building_complete` on every index before `load()`.
+    /// Timing out is a hard error: silently searching a half-indexed collection
+    /// is exactly the failure mode this PR exists to remove.
+    fn wait_for_indexes_built(
+        &self,
+        client: &reqwest::blocking::Client,
+        uploaded_rows: usize,
+    ) -> Result<(), String> {
+        let expect_rows = uploaded_rows > 0;
+        let timeout_secs: u64 = std::env::var("MILVUS_INDEX_BUILD_TIMEOUT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1800);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+        let mut backoff = std::time::Duration::from_millis(500);
+        let max_backoff = std::time::Duration::from_secs(10);
+
+        loop {
+            let progress = self.describe_indexes(client)?;
+            if !progress.is_empty() && progress.iter().all(|p| p.is_built(expect_rows)) {
+                let summary: Vec<String> = progress
+                    .iter()
+                    .map(|p| {
+                        format!(
+                            "{}({}, {} rows)",
+                            p.field_name, p.index_type, p.indexed_rows
+                        )
+                    })
+                    .collect();
+                println!("All indexes built: {}", summary.join(", "));
+                return Ok(());
+            }
+            if std::time::Instant::now() > deadline {
+                let summary: Vec<String> = progress
+                    .iter()
+                    .map(|p| {
+                        format!(
+                            "{}({}, state={}, indexed={}/{}, pending={})",
+                            p.field_name,
+                            p.index_type,
+                            p.state,
+                            p.indexed_rows,
+                            p.total_rows,
+                            p.pending_rows
+                        )
+                    })
+                    .collect();
+                return Err(format!(
+                    "Timed out after {}s waiting for indexes to cover all rows: {}",
+                    timeout_secs,
+                    summary.join(", ")
+                ));
+            }
+            std::thread::sleep(backoff);
+            backoff = (backoff * 2).min(max_backoff);
+        }
     }
 
     fn load_collection(&self, client: &reqwest::blocking::Client) -> Result<(), String> {
@@ -1134,17 +1398,28 @@ impl Engine for MilvusEngine {
             vectors.len() as f64 / upload_time
         );
 
-        // Create index after upload, then load the collection into memory. Both
-        // are part of the ingest cost and are included in total_time for
-        // cross-engine comparability (mirrors mongodb; matches v0's post_upload()
-        // timing).
+        // Flush -> create indexes -> wait for them to cover every row -> load.
+        // This whole block is part of the ingest cost and is included in
+        // total_time for cross-engine comparability (mirrors mongodb; matches
+        // v0's post_upload() timing), and it mirrors upstream's post_upload
+        // order exactly (flush, create_index, wait_for_index_building_complete,
+        // load). Every step is load-bearing: without the flush the indexes cover
+        // zero rows, and without the wait the search phase starts against a
+        // collection Milvus reports as "loaded" while it is still brute-forcing.
         let client = self.create_client()?;
+        let index_start = Instant::now();
+
+        println!("Flushing collection (seal growing segments so indexes cover them)...");
+        self.flush_collection(&client)?;
+
         println!(
             "Creating {} index (M={}, efConstruction={}, metric={})...",
             self.index_type, self.index_m, self.index_ef_construction, self.metric_type
         );
-        let index_start = Instant::now();
         self.create_index(&client, dataset)?;
+
+        println!("Waiting for all indexes to cover every row...");
+        self.wait_for_indexes_built(&client, vectors.len())?;
 
         // Load collection into memory
         self.load_collection(&client)?;
@@ -1713,6 +1988,53 @@ mod tests {
     #[test]
     fn scalar_index_plan_empty_for_unfiltered_dataset() {
         assert!(scalar_index_plan(&dataset_with_schema(json!({}))).is_empty());
+    }
+
+    /// The zero-row trap that made the #218 fix inert until the flush landed:
+    /// before a collection is flushed, EVERY index (the HNSW one included)
+    /// reports `Finished` with `indexedRows = totalRows = 0` and stays that way
+    /// indefinitely, while queries brute-force the growing segments. Verified
+    /// live on v2.6.19. So "built" must mean "covers every row", not "state is
+    /// Finished".
+    #[test]
+    fn index_is_built_requires_row_coverage_not_just_finished() {
+        let p = |state: &str, indexed: i64, pending: i64, total: i64| IndexProgress {
+            field_name: "a".into(),
+            index_type: "INVERTED".into(),
+            state: state.into(),
+            indexed_rows: indexed,
+            pending_rows: pending,
+            total_rows: total,
+        };
+        // The exact reply a pre-flush collection gives: Finished over nothing.
+        assert!(!p("Finished", 0, 0, 0).is_built(true));
+        // Still building.
+        assert!(!p("InProgress", 0, 100, 100).is_built(true));
+        // Built but only partially covering.
+        assert!(!p("Finished", 60, 40, 100).is_built(true));
+        // Genuinely usable.
+        assert!(p("Finished", 100, 0, 100).is_built(true));
+        // Fully indexed WHILE background compaction re-queues segments: the
+        // verbatim v2.6.19 reply for a settled 1M-row collection. Must count as
+        // built, or every large upload hangs until the timeout.
+        assert!(p("Finished", 1_000_000, 847_872, 1_000_000).is_built(true));
+        // An empty upload legitimately has no rows to cover, so the row
+        // requirement is waived rather than deadlocking the wait loop.
+        assert!(p("Finished", 0, 0, 0).is_built(false));
+    }
+
+    #[test]
+    fn parse_index_progress_reads_row_counts() {
+        let row = json!({
+            "fieldName": "color", "indexType": "INVERTED", "indexState": "Finished",
+            "indexedRows": 1000, "pendingRows": 0, "totalRows": 1000,
+        });
+        let p = parse_index_progress(&row);
+        assert_eq!(p.field_name, "color");
+        assert_eq!(p.index_type, "INVERTED");
+        assert_eq!(p.indexed_rows, 1000);
+        assert_eq!(p.total_rows, 1000);
+        assert!(p.is_built(true));
     }
 
     /// Only a genuine "the field is already indexed" reply is tolerated. Both

--- a/tests/integration_milvus.rs
+++ b/tests/integration_milvus.rs
@@ -1,6 +1,7 @@
 //! Integration tests for the Milvus engine.
 //!
-//! Requires Milvus 2.5.6 running on port 19531 (standalone mode with etcd + minio).
+//! Requires Milvus (v2.6.19, per tests/docker-compose.test.yml) running on port
+//! 19531 (standalone mode with etcd + minio).
 //! Start with: docker compose -f tests/docker-compose.test.yml up -d milvus --wait
 //! Run with:   MILVUS_PORT=19531 cargo test --test integration_milvus --release -- --test-threads=1
 
@@ -55,12 +56,175 @@ fn wait_for_milvus() {
 }
 
 fn drop_test_collection() {
+    drop_collection(TEST_COLLECTION);
+}
+
+/// Best-effort drop of a named collection (the index read-back tests run with
+/// `--keep-data`, so they must clean up their own collection afterwards).
+fn drop_collection(name: &str) {
     let client = http_client();
     let url = format!("{}/v2/vectordb/collections/drop", milvus_base_url());
     let _ = client
         .post(&url)
-        .json(&serde_json::json!({"collectionName": TEST_COLLECTION}))
+        .json(&serde_json::json!({"collectionName": name}))
         .send();
+}
+
+/// Read the collection's indexes back FROM THE SERVER and return
+/// `fieldName -> (indexType, indexState)`.
+///
+/// `indexes/list` returns index NAMES only, so each one is then described to
+/// recover which field it covers and what type it is. Reading it back from the
+/// server (rather than trusting the create call's 200) is the whole point: the
+/// create path already returned success while creating nothing but the vector
+/// index (issue #218).
+fn read_back_indexes(collection: &str) -> std::collections::HashMap<String, (String, String)> {
+    let client = http_client();
+    let resp = client
+        .post(format!("{}/v2/vectordb/indexes/list", milvus_base_url()))
+        .json(&serde_json::json!({ "collectionName": collection }))
+        .send()
+        .expect("indexes/list request failed");
+    let body: serde_json::Value = resp.json().expect("indexes/list not JSON");
+    assert_eq!(
+        body.get("code").and_then(|c| c.as_i64()),
+        Some(0),
+        "indexes/list failed for '{}': {:?}",
+        collection,
+        body
+    );
+
+    let mut out = std::collections::HashMap::new();
+    for name in body
+        .get("data")
+        .and_then(|d| d.as_array())
+        .cloned()
+        .unwrap_or_default()
+    {
+        let name = name.as_str().unwrap_or_default();
+        let resp = client
+            .post(format!(
+                "{}/v2/vectordb/indexes/describe",
+                milvus_base_url()
+            ))
+            .json(&serde_json::json!({"collectionName": collection, "indexName": name}))
+            .send()
+            .expect("indexes/describe request failed");
+        let body: serde_json::Value = resp.json().expect("indexes/describe not JSON");
+        for row in body
+            .get("data")
+            .and_then(|d| d.as_array())
+            .cloned()
+            .unwrap_or_default()
+        {
+            let field = row
+                .get("fieldName")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let itype = row
+                .get("indexType")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let state = row
+                .get("indexState")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            out.insert(field, (itype, state));
+        }
+    }
+    out
+}
+
+/// The scalar `indexType` the engine must create for a dataset schema type —
+/// the test's INDEPENDENT copy of `milvus_field_kind`'s decision, so a silent
+/// change to the engine's mapping fails here rather than passing by circularity.
+/// `None` = the type is not materialised as a column (only `geo`, issue #223).
+fn expected_index_type(field_name: &str, schema_type: &str) -> Option<&'static str> {
+    if schema_type == "geo" {
+        return None;
+    }
+    if field_name == "labels" && (schema_type == "keyword" || schema_type == "text") {
+        return Some("INVERTED"); // Array(VarChar)
+    }
+    match schema_type {
+        "bool" => Some("BITMAP"),
+        "int" | "float" | "datetime" | "keyword" | "text" | "uuid" => Some("INVERTED"),
+        _ => None,
+    }
+}
+
+/// **Issue #218 guard.** Assert that EVERY field of the dataset schema has a
+/// scalar index on the server, of the expected type and in a built state — plus
+/// the `vector` ANN index.
+///
+/// This cannot be replaced by a recall assertion: an unindexed scalar column
+/// returns exactly the same rows as an indexed one, so recall is identical and
+/// only latency differs. That is precisely why a Milvus collection ran for this
+/// long with no scalar index at all. The property must be read back from the
+/// server's own index catalogue.
+fn assert_all_schema_fields_indexed(collection: &str, schema: &serde_json::Value) {
+    let found = read_back_indexes(collection);
+    println!("milvus index read-back for '{}': {:?}", collection, found);
+
+    let vector = found.get("vector").unwrap_or_else(|| {
+        panic!(
+            "collection '{}' has no vector index: {:?}",
+            collection, found
+        )
+    });
+    assert_eq!(
+        vector.0, "HNSW",
+        "vector index type unexpected in '{}': {:?}",
+        collection, found
+    );
+
+    let mut expected_fields = std::collections::BTreeSet::new();
+    for (field, ty) in schema.as_object().expect("schema must be an object") {
+        let schema_type = ty.as_str().unwrap_or_default();
+        let Some(expected) = expected_index_type(field, schema_type) else {
+            continue;
+        };
+        expected_fields.insert(field.clone());
+        let (itype, state) = found.get(field).unwrap_or_else(|| {
+            panic!(
+                "schema field '{}' ({}) has NO index in collection '{}' — a filter on it is a \
+                 brute-force scalar scan (issue #218). Indexes present: {:?}",
+                field, schema_type, collection, found
+            )
+        });
+        assert_eq!(
+            itype, expected,
+            "schema field '{}' ({}) is indexed as {} in '{}', expected {}",
+            field, schema_type, itype, collection, expected
+        );
+        assert_eq!(
+            state, "Finished",
+            "index on '{}' in '{}' is not built (state={})",
+            field, collection, state
+        );
+    }
+    assert!(
+        !expected_fields.is_empty(),
+        "fixture schema declared no indexable field — the assertion would be vacuous"
+    );
+
+    // Exact set equality, not just containment: an index on the server that the
+    // caller's schema literal does not mention means this test's copy of the
+    // fixture schema has drifted, and the "every field is indexed" claim would
+    // be checked against the wrong field list.
+    let actual_fields: std::collections::BTreeSet<String> = found
+        .keys()
+        .filter(|f| f.as_str() != "vector")
+        .cloned()
+        .collect();
+    assert_eq!(
+        actual_fields, expected_fields,
+        "scalar indexes on '{}' do not match the declared schema",
+        collection
+    );
 }
 
 fn generate_test_vectors(count: usize, dim: usize) -> (Vec<i64>, Vec<Vec<f32>>) {
@@ -471,7 +635,7 @@ fn test_binary_milvus_bool() {
         common::write_bool_project("bool-test", &serde_json::to_string(&configs).unwrap(), dim);
     assert!(proj.matching_docs >= proj.top);
     assert!(
-        common::run_binary(
+        common::run_binary_extra(
             &proj.root,
             "milvus-bool",
             "bool-test",
@@ -480,9 +644,12 @@ fn test_binary_milvus_bool() {
                 ("MILVUS_PORT", "19531"),
                 ("MILVUS_COLLECTION_NAME", "bench_bool")
             ],
+            &["--keep-data"],
         ),
         "milvus bool run failed"
     );
+    assert_all_schema_fields_indexed("bench_bool", &serde_json::json!({"flag": "bool"}));
+    drop_collection("bench_bool");
     let recall = common::read_recall(&proj.root, "milvus-bool");
     println!("milvus bool recall={:.3}", recall);
     assert!(recall >= 0.9, "milvus bool recall {:.3} < 0.9", recall);
@@ -505,7 +672,7 @@ fn test_binary_milvus_uuid() {
         common::write_uuid_project("uuid-test", &serde_json::to_string(&configs).unwrap(), dim);
     assert!(proj.matching_docs >= proj.top);
     assert!(
-        common::run_binary(
+        common::run_binary_extra(
             &proj.root,
             "milvus-uuid",
             "uuid-test",
@@ -514,9 +681,12 @@ fn test_binary_milvus_uuid() {
                 ("MILVUS_PORT", "19531"),
                 ("MILVUS_COLLECTION_NAME", "bench_uuid")
             ],
+            &["--keep-data"],
         ),
         "milvus uuid run failed"
     );
+    assert_all_schema_fields_indexed("bench_uuid", &serde_json::json!({"uid": "uuid"}));
+    drop_collection("bench_uuid");
     let recall = common::read_recall(&proj.root, "milvus-uuid");
     println!("milvus uuid recall={:.3}", recall);
     assert!(recall >= 0.9, "milvus uuid recall {:.3} < 0.9", recall);
@@ -541,7 +711,7 @@ fn test_binary_milvus_and_filter() {
     );
     assert!(proj.matching_docs >= proj.top);
     assert!(
-        common::run_binary(
+        common::run_binary_extra(
             &proj.root,
             "milvus-and",
             "and-test",
@@ -550,9 +720,15 @@ fn test_binary_milvus_and_filter() {
                 ("MILVUS_PORT", "19531"),
                 ("MILVUS_COLLECTION_NAME", "bench_and")
             ],
+            &["--keep-data"],
         ),
         "milvus and-filter run failed"
     );
+    assert_all_schema_fields_indexed(
+        "bench_and",
+        &serde_json::json!({"color": "keyword", "size": "int"}),
+    );
+    drop_collection("bench_and");
     let recall = common::read_recall(&proj.root, "milvus-and");
     println!("milvus and-filter recall={:.3}", recall);
     assert!(
@@ -611,7 +787,7 @@ fn test_binary_milvus_datetime() {
         common::write_datetime_project("dt-test", &serde_json::to_string(&configs).unwrap(), dim);
     assert!(proj.matching_docs >= proj.top);
     assert!(
-        common::run_binary(
+        common::run_binary_extra(
             &proj.root,
             "milvus-dt",
             "dt-test",
@@ -620,9 +796,12 @@ fn test_binary_milvus_datetime() {
                 ("MILVUS_PORT", "19531"),
                 ("MILVUS_COLLECTION_NAME", "bench_dt")
             ],
+            &["--keep-data"],
         ),
         "milvus datetime run failed"
     );
+    assert_all_schema_fields_indexed("bench_dt", &serde_json::json!({"ts": "datetime"}));
+    drop_collection("bench_dt");
     let recall = common::read_recall(&proj.root, "milvus-dt");
     println!("milvus datetime recall={:.3}", recall);
     assert!(recall >= 0.9, "milvus datetime recall {:.3} < 0.9", recall);
@@ -645,7 +824,7 @@ fn test_binary_milvus_fulltext() {
         common::write_fulltext_project("ft-test", &serde_json::to_string(&configs).unwrap(), dim);
     assert!(proj.matching_docs >= proj.top);
     assert!(
-        common::run_binary(
+        common::run_binary_extra(
             &proj.root,
             "milvus-ft",
             "ft-test",
@@ -654,9 +833,12 @@ fn test_binary_milvus_fulltext() {
                 ("MILVUS_PORT", "19531"),
                 ("MILVUS_COLLECTION_NAME", "bench_ft")
             ],
+            &["--keep-data"],
         ),
         "milvus fulltext run failed"
     );
+    assert_all_schema_fields_indexed("bench_ft", &serde_json::json!({"body": "text"}));
+    drop_collection("bench_ft");
     let recall = common::read_recall(&proj.root, "milvus-ft");
     println!("milvus fulltext recall={:.3}", recall);
     assert!(recall >= 0.9, "milvus fulltext recall {:.3} < 0.9", recall);
@@ -732,7 +914,7 @@ fn test_binary_milvus_match_any_labels() {
     );
 
     assert!(
-        common::run_binary(
+        common::run_binary_extra(
             &proj.root,
             "milvus-mal",
             "match-any-labels-test",
@@ -741,10 +923,16 @@ fn test_binary_milvus_match_any_labels() {
                 ("MILVUS_PORT", "19531"),
                 ("MILVUS_COLLECTION_NAME", "bench_matchany_labels"),
             ],
+            &["--keep-data"],
         ),
         "milvus match_any labels run failed"
     );
 
+    assert_all_schema_fields_indexed(
+        "bench_matchany_labels",
+        &serde_json::json!({"labels": "keyword"}),
+    );
+    drop_collection("bench_matchany_labels");
     let recall = common::read_recall(&proj.root, "milvus-mal");
     println!("milvus match_any labels recall={:.3}", recall);
     assert!(

--- a/tests/integration_milvus.rs
+++ b/tests/integration_milvus.rs
@@ -70,15 +70,31 @@ fn drop_collection(name: &str) {
         .send();
 }
 
-/// Read the collection's indexes back FROM THE SERVER and return
-/// `fieldName -> (indexType, indexState)`.
+/// What the server reports for one index: its type, build state, and — crucially
+/// — how many rows it actually covers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IndexInfo {
+    index_type: String,
+    state: String,
+    indexed_rows: i64,
+    pending_rows: i64,
+    total_rows: i64,
+}
+
+/// Read the collection's indexes back FROM THE SERVER, keyed by field name.
 ///
 /// `indexes/list` returns index NAMES only, so each one is then described to
-/// recover which field it covers and what type it is. Reading it back from the
-/// server (rather than trusting the create call's 200) is the whole point: the
-/// create path already returned success while creating nothing but the vector
-/// index (issue #218).
-fn read_back_indexes(collection: &str) -> std::collections::HashMap<String, (String, String)> {
+/// recover which field it covers, its type, and its row coverage. Reading this
+/// back from the server (rather than trusting the create call's 200) is the
+/// whole point: the create path already returned success while creating nothing
+/// but the vector index (issue #218).
+///
+/// `indexedRows`/`totalRows` are load-bearing, not decoration. Before the
+/// collection is flushed every index reports `state: "Finished"` with
+/// `indexedRows = totalRows = 0` — "finished indexing nothing" — and queries
+/// brute-force the growing segments regardless. An assertion that only checked
+/// `state` would pass on a collection where no index covers a single row.
+fn read_back_indexes(collection: &str) -> std::collections::HashMap<String, IndexInfo> {
     let client = http_client();
     let resp = client
         .post(format!("{}/v2/vectordb/indexes/list", milvus_base_url()))
@@ -117,22 +133,23 @@ fn read_back_indexes(collection: &str) -> std::collections::HashMap<String, (Str
             .cloned()
             .unwrap_or_default()
         {
-            let field = row
-                .get("fieldName")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let itype = row
-                .get("indexType")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let state = row
-                .get("indexState")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            out.insert(field, (itype, state));
+            let s = |k: &str| {
+                row.get(k)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string()
+            };
+            let n = |k: &str| row.get(k).and_then(|v| v.as_i64()).unwrap_or(0);
+            out.insert(
+                s("fieldName"),
+                IndexInfo {
+                    index_type: s("indexType"),
+                    state: s("indexState"),
+                    indexed_rows: n("indexedRows"),
+                    pending_rows: n("pendingRows"),
+                    total_rows: n("totalRows"),
+                },
+            );
         }
     }
     out
@@ -156,17 +173,56 @@ fn expected_index_type(field_name: &str, schema_type: &str) -> Option<&'static s
     }
 }
 
+/// Assert one index is genuinely usable: built, nothing pending, and covering
+/// EVERY row of the collection.
+///
+/// `state == "Finished"` on its own proves nothing — before the collection is
+/// flushed, every index reports `Finished` with `indexedRows = totalRows = 0`,
+/// so a state-only assertion passes while the server brute-forces the entire
+/// corpus. That is the exact hole this check closes.
+fn assert_index_covers_all_rows(collection: &str, field: &str, info: &IndexInfo) {
+    assert_eq!(
+        info.state, "Finished",
+        "index on '{}' in '{}' is not built (state={})",
+        field, collection, info.state
+    );
+    // NB: `pendingRows` is intentionally not asserted. On v2.6.19 a fully
+    // indexed collection still reports a large `pendingRows` while background
+    // compaction re-queues segments (measured: indexed = total = 1000000 with
+    // pendingRows = 847872). Coverage, not the pending counter, is what says
+    // the index is usable.
+    assert!(
+        info.total_rows > 0,
+        "index on '{}' in '{}' covers ZERO rows (totalRows=0) — the collection was not \
+         flushed, so every query brute-forces the growing segments and the index is inert",
+        field,
+        collection
+    );
+    assert_eq!(
+        info.indexed_rows, info.total_rows,
+        "index on '{}' in '{}' covers only {}/{} rows",
+        field, collection, info.indexed_rows, info.total_rows
+    );
+}
+
 /// **Issue #218 guard.** Assert that EVERY field of the dataset schema has a
-/// scalar index on the server, of the expected type and in a built state — plus
-/// the `vector` ANN index.
+/// scalar index on the server, of the expected type, built, and covering every
+/// row — plus the `vector` ANN index.
 ///
 /// This cannot be replaced by a recall assertion: an unindexed scalar column
 /// returns exactly the same rows as an indexed one, so recall is identical and
 /// only latency differs. That is precisely why a Milvus collection ran for this
 /// long with no scalar index at all. The property must be read back from the
 /// server's own index catalogue.
+///
+/// Row coverage is asserted too, not just existence and state: an index that
+/// exists but covers zero rows is exactly as useless as no index, and Milvus
+/// reports that state as `Finished` (see `assert_index_covers_all_rows`).
 fn assert_all_schema_fields_indexed(collection: &str, schema: &serde_json::Value) {
+    // Read the catalogue and drop the collection BEFORE asserting, so a failing
+    // assertion cannot leak the collection into the shared test server.
     let found = read_back_indexes(collection);
+    drop_collection(collection);
     println!("milvus index read-back for '{}': {:?}", collection, found);
 
     let vector = found.get("vector").unwrap_or_else(|| {
@@ -176,10 +232,12 @@ fn assert_all_schema_fields_indexed(collection: &str, schema: &serde_json::Value
         )
     });
     assert_eq!(
-        vector.0, "HNSW",
+        vector.index_type, "HNSW",
         "vector index type unexpected in '{}': {:?}",
         collection, found
     );
+    // The ANN index is subject to the same zero-row trap as the scalar ones.
+    assert_index_covers_all_rows(collection, "vector", vector);
 
     let mut expected_fields = std::collections::BTreeSet::new();
     for (field, ty) in schema.as_object().expect("schema must be an object") {
@@ -188,7 +246,7 @@ fn assert_all_schema_fields_indexed(collection: &str, schema: &serde_json::Value
             continue;
         };
         expected_fields.insert(field.clone());
-        let (itype, state) = found.get(field).unwrap_or_else(|| {
+        let info = found.get(field).unwrap_or_else(|| {
             panic!(
                 "schema field '{}' ({}) has NO index in collection '{}' — a filter on it is a \
                  brute-force scalar scan (issue #218). Indexes present: {:?}",
@@ -196,15 +254,11 @@ fn assert_all_schema_fields_indexed(collection: &str, schema: &serde_json::Value
             )
         });
         assert_eq!(
-            itype, expected,
+            info.index_type, expected,
             "schema field '{}' ({}) is indexed as {} in '{}', expected {}",
-            field, schema_type, itype, collection, expected
+            field, schema_type, info.index_type, collection, expected
         );
-        assert_eq!(
-            state, "Finished",
-            "index on '{}' in '{}' is not built (state={})",
-            field, collection, state
-        );
+        assert_index_covers_all_rows(collection, field, info);
     }
     assert!(
         !expected_fields.is_empty(),
@@ -649,7 +703,6 @@ fn test_binary_milvus_bool() {
         "milvus bool run failed"
     );
     assert_all_schema_fields_indexed("bench_bool", &serde_json::json!({"flag": "bool"}));
-    drop_collection("bench_bool");
     let recall = common::read_recall(&proj.root, "milvus-bool");
     println!("milvus bool recall={:.3}", recall);
     assert!(recall >= 0.9, "milvus bool recall {:.3} < 0.9", recall);
@@ -686,7 +739,6 @@ fn test_binary_milvus_uuid() {
         "milvus uuid run failed"
     );
     assert_all_schema_fields_indexed("bench_uuid", &serde_json::json!({"uid": "uuid"}));
-    drop_collection("bench_uuid");
     let recall = common::read_recall(&proj.root, "milvus-uuid");
     println!("milvus uuid recall={:.3}", recall);
     assert!(recall >= 0.9, "milvus uuid recall {:.3} < 0.9", recall);
@@ -728,7 +780,6 @@ fn test_binary_milvus_and_filter() {
         "bench_and",
         &serde_json::json!({"color": "keyword", "size": "int"}),
     );
-    drop_collection("bench_and");
     let recall = common::read_recall(&proj.root, "milvus-and");
     println!("milvus and-filter recall={:.3}", recall);
     assert!(
@@ -801,7 +852,6 @@ fn test_binary_milvus_datetime() {
         "milvus datetime run failed"
     );
     assert_all_schema_fields_indexed("bench_dt", &serde_json::json!({"ts": "datetime"}));
-    drop_collection("bench_dt");
     let recall = common::read_recall(&proj.root, "milvus-dt");
     println!("milvus datetime recall={:.3}", recall);
     assert!(recall >= 0.9, "milvus datetime recall {:.3} < 0.9", recall);
@@ -838,7 +888,6 @@ fn test_binary_milvus_fulltext() {
         "milvus fulltext run failed"
     );
     assert_all_schema_fields_indexed("bench_ft", &serde_json::json!({"body": "text"}));
-    drop_collection("bench_ft");
     let recall = common::read_recall(&proj.root, "milvus-ft");
     println!("milvus fulltext recall={:.3}", recall);
     assert!(recall >= 0.9, "milvus fulltext recall {:.3} < 0.9", recall);
@@ -932,7 +981,6 @@ fn test_binary_milvus_match_any_labels() {
         "bench_matchany_labels",
         &serde_json::json!({"labels": "keyword"}),
     );
-    drop_collection("bench_matchany_labels");
     let recall = common::read_recall(&proj.root, "milvus-mal");
     println!("milvus match_any labels recall={:.3}", recall);
     assert!(


### PR DESCRIPTION
## TL;DR — our published Milvus filtered numbers understated Milvus, on both speed and recall

Two independent defects, both fixed here:

1. **`create_index` posted a single `indexParams` entry for `fieldName: "vector"` and nothing else** — no scalar/payload index was ever created, so every filter on every filtered dataset was resolved by a brute-force scan of an unindexed column. (Issue #218.)
2. **The collection was never flushed before indexing**, so at the moment the search phase began, *every* index — including the HNSW vector index — covered **zero rows**. Fixing (1) without this leaves it inert.

**Headline, stated carefully:** the scalar-index fix itself is worth **~1.5–1.9×** on filtered queries — *not* the 3× an earlier draft of this description claimed. That earlier figure was an artefact of a sequential harness with a ±2.6× noise floor; it has been withdrawn and re-measured with paired designs. See "Measured impact".

Closes #218.

## Why no test caught it

An unindexed scalar scan returns **exactly the same rows** as an indexed lookup. Recall is identical; only speed differs. Every filter test we had asserted recall, so all passed while the index was missing. The guard has to read the server's own index catalogue back — and, as the review showed, it has to check row *coverage*, not just index existence.

## Measured impact

**Setup:** `milvusdb/milvus:v2.6.19` standalone (4 GB), localhost, 1M × 100d, HNSW M=16/efC=100, `ef=128`, keyword field with 1000 distinct values (~0.1% selectivity). Host was shared and loaded throughout — which is exactly why the designs below are paired rather than sequential.

### What the scalar index alone is worth: ~1.5–1.9×

Three independent measurements, all correctness-gated (every reply checked for `code == 0` and a non-empty hit list; recall reported):

| design | ratio (unindexed / indexed) |
|---|---|
| Paired columns, interleaved — `a` and `b` hold byte-identical values in the same rows, only `a` indexed, so both arms share one collection, one load, one graph, one instant | **1.79× p50**, 1.45× p95; indexed faster in 195/200 pairs; 0 hit-set mismatches |
| Same flushed 1M collection, scalar indexes dropped then re-created, replaying the real dataset queries | **1.81× QPS**, 1.89× p50, 1.89× p95; recall 1.0000 in both arms |
| Reviewer's independent paired run, same image and scale | **1.47–1.52×** |

Call it **~1.8× on this dataset, 1.5× on the reviewer's** — a real, reproducible, but roughly two-fold effect.

**Withdrawn:** an earlier revision of this PR claimed 2.95×. That came from a sequential drop/re-create harness whose own unfiltered control query — one no scalar index can affect — moved 8.98 → 6.39 → 16.60 ms across arms. The claimed effect sat inside that noise envelope. The unindexed arm agreed with the reviewer's (48.1 vs 39.1 ms); the *indexed* arm did not (16.5 vs 26.5 ms), i.e. the speedup came from an unusually fast indexed arm, the signature of a better machine state rather than a better index. It should not have been quoted.

### Where the gain does and does not appear

The gain tracks **how expensive the payload column is to scan**, not selectivity. Measured across 0.1 / 1 / 10 / 50 / 90% selectivity it is roughly flat (1.47 / 1.51 / 1.34 / 1.51 / 1.65×), because the index replaces a full column scan whose cost is selectivity-independent. What removes the gain is a *cheap* column: on a Bool column, INVERTED is worth nothing at all (`INV/none = 1.017`). So `random-100-match-kw-small-vocab-filters` and bool-filtered datasets will see materially less than the headline.

### End-to-end — the number our tables will actually carry

Full CLI runs, each doing its own 1M-row upload, `random-match-keyword-100-angular-filters`:

| parallel 1 | master | this PR |
|---|---|---|
| QPS | 11.8 | **175.7** |
| p50 | 50.76 ms | **5.40 ms** |
| p95 | 255.73 ms | **7.94 ms** |
| **mean recall** | **0.5734** | **1.0000** |

**Read this decomposition before quoting it.** Only ~1.8× of that is the scalar index (#218). The rest is the flush, which fixes the *vector* index covering zero rows — a defect that was penalising **every** Milvus run, filtered or not. Do not quote "Milvus got 15× faster from scalar indexes"; the correct statement is "the scalar index is worth ~1.8× on filtered queries, and separately the missing flush was crippling all Milvus results".

The recall column is its own finding: **master reported Milvus's recall as 0.573 when it is 1.000**, because the search phase began before the corpus was queryable. Master's recall was also unstable between phases of one run (0.5734 at parallel 1, 0.7917 at parallel 16) — the tell. We were understating Milvus on accuracy as well as speed.

`total_time` (ingest) rises from 134.6 s to ~167 s: the honest cost of an index Milvus should always have had, symmetric with Redis/Valkey building payload indexes at ingest. Unfiltered datasets are unaffected — `scalar_index_plan` returns empty and no extra request is sent.

### Index read-back, before and after

```
# master
POST /v2/vectordb/indexes/list {"collectionName":"bench218"}
  -> {"code":0,"data":["vector_index"]}          # a, b: NO INDEX
  vector_index  indexType=HNSW  state=Finished  indexedRows=0  totalRows=0   # and inert

# this PR
  -> {"code":0,"data":["vector_index","a_index","b_index"]}
  vector_index  field=vector  HNSW      Finished  indexed=1000000  total=1000000
  a_index       field=a       INVERTED  Finished  indexed=1000000  total=1000000
  b_index       field=b       INVERTED  Finished  indexed=1000000  total=1000000
```

## The fix

`src/bin/vector_db_benchmark/engine/milvus.rs`

* `milvus_field_kind(field_name, schema_type)` is the **single source of truth** for "does this schema field become a column, of what Milvus type" and "what scalar index does that column get". `create_collection` and `scalar_index_plan` both read it, so a column can no longer exist without an index — the structural guard.
* `create_scalar_indexes` creates one index per payload column, mirroring upstream `upload.py:76-87`. It checks the application-level `code` per field (the REST layer answers HTTP 200 on logical errors) and, on "already indexed", **reads the existing index's type back and confirms it** — the same 1100 reply covers a *wrong-type* index, and accepting that blindly would be #218's own failure class.
* **`flush_collection` + `wait_for_indexes_built` around index creation**, matching upstream's `flush` → `create_index` → `wait_for_index_building_complete` → `load`. "Built" means `indexedRows == totalRows > 0`, not `state == "Finished"` — the pre-flush state reports `Finished` over zero rows indefinitely. `pendingRows` is deliberately excluded: a settled 1M-row collection reports `pendingRows=847872` from background compaction while fully indexed, and requiring zero there hangs large uploads (caught live before shipping).

### Index type per column — measured, not merely permitted

Every (column type × index type) pair probed against v2.6.19; both reviewers reproduced all 20 cells verbatim.

* **INVERTED** for VarChar/Int64/Double/Array — the only type accepted on all four, serving both point (`==`, `in`, `array_contains*`, `TEXT_MATCH`) and range predicates. BITMAP does **not** beat it even where it should be strongest: ~0.95–1.03 on a 10-distinct keyword column.
* **BITMAP for Bool is necessary, not optional** — on Bool, INVERTED is worth *nothing* (`INV/none = 0.987–1.017`) while BITMAP gives 20–24%. Simplifying to "INVERTED everywhere" would have left `synthetic-filter-32`'s `flag` filter with no benefit at all.
* **This mapping is what AUTOINDEX resolves to**: VarChar `auto/INV = 0.937`; Bool `auto/BMP = 1.009` vs `auto/INV = 0.774`. We give each column exactly the index Milvus would choose for itself — the fairest possible setting for a competitor.
* Not STL_SORT (rejected on Bool/Array), not Trie (VarChar-and-prefix-only; we never emit a prefix predicate).

Two earlier claims in this rationale were wrong and have been removed: no shipped dataset has a 2-valued keyword field (the small-vocab one has **10**), and BITMAP's ~500-cardinality ceiling is **not** enforced on v2.6.19 (it builds fine on 60k distinct values).

### `labels` / array fields and `datetime` — both were affected, both fixed

`labels` is an `Array(VarChar)` (#88) filtered with `array_contains_any` → INVERTED (STL_SORT and Trie are server-rejected on Array). `datetime` is an Int64 epoch column filtered by range → INVERTED.

## Proof the indexes exist and are used

`assert_all_schema_fields_indexed` lists indexes back from the server and fails if any schema field is unindexed, of the wrong type, or **covers fewer than all rows**. Exact set equality against the declared schema catches fixture drift; `expected_index_type` is an independent copy of the engine's decision, so the assertion is not circular. The collection is dropped *before* asserting, so a failure cannot leak it into a shared CI Milvus.

**Negative control** (master binary + this PR's test, live):

```
milvus index read-back for 'bench_and':
  {"vector": IndexInfo { index_type: "HNSW", state: "Finished",
                         indexed_rows: 0, pending_rows: 0, total_rows: 0 }}
panicked: index on 'vector' in 'bench_and' covers ZERO rows (totalRows=0)
  — the collection was not flushed, so every query brute-forces the growing
    segments and the index is inert
test result: FAILED
```

with **`recall = 1.000` in both arms** — recall cannot see any of this.

Independently, the reviewer confirmed the planner really does use the index, by cgroup CPU accounting rather than wall clock: the same predicate over the same rows costs **203.7 ms server CPU unindexed vs 76.2 ms indexed**.

## Interaction with the known nearby traps

* **#223, geo dropped silently**: unchanged. `milvus_field_kind` returns `None` for `geo`, so no geo column and no geo index — identical to today. Because both passes route through one function, when #223 is fixed the index pass follows automatically.
* **#243, the broader flush/index-readiness issue**: this PR fixes the narrow instance in the Milvus ingest path. The general question of index readiness across engines stays in #243.
* **`index_type`/`index_params` passthrough**: untouched. The vector index still reads `upload_params` exactly as before; scalar index types derive from field type, as upstream.

## Verification

`cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` clean · `cargo test --lib --bins` 572 passed (28 Milvus unit tests) · live `integration_milvus` against v2.6.19 **13 passed, 0 failed**.
