### PR TITLE
fix(metrics): stop publishing precision under upstream's `mean_precisions` key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,22 @@ When migrating or modifying search logic, **always compare precision output** be
 }
 ```
 
-**Rust search result JSON** uses the same field names as Python v0 (`mean_precisions`, `rps`, `p50_time`, etc.). Both versions write to `results/` with filename format: `{engine}-{dataset}-search-{id}-{pid}-{timestamp}.json`.
+**Rust search result JSON** uses the same field names as Python v0 for timing/throughput (`rps`, `p50_time`, …). Both versions write to `results/` with filename format: `{engine}-{dataset}-search-{id}-{pid}-{timestamp}.json`.
+
+#### Quality metric keys: `mean_precisions` is NOT ours (#217)
+
+Python v0 — and upstream `qdrant/vector-db-benchmark`, `engine/base_client/search.py` — computes `len(ids & expected[:top]) / top`, i.e. **recall@top**, and publishes it under the key `mean_precisions`. Our Rust build emits, since **schema version 2**:
+
+| key | formula | notes |
+|---|---|---|
+| `mean_precision_at_returned` | `hits / |results returned|` | was `mean_precisions` before schema v2 — the rename is what closed #217 |
+| `mean_recall` | `hits / |valid ground-truth ids in expected[:top]|` | equals Python/upstream `mean_precisions` **only** when every ground-truth row has >= `top` valid ids |
+| `precisions_at_returned` | per-query array of the above precision | only under `--dump-raw-latencies`; was `precisions` |
+| `precision_at_returned_dist` | digest of that array | was `precision_dist` |
+
+Every result file carries a top-level `metrics_schema` block with these formulas plus a `ground_truth` width profile and a `comparable_to_upstream_mean_precisions` field naming the key (if any) that can be overlaid on upstream numbers. **We never emit a key named `mean_precisions`** — the same name for two formulas is the state that must not ship.
+
+Calibration (`calibration_precision`) targets `mean_precision_at_returned`; when the dataset's ground truth is narrower than `top` the target can be unreachable by construction, which the run now warns about and records in `params.calibration.reached_target`.
 
 ### How to compare precision
 
@@ -141,5 +156,5 @@ When migrating or modifying search logic, **always compare precision output** be
    # Rust
    ./target/release/vector-db-benchmark --engines "redis-m-16-ef-128" --datasets "h-and-m-2048-angular-filters"
    ```
-2. Compare `mean_precisions` (Python) vs `mean_precision` (Rust) — values should match within floating-point tolerance
-3. If precision differs, check: score conversion, neighbor ordering, distance metric, and top-k cutoff logic
+2. Compare `mean_precisions` (Python) vs **`mean_recall`** (Rust) — the matching pair; values should agree within floating-point tolerance on full-width ground truth. `scripts/v0_check.sh` does this mapping for you. Comparing Python `mean_precisions` against Rust `mean_precision_at_returned` compares recall with precision.
+3. If it differs, check: score conversion, neighbor ordering, distance metric, top-k cutoff logic — and whether the dataset's ground-truth rows are shorter than `top` (`metrics_schema.ground_truth.queries_with_fewer_than_top_neighbours` in the Rust output), in which case the two denominators legitimately disagree.

--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ Results JSON includes separate metrics for both operation types:
 {
   "results": {
     "rps": 5891.2,
-    "precision": 0.9785,
+    "mean_precision_at_returned": 0.9785,
+    "mean_recall": 0.9785,
     "p50_time": 0.00032,
     "p95_time": 0.00089,
     "p99_time": 0.00142,
@@ -395,8 +396,8 @@ Most datasets are automatically downloaded on first use. The image includes `ran
 | Random-100: Small synthetic dataset                                                                        |        100 |         100 |         9 |         9 | Cosine    |
 | Random-100-Euclidean: Small synthetic dataset                                                              |        100 |         100 |         9 |         9 | L2        |
 | **Filtered Search Datasets**                                                                               |            |             |           |           |           |
-| H&M-2048: Fashion product embeddings (with filters)                                                        |      2,048 |     105,542 |     2,000 |       100 | Cosine    |
-| H&M-2048: Fashion product embeddings (no filters)                                                          |      2,048 |     105,542 |     2,000 |       100 | Cosine    |
+| H&M-2048: Fashion product embeddings (with filters)                                                        |      2,048 |     105,542 |    10,000 |    ≤ 25 † | Cosine    |
+| H&M-2048: Fashion product embeddings (no filters)                                                          |      2,048 |     105,542 |    10,000 |        10 | Cosine    |
 | ArXiv-384: Academic paper embeddings (with filters)                                                        |        384 |   2,205,995 |    10,000 |       100 | Cosine    |
 | ArXiv-384: Academic paper embeddings (no filters)                                                          |        384 |   2,205,995 |    10,000 |       100 | Cosine    |
 | Random Match Keyword-100: Synthetic keyword matching (with filters)                                        |        100 |   1,000,000 |    10,000 |       100 | Cosine    |
@@ -419,6 +420,8 @@ Most datasets are automatically downloaded on first use. The image includes `ran
 | Random Match Keyword Small Vocab-256: Small vocabulary keyword matching (no filters)                       |        256 |   1,000,000 |    10,000 |       100 | Cosine    |
 | **Multi-Tenancy** (many tenants share one index; every query scoped to one tenant)                          |            |             |           |           |           |
 | Random-768-100-tenants: 100 tenants, per-tenant scoped queries (tenant field `a`)                          |        768 |   1,000,000 |       200 |        25 | Cosine    |
+
+† **The "Neighbors" column is the ground-truth width, and it bounds what recall can mean.** H&M-2048 (with filters) is not uniform: its 10,000 queries carry between **1 and 25** true neighbours (mean 23.4; 931 queries have fewer than 25), because a filtered query only has as many true neighbours as the filter admits. Our `mean_recall` divides by the neighbours that actually exist, so a 1-neighbour query can still score 1.0; upstream `qdrant/vector-db-benchmark` always divides by `top`, so the same query caps at `1/top`. A run's `metrics_schema.ground_truth` block reports the measured profile and the resulting ceiling — at `top: 100` H&M's ceiling is 0.233, so a `calibration_precision` above that is unreachable by construction. Configs that do not set `top` derive it from the ground-truth row width (25 here, 10 for the no-filters variant), which is why this matters mostly when `top` is set explicitly.
 
 ### Generating local datasets
 

--- a/scripts/v0_check.sh
+++ b/scripts/v0_check.sh
@@ -62,9 +62,21 @@ failed = False
 print(f\"{'Metric':<20} {'Python v0':>15} {'Rust':>15} {'Status':>20}\")
 print('=' * 72)
 
+# Python v0 (like upstream qdrant/vector-db-benchmark) computes
+# len(ids & expected[:top]) / top and stores it under 'mean_precisions'. That is
+# recall@top, i.e. the Rust 'mean_recall' field — NOT the Rust
+# 'mean_precision_at_returned', whose denominator is the number of results the
+# engine returned (#217). The two agree only on full-width ground truth, which
+# every dataset this script runs has; comparing the wrong pair here is precisely
+# the mistake the rename was meant to make impossible.
+KEY_MAP = {
+    'mean_precisions': 'mean_recall',
+}
+
 for key in ['mean_precisions', 'rps', 'mean_time', 'p50_time', 'p95_time', 'p99_time']:
+    rs_key = KEY_MAP.get(key, key)
     pv = py_r.get(key, 0.0)
-    rv = rs_r.get(key, 0.0)
+    rv = rs_r.get(rs_key, 0.0)
 
     if key == 'mean_precisions':
         if abs(pv - rv) < 0.001:
@@ -81,7 +93,8 @@ for key in ['mean_precisions', 'rps', 'mean_time', 'p50_time', 'p95_time', 'p99_
     else:
         status = 'PASS (Rust <= Py)' if rv <= pv * 1.5 else 'WARN (Rust > Py)'
 
-    print(f'{key:<20} {pv:>15.6f} {rv:>15.6f} {status:>20}')
+    label = key if rs_key == key else f'{key}→{rs_key}'
+    print(f'{label:<20} {pv:>15.6f} {rv:>15.6f} {status:>20}')
 
 print()
 if failed:

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -70,7 +70,16 @@ pub struct UpdateSearchRatio {
 pub struct SearchResults {
     pub total_time: f64,
     pub mean_time: f64,
-    pub mean_precision: f64,
+    /// Mean per-query precision, denominator = results the engine actually
+    /// returned: `hits / |deduped results kept|`. Emitted as
+    /// `mean_precision_at_returned`, NOT as `mean_precisions` — upstream
+    /// `qdrant/vector-db-benchmark` publishes recall@top under that key (#217).
+    /// `-1.0` is the filter-only sentinel (no vector search, no quality metric).
+    pub mean_precision_at_returned: f64,
+    /// Mean per-query recall, denominator = the valid, deduped ground-truth ids
+    /// that exist in `expected[:top]` (so a query with 3 true neighbours can
+    /// reach 1.0). Equals upstream's `mean_precisions` only when every
+    /// ground-truth row is at least `top` wide.
     pub mean_recall: f64,
     /// 10th-percentile per-query recall — the "worst 10%" floor. A healthy mean
     /// with a near-zero p10 means a slice of queries return almost nothing (e.g.
@@ -89,7 +98,8 @@ pub struct SearchResults {
     pub p50_time: f64,
     pub p95_time: f64,
     pub p99_time: f64,
-    pub precisions: Vec<f64>,
+    /// Per-query precision-at-returned samples (see `mean_precision_at_returned`).
+    pub precisions_at_returned: Vec<f64>,
     pub latencies: Vec<f64>,
     pub top: usize,
     /// Number of *successful* queries folded into the latency/quality stats.
@@ -331,7 +341,7 @@ pub fn compute_search_stats(
     Ok(SearchResults {
         total_time,
         mean_time,
-        mean_precision: mean(precisions),
+        mean_precision_at_returned: mean(precisions),
         mean_recall: mean(recalls),
         recall_p10,
         mean_mrr: mean(mrrs),
@@ -346,7 +356,7 @@ pub fn compute_search_stats(
         p50_time: pct(0.50),
         p95_time: pct(0.95),
         p99_time: pct(0.99),
-        precisions: precisions.to_vec(),
+        precisions_at_returned: precisions.to_vec(),
         latencies: times.to_vec(),
         top,
         num_queries: times.len(),

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -303,7 +303,8 @@ impl MongoDBEngine {
         // Route latency stats through the shared percentile path (linear
         // interpolation) so filter-only is measured on the same footing as the
         // main search(). Filter-only has no precision/recall: signal that with the
-        // mean_precision == -1 sentinel, an empty precisions vec, and top == 0.
+        // mean_precision_at_returned == -1 sentinel, an empty precisions vec,
+        // and top == 0.
         let mut results = crate::engine::compute_search_stats(
             &times,
             &[],
@@ -315,7 +316,7 @@ impl MongoDBEngine {
             parallel,
             num_to_run,
         )?;
-        results.mean_precision = -1.0;
+        results.mean_precision_at_returned = -1.0;
         Ok(results)
     }
 

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -945,7 +945,8 @@ impl RedisEngine {
         // Route latency stats through the shared percentile path (linear
         // interpolation) so filter-only is measured on the same footing as the
         // main search(). Filter-only has no precision/recall: signal that with the
-        // mean_precision == -1 sentinel, an empty precisions vec, and top == 0.
+        // mean_precision_at_returned == -1 sentinel, an empty precisions vec,
+        // and top == 0.
         let mut results = crate::engine::compute_search_stats(
             &times,
             &[],
@@ -957,7 +958,7 @@ impl RedisEngine {
             parallel,
             num_to_run,
         )?;
-        results.mean_precision = -1.0;
+        results.mean_precision_at_returned = -1.0;
         Ok(results)
     }
 

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -676,7 +676,8 @@ impl ValkeyEngine {
         // Route latency stats through the shared percentile path (linear
         // interpolation) so filter-only is measured on the same footing as the
         // main search(). Filter-only has no precision/recall: signal that with the
-        // mean_precision == -1 sentinel, an empty precisions vec, and top == 0.
+        // mean_precision_at_returned == -1 sentinel, an empty precisions vec,
+        // and top == 0.
         let mut results = crate::engine::compute_search_stats(
             &times,
             &[],
@@ -688,7 +689,7 @@ impl ValkeyEngine {
             parallel,
             num_to_run,
         )?;
-        results.mean_precision = -1.0;
+        results.mean_precision_at_returned = -1.0;
         Ok(results)
     }
 

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -500,23 +500,29 @@ fn run_single_experiment(
     // (a) whether our recall is the same quantity upstream calls `mean_precisions`
     // — reported in every result file — and (b) whether a calibration target is
     // reachable at all on this dataset (#217). Best-effort: a dataset whose query
-    // file cannot be profiled simply omits the block. Filter-only runs have no
-    // ground truth to speak of.
-    let ground_truth: Option<crate::ground_truth::GroundTruthProfile> = if args.skip_vector_index {
-        None
-    } else {
-        match crate::ground_truth::GroundTruthProfile::load(dataset) {
-            Ok(gt) => Some(gt),
-            Err(e) => {
-                eprintln!(
+    // file cannot be profiled simply omits the block.
+    //
+    // Skipped when nothing will consume it. `--skip-search` writes no search
+    // results and runs no calibration, and filter-only runs have no ground truth
+    // to speak of — reading the query file anyway costs a full parse of every
+    // query vector just to drop it (~22 s warm / ~137 s cold per config on the
+    // compound h-and-m dataset, paid once per config in a sweep).
+    let ground_truth: Option<crate::ground_truth::GroundTruthProfile> =
+        if args.skip_vector_index || args.skip_search {
+            None
+        } else {
+            match crate::ground_truth::GroundTruthProfile::load(dataset) {
+                Ok(gt) => Some(gt),
+                Err(e) => {
+                    eprintln!(
                     "\tNote: could not profile ground-truth widths ({}); result files will omit \
                      metrics_schema.ground_truth",
                     e
                 );
-                None
+                    None
+                }
             }
-        }
-    };
+        };
     // Configs that lost queries, collected so --fail-on-dropped-queries can fail
     // the run *after* every result file is written rather than instead of it.
     let mut dropped_query_failures: Vec<String> = Vec::new();
@@ -925,6 +931,7 @@ fn run_single_experiment(
                             ef: effective_ef.clone(),
                             parallel,
                             results,
+                            calibration: calibration_json.clone(),
                         });
                     }
                     None => {
@@ -987,6 +994,45 @@ fn run_single_experiment(
             dropped_query_failures.len(),
             dropped_query_failures.join("; ")
         ));
+    }
+
+    // Repeat any unreached calibration target at the END of the run. The warning
+    // the sweep printed up front is ~10 iterations of progress output away by now,
+    // and a sweep that "calibrated" against an unreachable target otherwise exits 0
+    // with nothing on screen to say the `ef` it settled on is meaningless (#217).
+    let uncalibrated: Vec<&SearchEntry> = search_entries
+        .iter()
+        .filter(|e| {
+            e.calibration
+                .as_ref()
+                .and_then(|c| c.get("reached_target"))
+                .and_then(|v| v.as_bool())
+                == Some(false)
+        })
+        .collect();
+    if !uncalibrated.is_empty() {
+        eprintln!(
+            "\n⚠ WARNING: {} search config(s) did NOT reach their calibration target; the swept \
+             parameter for those points is the closest value found, not a calibrated one. See \
+             `uncalibrated_configs` in the summary JSON.",
+            uncalibrated.len()
+        );
+        for e in &uncalibrated {
+            if let Some(cal) = &e.calibration {
+                eprintln!(
+                    "\t  search #{}: {}={} → {:.4} (target {:.4})",
+                    e.search_id,
+                    cal.get("param").and_then(|v| v.as_str()).unwrap_or("?"),
+                    cal.get("value").and_then(|v| v.as_i64()).unwrap_or(-1),
+                    cal.get("achieved")
+                        .and_then(|v| v.as_f64())
+                        .unwrap_or(f64::NAN),
+                    cal.get("target")
+                        .and_then(|v| v.as_f64())
+                        .unwrap_or(f64::NAN),
+                );
+            }
+        }
     }
 
     // Display precision summary and save summary JSON
@@ -1276,6 +1322,10 @@ fn metrics_schema(gt: Option<&crate::ground_truth::GroundTruthStats>) -> serde_j
              row has at least `top` valid ids (see `ground_truth` below), and it equals our \
              `mean_precision_at_returned` only when the engine returns a full page of `top` \
              results.",
+        // Names the field in THIS file that IS upstream's `mean_precisions`
+        // number, or null when no field is. Not "similar to": when this says
+        // `mean_recall`, our mean_recall and upstream's mean_precisions are the
+        // same quantity computed the same way, and may be overlaid directly.
         "comparable_to_upstream_mean_precisions": comparable,
     });
     if let Some(stats) = gt {

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -490,7 +490,33 @@ fn run_single_experiment(
     // Search-result files are written after the whole search phase so the
     // AFTER server-metadata snapshot (taken once all reps complete) can be
     // embedded alongside the BEFORE snapshot in every file.
-    let mut pending_saves: Vec<(usize, SearchParams, crate::engine::SearchResults)> = Vec::new();
+    let mut pending_saves: Vec<(
+        usize,
+        SearchParams,
+        crate::engine::SearchResults,
+        Option<serde_json::Value>,
+    )> = Vec::new();
+    // Ground-truth width profile, read once for the whole experiment. It decides
+    // (a) whether our recall is the same quantity upstream calls `mean_precisions`
+    // — reported in every result file — and (b) whether a calibration target is
+    // reachable at all on this dataset (#217). Best-effort: a dataset whose query
+    // file cannot be profiled simply omits the block. Filter-only runs have no
+    // ground truth to speak of.
+    let ground_truth: Option<crate::ground_truth::GroundTruthProfile> = if args.skip_vector_index {
+        None
+    } else {
+        match crate::ground_truth::GroundTruthProfile::load(dataset) {
+            Ok(gt) => Some(gt),
+            Err(e) => {
+                eprintln!(
+                    "\tNote: could not profile ground-truth widths ({}); result files will omit \
+                     metrics_schema.ground_truth",
+                    e
+                );
+                None
+            }
+        }
+    };
     // Configs that lost queries, collected so --fail-on-dropped-queries can fail
     // the run *after* every result file is written rather than instead of it.
     let mut dropped_query_failures: Vec<String> = Vec::new();
@@ -592,6 +618,7 @@ fn run_single_experiment(
                 let parallel = search_params.parallel.unwrap_or(1);
 
                 // Calibration is skipped for filter-only mode (no vector search to tune)
+                let mut calibration_json: Option<serde_json::Value> = None;
                 let calibrated_params = if skip_vector_index {
                     None
                 } else if let (Some(cal_param), Some(cal_precision)) = (
@@ -599,7 +626,7 @@ fn run_single_experiment(
                     search_params.calibration_precision,
                 ) {
                     println!(
-                        "\tCalibrating {}: target precision={:.4}, parallel={}",
+                        "\tCalibrating {}: target mean_precision_at_returned={:.4}, parallel={}",
                         cal_param, cal_precision, parallel
                     );
                     match calibrate(
@@ -609,12 +636,23 @@ fn run_single_experiment(
                         cal_param,
                         cal_precision,
                         args.queries,
+                        ground_truth.as_ref(),
                     ) {
-                        Ok((value, precision)) => {
+                        Ok(outcome) => {
+                            let value = outcome.value;
                             println!(
-                                "\tCalibrated {}={} → precision={:.4}",
-                                cal_param, value, precision
+                                "\tCalibrated {}={} → precision_at_returned={:.4} (target {:.4}{})",
+                                cal_param,
+                                value,
+                                outcome.achieved,
+                                outcome.target,
+                                if outcome.reached_target {
+                                    " reached"
+                                } else {
+                                    " NOT reached"
+                                },
                             );
+                            calibration_json = Some(outcome.to_json());
                             // Create a new SearchParams with calibrated value
                             let mut calibrated = search_params.clone();
                             let inner =
@@ -816,8 +854,8 @@ fn run_single_experiment(
                             println!("\t→ QPS: {:.1} (filter-only, no precision)", results.rps);
                         } else {
                             println!(
-                                "\t→ QPS: {:.1}, Recall: {:.4}, Precision: {:.4}, MRR: {:.4}, NDCG: {:.4}{}",
-                                results.rps, results.mean_recall, results.mean_precision, results.mean_mrr, results.mean_ndcg,
+                                "\t→ QPS: {:.1}, Recall: {:.4}, Precision@returned: {:.4}, MRR: {:.4}, NDCG: {:.4}{}",
+                                results.rps, results.mean_recall, results.mean_precision_at_returned, results.mean_mrr, results.mean_ndcg,
                                 if repetitions > 1 { " (best of reps)" } else { "" }
                             );
                         }
@@ -875,7 +913,12 @@ fn run_single_experiment(
                             );
                         }
                         // Defer the file write until the AFTER snapshot exists.
-                        pending_saves.push((*search_id, effective_params.clone(), results.clone()));
+                        pending_saves.push((
+                            *search_id,
+                            effective_params.clone(),
+                            results.clone(),
+                            calibration_json.clone(),
+                        ));
 
                         search_entries.push(SearchEntry {
                             search_id: *search_id,
@@ -915,7 +958,7 @@ fn run_single_experiment(
     // before and after snapshots. For non-Redis engines both are None and the
     // `server_metadata` key is omitted from the result JSON.
     let server_metadata_after = engine.server_metadata();
-    for (search_id, params, results) in &pending_saves {
+    for (search_id, params, results, calibration) in &pending_saves {
         save_search_results(
             engine.name(),
             &dataset.config.name,
@@ -926,6 +969,8 @@ fn run_single_experiment(
             server_metadata_after.as_ref(),
             args.dump_raw_latencies,
             number_of_shards,
+            ground_truth.as_ref(),
+            calibration.as_ref(),
         )?;
     }
 
@@ -980,11 +1025,52 @@ fn run_single_experiment(
     Ok(())
 }
 
+/// Outcome of a calibration sweep, including whether it actually got there.
+struct CalibrationOutcome {
+    param: String,
+    value: i64,
+    target: f64,
+    /// `mean_precision_at_returned` achieved at `value`.
+    achieved: f64,
+    reached_target: bool,
+    /// Ceiling implied by the dataset's ground-truth widths at this `top`, when
+    /// the ground truth could be profiled.
+    ceiling: Option<f64>,
+    /// Why the target was not reached, when it was not.
+    note: Option<String>,
+}
+
+impl CalibrationOutcome {
+    fn to_json(&self) -> serde_json::Value {
+        json!({
+            "param": self.param,
+            "value": self.value,
+            "metric": "mean_precision_at_returned",
+            "target": self.target,
+            "achieved": self.achieved,
+            "reached_target": self.reached_target,
+            "ground_truth_ceiling": self.ceiling,
+            "note": self.note,
+        })
+    }
+}
+
 /// Binary search calibration matching Python v0.
 ///
-/// Searches for the value of `calibration_param` (e.g., "ef") that achieves
-/// the target precision. Uses binary search between `min_value` (from `top` in
-/// search params, default 10) and `max_value` (1000).
+/// Searches for the value of `calibration_param` (e.g., "ef") that achieves the
+/// target `mean_precision_at_returned`. Uses binary search between `min_value`
+/// (from `top` in search params, default 10) and `max_value` (1000).
+///
+/// # The target can be unreachable by construction (#217)
+///
+/// The metric being chased has "results returned" as its denominator, so on a
+/// dataset whose ground-truth rows are narrower than `top` it is capped well
+/// below 1.0 — with `top: 100` (as shipped in `cohere-calibration.json` and
+/// `dbpedia-calibration.json`) and a 3-neighbour ground-truth row, no `ef`
+/// reaches 0.95. The sweep used to converge on `ef = 1000` and report it as a
+/// success. It now bounds the target against the ground-truth ceiling before
+/// spending a single search, and reports `reached_target` either way — both on
+/// stderr and in the result file's `params.calibration` block.
 fn calibrate(
     engine: &mut dyn Engine,
     dataset: &Dataset,
@@ -992,12 +1078,30 @@ fn calibrate(
     calibration_param: &str,
     target_precision: f64,
     num_queries: i64,
-) -> Result<(i64, f64), String> {
+    ground_truth: Option<&crate::ground_truth::GroundTruthProfile>,
+) -> Result<CalibrationOutcome, String> {
     // "EF" (upstream's redis spelling) is the same typed field as "ef"; without
     // this the loop would sweep extra["EF"], which no engine reads.
     let calibration_param = SearchParams::canonical_knob_name(calibration_param);
     let min_value = search_params.top.unwrap_or(10);
     let max_value: i64 = 1000;
+
+    // Bound the target against what the dataset's ground truth allows, before
+    // burning ~10 full search runs chasing a number that cannot exist.
+    let gt_stats = ground_truth.and_then(|gt| {
+        let top = search_params
+            .top
+            .and_then(|t| usize::try_from(t).ok())
+            .or_else(|| gt.first_row_len())?;
+        gt.stats(top)
+    });
+    let ceiling = gt_stats.as_ref().map(|s| s.recall_at_top_ceiling);
+    let unreachable_note = gt_stats
+        .as_ref()
+        .and_then(|s| s.unreachable_target_note(target_precision));
+    if let Some(note) = &unreachable_note {
+        eprintln!("\t⚠ WARNING: calibration target is unreachable — {}", note);
+    }
 
     let mut lower_bound = min_value;
     let mut upper_bound = max_value;
@@ -1024,15 +1128,24 @@ fn calibrate(
         }
 
         let results = engine.search(dataset, &test_params, num_queries)?;
-        let current_precision = results.mean_precision;
+        let current_precision = results.mean_precision_at_returned;
 
         println!(
-            "\t  calibration: {}={} → precision={:.4}",
+            "\t  calibration: {}={} → precision_at_returned={:.4}",
             calibration_param, current, current_precision
         );
 
         if (current_precision - target_precision).abs() < 1e-9 {
-            return Ok((current, current_precision));
+            return Ok(finish_calibration(
+                calibration_param,
+                current,
+                current_precision,
+                target_precision,
+                ceiling,
+                unreachable_note,
+                min_value,
+                max_value,
+            ));
         } else if current_precision > target_precision {
             upper_bound = current;
             upper_visited = true;
@@ -1047,19 +1160,137 @@ fn calibrate(
         if (lower_visited && next_value == lower_bound)
             || (upper_visited && next_value == upper_bound)
         {
-            if (previous_precision - target_precision).abs()
+            let (value, achieved) = if (previous_precision - target_precision).abs()
                 < (current_precision - target_precision).abs()
             {
-                return Ok((previous, previous_precision));
+                (previous, previous_precision)
             } else {
-                return Ok((current, current_precision));
-            }
+                (current, current_precision)
+            };
+            return Ok(finish_calibration(
+                calibration_param,
+                value,
+                achieved,
+                target_precision,
+                ceiling,
+                unreachable_note,
+                min_value,
+                max_value,
+            ));
         }
 
         previous = current;
         previous_precision = current_precision;
         current = next_value;
     }
+}
+
+/// Build the calibration outcome and say plainly whether the target was met.
+///
+/// Before #217 the sweep returned the closest value it found with no signal at
+/// all, so a target the dataset makes unreachable came out looking like a
+/// successful calibration at the maximum swept value.
+#[allow(clippy::too_many_arguments)]
+fn finish_calibration(
+    param: &str,
+    value: i64,
+    achieved: f64,
+    target: f64,
+    ceiling: Option<f64>,
+    unreachable_note: Option<String>,
+    min_value: i64,
+    max_value: i64,
+) -> CalibrationOutcome {
+    let reached_target = achieved + 1e-9 >= target;
+    let note = if reached_target {
+        None
+    } else if let Some(n) = unreachable_note {
+        Some(n)
+    } else {
+        Some(format!(
+            "the sweep of `{}` over [{}, {}] topped out at mean_precision_at_returned={:.4}, \
+             below the target {:.4}{}. The reported value is the closest point found, not a \
+             value that meets the target.",
+            param,
+            min_value,
+            max_value,
+            achieved,
+            target,
+            if value >= max_value {
+                format!(
+                    ", with `{}` pinned at the maximum swept value ({})",
+                    param, max_value
+                )
+            } else {
+                String::new()
+            },
+        ))
+    };
+    if let Some(n) = &note {
+        eprintln!(
+            "\t⚠ WARNING: calibration did NOT reach its target ({}={} → {:.4} < {:.4}) — {}",
+            param, value, achieved, target, n
+        );
+    }
+    CalibrationOutcome {
+        param: param.to_string(),
+        value,
+        target,
+        achieved,
+        reached_target,
+        ceiling,
+        note,
+    }
+}
+
+/// Retrieval-quality key definitions, emitted into every result file.
+///
+/// This block exists because the same key name meant two different things in the
+/// two benchmarks (#217). Upstream `qdrant/vector-db-benchmark`
+/// (`engine/base_client/search.py`) computes
+/// `len(ids.intersection(query.expected_result[:top])) / top` — recall@top — and
+/// publishes it as `mean_precisions`. We published *precision* (denominator =
+/// results returned) under that identical key, so overlaying the two tools'
+/// result files silently plotted precision against recall. We no longer emit a
+/// `mean_precisions` key at all; the definitions travel with the data instead of
+/// living only in a commit message.
+fn metrics_schema(gt: Option<&crate::ground_truth::GroundTruthStats>) -> serde_json::Value {
+    let comparable = gt
+        .filter(|s| s.recall_matches_upstream())
+        .map(|_| "mean_recall");
+    let mut schema = json!({
+        "version": 2,
+        "mean_precision_at_returned":
+            "hits / |deduped results kept (<= top)|, where hits = |results ∩ valid, deduped \
+             ground-truth ids in expected[:top]|. Renamed from `mean_precisions` in schema \
+             version 2 (#217): that key name is taken by a DIFFERENT formula upstream. \
+             -1.0 is the filter-only sentinel (no vector search was run).",
+        "mean_recall":
+            "hits / |valid, deduped ground-truth ids in expected[:top]|. The denominator is the \
+             ground truth that actually exists, so a query with 3 true neighbours can reach 1.0.",
+        "recall_p10": "10th percentile of the per-query recall defined above.",
+        "upstream_qdrant_mean_precisions":
+            "len(ids & expected[:top]) / top — recall@top. This is what upstream \
+             qdrant/vector-db-benchmark emits under the key `mean_precisions`. We deliberately \
+             do NOT emit that key name. It equals our `mean_recall` only when every ground-truth \
+             row has at least `top` valid ids (see `ground_truth` below), and it equals our \
+             `mean_precision_at_returned` only when the engine returns a full page of `top` \
+             results.",
+        "comparable_to_upstream_mean_precisions": comparable,
+    });
+    if let Some(stats) = gt {
+        schema["ground_truth"] = stats.to_json();
+        if comparable.is_none() {
+            schema["comparability_note"] = json!(format!(
+                "{} of {} queries have fewer than top={} valid ground-truth neighbours, so no \
+                 field in this file is directly comparable to upstream's `mean_precisions`; \
+                 upstream's value is capped at {:.4} on this dataset while our `mean_recall` \
+                 can still reach 1.0.",
+                stats.queries_below_top, stats.queries, stats.top, stats.recall_at_top_ceiling
+            ));
+        }
+    }
+    schema
 }
 
 /// Save search results to JSON file (matches Python v0 format)
@@ -1074,6 +1305,8 @@ fn save_search_results(
     server_metadata_after: Option<&serde_json::Value>,
     dump_raw_latencies: bool,
     number_of_shards: Option<&serde_json::Value>,
+    ground_truth: Option<&crate::ground_truth::GroundTruthProfile>,
+    calibration: Option<&serde_json::Value>,
 ) -> Result<(), String> {
     let timestamp = Local::now().format("%Y-%m-%d-%H-%M-%S");
     let pid = std::process::id();
@@ -1087,6 +1320,45 @@ fn save_search_results(
         engine_name, dataset_name, search_id, mixed_tag, pid, timestamp
     );
 
+    let result = build_search_result_json(
+        engine_name,
+        dataset_name,
+        search_params,
+        results,
+        server_metadata_before,
+        server_metadata_after,
+        dump_raw_latencies,
+        number_of_shards,
+        ground_truth,
+        calibration,
+    );
+
+    let path = results_dir().join(&filename);
+    fs::write(&path, serde_json::to_string_pretty(&result).unwrap())
+        .map_err(|e| format!("Failed to save results: {}", e))?;
+
+    println!("\tResults saved to: {:?}", path);
+    Ok(())
+}
+
+/// Build the search-result JSON document.
+///
+/// Split out of `save_search_results` so the emitted key set — in particular the
+/// absence of `mean_precisions` and the presence of `metrics_schema` (#217) — is
+/// unit-testable without writing a file.
+#[allow(clippy::too_many_arguments)]
+fn build_search_result_json(
+    engine_name: &str,
+    dataset_name: &str,
+    search_params: &crate::config::SearchParams,
+    results: &crate::engine::SearchResults,
+    server_metadata_before: Option<&serde_json::Value>,
+    server_metadata_after: Option<&serde_json::Value>,
+    dump_raw_latencies: bool,
+    number_of_shards: Option<&serde_json::Value>,
+    ground_truth: Option<&crate::ground_truth::GroundTruthProfile>,
+    calibration: Option<&serde_json::Value>,
+) -> serde_json::Value {
     let mut result = json!({
         "params": {
             "dataset": dataset_name,
@@ -1129,7 +1401,13 @@ fn save_search_results(
             "end_to_end_p50_time": results.end_to_end_p50_time,
             "end_to_end_p95_time": results.end_to_end_p95_time,
             "end_to_end_p99_time": results.end_to_end_p99_time,
-            "mean_precisions": results.mean_precision,
+            // Retrieval quality. THREE denominators are in play and only two of
+            // them are ours; see the `metrics_schema` block below (and
+            // src/metrics.rs) for the formulas. `mean_precisions` — upstream's
+            // key for recall@top — is intentionally absent: we used to emit our
+            // precision under that name, which made cross-tool overlays compare
+            // precision against recall (#217).
+            "mean_precision_at_returned": results.mean_precision_at_returned,
             "mean_recall": results.mean_recall,
             "recall_p10": results.recall_p10,
             "mean_mrr": results.mean_mrr,
@@ -1146,12 +1424,27 @@ fn save_search_results(
             // p50/p95/p99_time seconds fields above are unchanged for back-compat.
             // Raw arrays are additionally dumped only under --dump-raw-latencies.
             "latency_hdr": crate::latency_digest::latency_hdr(&results.latencies),
-            "precision_dist": crate::latency_digest::quality_dist(&results.precisions),
+            "precision_at_returned_dist":
+                crate::latency_digest::quality_dist(&results.precisions_at_returned),
             "recall_dist": crate::latency_digest::quality_dist(&results.recalls),
             "mrr_dist": crate::latency_digest::quality_dist(&results.mrrs),
             "ndcg_dist": crate::latency_digest::quality_dist(&results.ndcgs),
         }
     });
+
+    // Metric definitions travel with the numbers (#217). The ground-truth width
+    // profile is evaluated at the `top` this run actually used, so a reader can
+    // see whether `mean_recall` is the same quantity upstream calls
+    // `mean_precisions` for this dataset — or by how much they cannot be.
+    let gt_stats = ground_truth.and_then(|gt| gt.stats(results.top));
+    result["metrics_schema"] = metrics_schema(gt_stats.as_ref());
+
+    // How the swept parameter was chosen, and — crucially — whether the target
+    // was actually reached. A calibration that converged on the maximum value
+    // without reaching its target is not a calibration.
+    if let Some(cal) = calibration {
+        result["params"]["calibration"] = cal.clone();
+    }
 
     // Shard count the index was built with. Recall and QPS both move with it, so
     // a published search result carries it instead of leaving it to be inferred
@@ -1165,7 +1458,12 @@ fn save_search_results(
     // exactly as before. Off by default so large runs stay ~1000x smaller.
     if dump_raw_latencies {
         let results_obj = result["results"].as_object_mut().unwrap();
-        results_obj.insert("precisions".to_string(), json!(results.precisions));
+        // `precisions` is another upstream key name carrying upstream's per-query
+        // recall@top values, so our array ships under an unambiguous name too.
+        results_obj.insert(
+            "precisions_at_returned".to_string(),
+            json!(results.precisions_at_returned),
+        );
         results_obj.insert("recalls".to_string(), json!(results.recalls));
         results_obj.insert("mrrs".to_string(), json!(results.mrrs));
         results_obj.insert("ndcgs".to_string(), json!(results.ndcgs));
@@ -1220,12 +1518,7 @@ fn save_search_results(
         }
     }
 
-    let path = results_dir().join(&filename);
-    fs::write(&path, serde_json::to_string_pretty(&result).unwrap())
-        .map_err(|e| format!("Failed to save results: {}", e))?;
-
-    println!("\tResults saved to: {:?}", path);
-    Ok(())
+    result
 }
 
 /// Save upload results to JSON file
@@ -1355,5 +1648,215 @@ mod tests {
         // searches == 0 would divide-by-zero later, so it is rejected up front.
         let err = parse_update_search_ratio("1:0").unwrap_err();
         assert_eq!(err, "Search count must be > 0");
+    }
+
+    mod metrics_keys {
+        use super::super::{finish_calibration, metrics_schema};
+        use crate::ground_truth::GroundTruthProfile;
+
+        fn rows(n: usize, width: usize) -> Vec<Vec<i64>> {
+            (0..n)
+                .map(|q| ((q * 1000) as i64..(q * 1000 + width) as i64).collect())
+                .collect()
+        }
+
+        /// The whole point of #217: we must never emit a key named
+        /// `mean_precisions`, because upstream publishes recall@top under it.
+        #[test]
+        fn schema_never_reuses_the_upstream_key_name() {
+            let schema = metrics_schema(None);
+            let obj = schema.as_object().unwrap();
+            assert!(
+                !obj.contains_key("mean_precisions"),
+                "`mean_precisions` must not be an emitted key: {:?}",
+                obj.keys().collect::<Vec<_>>()
+            );
+            assert!(obj.contains_key("mean_precision_at_returned"));
+            assert!(obj.contains_key("upstream_qdrant_mean_precisions"));
+            assert_eq!(schema["version"], 2);
+        }
+
+        /// Full-width ground truth: our `mean_recall` IS upstream's
+        /// `mean_precisions`, and the file says so.
+        #[test]
+        fn full_width_ground_truth_declares_mean_recall_comparable() {
+            let gt = GroundTruthProfile::from_rows(rows(100, 100));
+            let stats = gt.stats(100).unwrap();
+            let schema = metrics_schema(Some(&stats));
+            assert_eq!(
+                schema["comparable_to_upstream_mean_precisions"],
+                "mean_recall"
+            );
+            assert!(schema.get("comparability_note").is_none());
+            assert_eq!(
+                schema["ground_truth"]["queries_with_fewer_than_top_neighbours"],
+                0
+            );
+            assert_eq!(schema["ground_truth"]["recall_at_top_ceiling"], 1.0);
+        }
+
+        /// Short ground-truth rows: nothing in the file is comparable to
+        /// upstream's `mean_precisions`, and the file says that too rather than
+        /// inviting the overlay.
+        #[test]
+        fn short_ground_truth_declares_nothing_comparable() {
+            let mut r = rows(9, 100);
+            r.push(vec![42]); // one query with a single true neighbour
+            let gt = GroundTruthProfile::from_rows(r);
+            let stats = gt.stats(100).unwrap();
+            let schema = metrics_schema(Some(&stats));
+            assert!(schema["comparable_to_upstream_mean_precisions"].is_null());
+            let note = schema["comparability_note"].as_str().unwrap();
+            assert!(note.contains("1 of 10"), "{}", note);
+            assert!(note.contains("0.9010"), "{}", note);
+        }
+
+        #[test]
+        fn calibration_that_reaches_its_target_is_reported_clean() {
+            let out = finish_calibration("ef", 128, 0.9612, 0.95, Some(1.0), None, 10, 1000);
+            assert!(out.reached_target);
+            assert!(out.note.is_none());
+            let j = out.to_json();
+            assert_eq!(j["metric"], "mean_precision_at_returned");
+            assert_eq!(j["reached_target"], true);
+            assert_eq!(j["value"], 128);
+        }
+
+        /// The #217 calibrator failure mode: ground truth narrower than `top`
+        /// caps precision, the sweep pins the knob at its maximum, and the run
+        /// used to print that as a successful calibration.
+        #[test]
+        fn unreachable_target_is_reported_not_silently_accepted() {
+            let gt = GroundTruthProfile::from_rows(vec![vec![1, 2, 3]; 8]);
+            let stats = gt.stats(100).unwrap();
+            let note = stats.unreachable_target_note(0.95);
+            assert!(note.is_some(), "0.95 vs a 0.03 ceiling must be flagged");
+            let out = finish_calibration(
+                "ef",
+                1000,
+                0.03,
+                0.95,
+                Some(stats.recall_at_top_ceiling),
+                note,
+                100,
+                1000,
+            );
+            assert!(!out.reached_target);
+            let j = out.to_json();
+            assert_eq!(j["reached_target"], false);
+            assert!((j["ground_truth_ceiling"].as_f64().unwrap() - 0.03).abs() < 1e-9);
+            let note = j["note"].as_str().unwrap();
+            assert!(note.contains("ceiling"), "{}", note);
+        }
+
+        /// End-to-end over the document actually written to `results/`: the
+        /// colliding key names must be gone, the unambiguous ones present, and the
+        /// definitions must ship with the numbers.
+        #[test]
+        fn emitted_document_has_no_colliding_key_names() {
+            use super::super::build_search_result_json;
+            use crate::config::SearchParams;
+            use crate::engine::SearchResults;
+
+            let params: SearchParams =
+                serde_json::from_value(serde_json::json!({"parallel": 1, "top": 10})).unwrap();
+            let results = SearchResults {
+                top: 10,
+                mean_precision_at_returned: 1.0,
+                mean_recall: 0.5,
+                precisions_at_returned: vec![1.0, 1.0],
+                recalls: vec![0.5, 0.5],
+                mrrs: vec![1.0, 1.0],
+                ndcgs: vec![1.0, 1.0],
+                latencies: vec![0.001, 0.002],
+                ..Default::default()
+            };
+            let gt = GroundTruthProfile::from_rows(rows(2, 10));
+            let doc = build_search_result_json(
+                "redis-test",
+                "glove-25-angular",
+                &params,
+                &results,
+                None,
+                None,
+                true, // --dump-raw-latencies: exercises the raw-array key too
+                None,
+                Some(&gt),
+                None,
+            );
+
+            let res = doc["results"].as_object().unwrap();
+            // The 5-of-10 case from #217: our precision is 1.0 while upstream
+            // would publish 0.5 under `mean_precisions`. Neither the aggregate nor
+            // the per-query array may reuse an upstream key name.
+            assert!(
+                !res.contains_key("mean_precisions"),
+                "emitted `mean_precisions`: {:?}",
+                res.keys().collect::<Vec<_>>()
+            );
+            assert!(!res.contains_key("precisions"));
+            assert!(!res.contains_key("precision_dist"));
+            assert_eq!(res["mean_precision_at_returned"], 1.0);
+            assert_eq!(res["mean_recall"], 0.5);
+            assert_eq!(res["precisions_at_returned"], serde_json::json!([1.0, 1.0]));
+            assert!(res.contains_key("precision_at_returned_dist"));
+
+            // Definitions travel with the data, not just with the commit message.
+            let schema = doc["metrics_schema"].as_object().unwrap();
+            assert_eq!(schema["version"], 2);
+            assert_eq!(doc["metrics_schema"]["ground_truth"]["top"], 10);
+            assert_eq!(
+                doc["metrics_schema"]["comparable_to_upstream_mean_precisions"],
+                "mean_recall"
+            );
+        }
+
+        /// A calibrated run records how the knob was chosen, including a target it
+        /// failed to reach.
+        #[test]
+        fn emitted_document_carries_the_calibration_outcome() {
+            use super::super::{build_search_result_json, finish_calibration};
+            use crate::config::SearchParams;
+            use crate::engine::SearchResults;
+
+            let outcome = finish_calibration("ef", 1000, 0.24, 0.95, Some(0.25), None, 100, 1000);
+            let doc = build_search_result_json(
+                "redis-test",
+                "h-and-m-2048-angular",
+                &serde_json::from_value::<SearchParams>(
+                    serde_json::json!({"parallel": 1, "top": 100}),
+                )
+                .unwrap(),
+                &SearchResults {
+                    top: 100,
+                    ..Default::default()
+                },
+                None,
+                None,
+                false,
+                None,
+                None,
+                Some(&outcome.to_json()),
+            );
+            let cal = &doc["params"]["calibration"];
+            assert_eq!(cal["reached_target"], false);
+            assert_eq!(cal["metric"], "mean_precision_at_returned");
+            assert_eq!(cal["value"], 1000);
+            assert!(cal["note"].as_str().unwrap().contains("topped out"));
+        }
+
+        /// Target below the ceiling but still not reached by the sweep (a genuinely
+        /// weak engine): still reported, with the saturated-knob detail.
+        #[test]
+        fn target_missed_without_a_ceiling_explanation_still_warns() {
+            let out = finish_calibration("ef", 1000, 0.80, 0.95, Some(1.0), None, 10, 1000);
+            assert!(!out.reached_target);
+            let note = out.note.unwrap();
+            assert!(
+                note.contains("pinned at the maximum swept value"),
+                "{}",
+                note
+            );
+        }
     }
 }

--- a/src/bin/vector_db_benchmark/ground_truth.rs
+++ b/src/bin/vector_db_benchmark/ground_truth.rs
@@ -132,7 +132,9 @@ impl GroundTruthStats {
     /// the ceiling, so this is reported as a warning rather than treated as a
     /// hard failure.
     pub fn unreachable_target_note(&self, target: f64) -> Option<String> {
-        if !target.is_finite() || target <= self.recall_at_top_ceiling + 1e-9 {
+        // NaN compares false against everything, so it is excluded explicitly;
+        // +inf is a legitimately unreachable target and must still be flagged.
+        if target.is_nan() || target <= self.recall_at_top_ceiling + 1e-9 {
             return None;
         }
         Some(format!(
@@ -158,8 +160,17 @@ impl GroundTruthStats {
     }
 
     /// Whether our `mean_recall` is numerically the same quantity as upstream's
-    /// `mean_precisions` for this dataset/`top` — true exactly when every row is
-    /// at least `top` wide, so both denominators equal `top`.
+    /// `mean_precisions` for this dataset/`top`: true when every row is at least
+    /// `top` wide, so both denominators equal `top`.
+    ///
+    /// This assumes the two normal shapes — sentinel padding only ever trails the
+    /// real ids, and the engine returns no more than `top` results. Two
+    /// pathological shapes can still separate the numbers even at full width: a
+    /// sentinel *interleaved* among real ids (upstream slices the raw row at
+    /// `top` and keeps the sentinel, we filter first and reach one id further),
+    /// and an engine returning MORE than `top` results (we truncate at `top`,
+    /// upstream intersects everything it got). Neither occurs in the shipped
+    /// datasets or engines.
     pub fn recall_matches_upstream(&self) -> bool {
         self.queries_below_top == 0
     }
@@ -256,9 +267,13 @@ mod tests {
     }
 
     #[test]
-    fn non_finite_target_is_not_reported_unreachable() {
+    fn nan_target_is_not_reported_unreachable_but_infinity_is() {
         let p = GroundTruthProfile::from_rows(rows(2, 10));
         let s = p.stats(10).unwrap();
         assert!(s.unreachable_target_note(f64::NAN).is_none());
+        assert!(
+            s.unreachable_target_note(f64::INFINITY).is_some(),
+            "+inf is unreachable even against a ceiling of 1.0"
+        );
     }
 }

--- a/src/bin/vector_db_benchmark/ground_truth.rs
+++ b/src/bin/vector_db_benchmark/ground_truth.rs
@@ -1,0 +1,264 @@
+//! Ground-truth width profiling.
+//!
+//! "Width" is how many *valid* (non-sentinel, deduped) neighbour ids a query
+//! actually has in `expected[:top]`. On a standard HDF5 dataset every row is
+//! 100 neighbours wide and width == top for any sane `top`; on filtered, sparse
+//! and generated datasets rows are routinely shorter (the shipped
+//! `h-and-m-2048-angular` `tests.jsonl` has 931 of 10 000 queries with fewer
+//! than 25 `closest_ids`).
+//!
+//! Width is what makes the retrieval-quality denominators disagree (see
+//! `crate::metrics`):
+//!
+//! * our `mean_recall` divides by the width (a query with one true neighbour can
+//!   reach 1.0),
+//! * upstream `qdrant/vector-db-benchmark` always divides by `top` (that same
+//!   query caps at `1/top`),
+//! * our `mean_precision_at_returned` divides by what the engine returned, which
+//!   for a full page is `top` — so it is capped by the width too.
+//!
+//! Two consumers use this: the results JSON, which reports the profile so a
+//! reader can tell whether our numbers are comparable to upstream's at all, and
+//! the calibrator, which would otherwise binary-search for a target precision
+//! that the ground truth makes unreachable.
+
+use std::collections::HashSet;
+
+use crate::dataset::Dataset;
+
+/// Per-query ground-truth rows, kept only to derive width statistics.
+pub struct GroundTruthProfile {
+    rows: Vec<Vec<i64>>,
+}
+
+/// Width statistics evaluated at one specific `top`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroundTruthStats {
+    /// Number of ground-truth rows (queries) profiled.
+    pub queries: usize,
+    /// The `top` these statistics were evaluated at.
+    pub top: usize,
+    /// Mean number of valid truth ids per query, capped at `top`.
+    pub mean_width: f64,
+    /// Narrowest row (capped at `top`).
+    pub min_width: usize,
+    /// How many queries have fewer than `top` valid truth ids. Zero means our
+    /// `mean_recall` and upstream's `mean_precisions` are the same quantity.
+    pub queries_below_top: usize,
+    /// `mean(min(width, top)) / top`: the largest value upstream's
+    /// `mean_precisions` (recall@top) can take on this dataset, and — assuming
+    /// the engine returns a full page of `top` results — the largest value our
+    /// `mean_precision_at_returned` can take. 1.0 on full-width ground truth.
+    pub recall_at_top_ceiling: f64,
+}
+
+impl GroundTruthProfile {
+    /// Read the dataset's ground truth (dense, sparse or hybrid queries).
+    ///
+    /// This re-reads the query file the engine also reads; it is a few MB and is
+    /// done once per experiment, not per search config.
+    pub fn load(dataset: &Dataset) -> Result<Self, String> {
+        let rows = if dataset.is_hybrid() {
+            let (_dense, _sparse, neighbors) = dataset.read_hybrid_queries()?;
+            neighbors
+        } else if dataset.is_sparse() {
+            let (_queries, neighbors) = dataset.read_sparse_queries()?;
+            neighbors
+        } else {
+            let (_queries, neighbors, _conditions) = dataset.read_queries()?;
+            neighbors
+        };
+        Ok(Self::from_rows(rows))
+    }
+
+    pub fn from_rows(rows: Vec<Vec<i64>>) -> Self {
+        Self { rows }
+    }
+
+    /// Width of the first row, used as the fallback `top` when no config pins one
+    /// (the engines derive `top` the same way).
+    pub fn first_row_len(&self) -> Option<usize> {
+        self.rows.first().map(|r| r.len())
+    }
+
+    /// Width statistics at `top`. `None` when there is nothing to profile.
+    pub fn stats(&self, top: usize) -> Option<GroundTruthStats> {
+        if top == 0 || self.rows.is_empty() {
+            return None;
+        }
+        let widths: Vec<usize> = self.rows.iter().map(|r| valid_width(r, top)).collect();
+        let queries = widths.len();
+        let sum: usize = widths.iter().sum();
+        let min_width = widths.iter().copied().min().unwrap_or(0);
+        let queries_below_top = widths.iter().filter(|&&w| w < top).count();
+        let mean_width = sum as f64 / queries as f64;
+        Some(GroundTruthStats {
+            queries,
+            top,
+            mean_width,
+            min_width,
+            queries_below_top,
+            recall_at_top_ceiling: mean_width / top as f64,
+        })
+    }
+}
+
+/// Number of valid truth ids a row contributes at `top`, mirroring exactly what
+/// `crate::metrics::compute_metrics` counts: drop negative sentinels first, then
+/// take the first `top`, then dedup.
+fn valid_width(row: &[i64], top: usize) -> usize {
+    let set: HashSet<i64> = row
+        .iter()
+        .copied()
+        .filter(|&id| id >= 0)
+        .take(top)
+        .collect();
+    set.len()
+}
+
+impl GroundTruthStats {
+    /// Explain why a calibration target cannot be reached on this dataset, or
+    /// `None` when the ceiling allows it.
+    ///
+    /// The calibrator binary-searches on `mean_precision_at_returned`, whose
+    /// denominator is the number of results returned. An engine asked for `top`
+    /// normally returns `top`, so the ground-truth width caps the achievable
+    /// precision at `recall_at_top_ceiling` — a 0.95 target against rows that
+    /// average 24 neighbours at `top: 100` is unreachable no matter how high `ef`
+    /// goes, and the search silently converges on the maximum `ef`.
+    ///
+    /// The bound is an estimate in one direction only: a *filtered* query where
+    /// the engine legitimately returns fewer than `top` results can score above
+    /// the ceiling, so this is reported as a warning rather than treated as a
+    /// hard failure.
+    pub fn unreachable_target_note(&self, target: f64) -> Option<String> {
+        if !target.is_finite() || target <= self.recall_at_top_ceiling + 1e-9 {
+            return None;
+        }
+        Some(format!(
+            "target precision {:.4} is above the ceiling this dataset allows: {} of {} queries \
+             have fewer than top={} valid ground-truth neighbours (mean {:.2}, min {}), so \
+             mean_precision_at_returned cannot exceed {:.4} for an engine that returns a full \
+             page of {} results. Raising the calibrated parameter cannot close that gap — it \
+             will converge on the maximum value tried. Lower calibration_precision to <= {:.4}, \
+             lower `top`, or calibrate against a dataset with full-width ground truth. \
+             (A filtered query that returns fewer than {} results can score above this ceiling, \
+             so treat it as an estimate.)",
+            target,
+            self.queries_below_top,
+            self.queries,
+            self.top,
+            self.mean_width,
+            self.min_width,
+            self.recall_at_top_ceiling,
+            self.top,
+            self.recall_at_top_ceiling,
+            self.top,
+        ))
+    }
+
+    /// Whether our `mean_recall` is numerically the same quantity as upstream's
+    /// `mean_precisions` for this dataset/`top` — true exactly when every row is
+    /// at least `top` wide, so both denominators equal `top`.
+    pub fn recall_matches_upstream(&self) -> bool {
+        self.queries_below_top == 0
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "queries": self.queries,
+            "top": self.top,
+            "mean_valid_neighbours_per_query": self.mean_width,
+            "min_valid_neighbours_per_query": self.min_width,
+            "queries_with_fewer_than_top_neighbours": self.queries_below_top,
+            "recall_at_top_ceiling": self.recall_at_top_ceiling,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows(n: usize, width: usize) -> Vec<Vec<i64>> {
+        (0..n)
+            .map(|q| ((q * 1000) as i64..(q * 1000 + width) as i64).collect())
+            .collect()
+    }
+
+    #[test]
+    fn full_width_ground_truth_has_ceiling_one() {
+        let p = GroundTruthProfile::from_rows(rows(10, 100));
+        let s = p.stats(100).unwrap();
+        assert_eq!(s.queries, 10);
+        assert_eq!(s.min_width, 100);
+        assert_eq!(s.queries_below_top, 0);
+        assert!((s.recall_at_top_ceiling - 1.0).abs() < 1e-9);
+        assert!(s.recall_matches_upstream());
+        assert!(s.unreachable_target_note(0.95).is_none());
+    }
+
+    #[test]
+    fn top_below_row_width_is_still_full_width() {
+        // 100-neighbour HDF5 rows queried at top=10: still full width.
+        let p = GroundTruthProfile::from_rows(rows(5, 100));
+        let s = p.stats(10).unwrap();
+        assert_eq!(s.min_width, 10);
+        assert_eq!(s.queries_below_top, 0);
+        assert!((s.recall_at_top_ceiling - 1.0).abs() < 1e-9);
+    }
+
+    /// The `h-and-m`-shaped case from #217, scaled down: most rows are wide, a
+    /// tenth are single-neighbour, `top` is 100.
+    #[test]
+    fn short_rows_pull_the_ceiling_below_the_calibration_target() {
+        let mut r = rows(9, 100);
+        r.push(vec![42]);
+        let p = GroundTruthProfile::from_rows(r);
+        let s = p.stats(100).unwrap();
+        assert_eq!(s.queries, 10);
+        assert_eq!(s.queries_below_top, 1);
+        assert_eq!(s.min_width, 1);
+        // mean width = (9*100 + 1)/10 = 90.1 -> ceiling 0.901
+        assert!((s.mean_width - 90.1).abs() < 1e-9, "{}", s.mean_width);
+        assert!((s.recall_at_top_ceiling - 0.901).abs() < 1e-9);
+        assert!(!s.recall_matches_upstream());
+        let note = s
+            .unreachable_target_note(0.95)
+            .expect("0.95 > 0.901 must be flagged");
+        assert!(note.contains("0.9010"), "{}", note);
+        assert!(s.unreachable_target_note(0.90).is_none());
+    }
+
+    #[test]
+    fn sentinel_padding_does_not_count_as_ground_truth() {
+        let p = GroundTruthProfile::from_rows(vec![vec![1, 2, -1, -1, -1]]);
+        let s = p.stats(5).unwrap();
+        assert_eq!(s.min_width, 2);
+        assert_eq!(s.queries_below_top, 1);
+        assert!((s.recall_at_top_ceiling - 0.4).abs() < 1e-9);
+    }
+
+    #[test]
+    fn duplicate_truth_ids_counted_once() {
+        let p = GroundTruthProfile::from_rows(vec![vec![7, 7, 7, 8]]);
+        let s = p.stats(4).unwrap();
+        assert_eq!(s.min_width, 2);
+        assert!((s.recall_at_top_ceiling - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn empty_or_zero_top_yields_no_stats() {
+        assert!(GroundTruthProfile::from_rows(vec![]).stats(10).is_none());
+        assert!(GroundTruthProfile::from_rows(rows(2, 10))
+            .stats(0)
+            .is_none());
+    }
+
+    #[test]
+    fn non_finite_target_is_not_reported_unreachable() {
+        let p = GroundTruthProfile::from_rows(rows(2, 10));
+        let s = p.stats(10).unwrap();
+        assert!(s.unreachable_target_note(f64::NAN).is_none());
+    }
+}

--- a/src/bin/vector_db_benchmark/main.rs
+++ b/src/bin/vector_db_benchmark/main.rs
@@ -9,6 +9,7 @@ mod dataset;
 mod download;
 mod engine;
 mod experiment;
+mod ground_truth;
 mod latency_digest;
 mod metrics;
 mod plot;

--- a/src/bin/vector_db_benchmark/plot.rs
+++ b/src/bin/vector_db_benchmark/plot.rs
@@ -128,6 +128,20 @@ pub fn export_chart(args: &Args) -> Result<(), String> {
 /// Extract (precision, qps) points from a summary's `precision_summary` map,
 /// falling back to `search_results` if that's absent.
 fn parse_points(json: &Value) -> Vec<Point> {
+    // A summary without `metrics_schema_version` predates the #217 rename — or was
+    // written by upstream qdrant/vector-db-benchmark, whose `precision_summary`
+    // keys and `mean_precisions` values are recall@top rather than our
+    // precision-at-returned. The two shapes are indistinguishable, so the X axis
+    // cannot be honestly labelled for such a file; say so instead of charting it
+    // silently under our label.
+    if json.get("metrics_schema_version").is_none() {
+        eprintln!(
+            "WARNING: summary has no `metrics_schema_version` — its precision values are either \
+             ours from before the #217 rename (precision = hits / results returned) or upstream's \
+             (recall@top = hits / top). They are plotted on the same axis; re-run the benchmark to \
+             get an unambiguous summary."
+        );
+    }
     if let Some(map) = json.get("precision_summary").and_then(|v| v.as_object()) {
         let mut pts: Vec<Point> = map
             .iter()
@@ -343,6 +357,7 @@ mod tests {
     #[test]
     fn parse_points_falls_back_to_search_results() {
         let json = serde_json::json!({
+            "metrics_schema_version": 2,
             "search_results": [
                 {"mean_precision_at_returned": 0.8, "rps": 100.0},
                 {"mean_precision_at_returned": 0.95, "rps": 60.0}

--- a/src/bin/vector_db_benchmark/plot.rs
+++ b/src/bin/vector_db_benchmark/plot.rs
@@ -143,12 +143,22 @@ fn parse_points(json: &Value) -> Vec<Point> {
         }
     }
     // Fallback: raw search_results entries.
+    //
+    // `mean_precisions` is read only for backwards compatibility with summary
+    // files written before schema version 2 (#217), where our precision shipped
+    // under that name. New files use `mean_precision_at_returned`. Note that a
+    // summary produced by upstream qdrant/vector-db-benchmark also has a
+    // `mean_precisions` field, but it holds recall@top — the two curves are not
+    // interchangeable, which is exactly why the key was renamed.
     json.get("search_results")
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
                 .filter_map(|e| {
-                    let precision = e.get("mean_precisions").and_then(|v| v.as_f64())?;
+                    let precision = e
+                        .get("mean_precision_at_returned")
+                        .or_else(|| e.get("mean_precisions"))
+                        .and_then(|v| v.as_f64())?;
                     let qps = e.get("rps").and_then(|v| v.as_f64())?;
                     Some(Point { precision, qps })
                 })
@@ -246,7 +256,10 @@ fn render_svg(title: &str, series: &[Series]) -> String {
         mt + plot_h
     ));
     svg.push_str(&format!(
-        r#"<text x="{}" y="{}" font-size="13" text-anchor="middle">Precision (recall@k)</text>"#,
+        // The X axis is our precision-at-returned (hits / results returned), NOT
+        // upstream's recall@top — the axis used to be labelled "recall@k", which
+        // is a different quantity (#217).
+        r#"<text x="{}" y="{}" font-size="13" text-anchor="middle">Precision@returned (hits / results returned)</text>"#,
         ml + plot_w / 2.0,
         h - 18.0
     ));
@@ -331,11 +344,45 @@ mod tests {
     fn parse_points_falls_back_to_search_results() {
         let json = serde_json::json!({
             "search_results": [
+                {"mean_precision_at_returned": 0.8, "rps": 100.0},
+                {"mean_precision_at_returned": 0.95, "rps": 60.0}
+            ]
+        });
+        assert_eq!(parse_points(&json).len(), 2);
+    }
+
+    /// Summaries written before the #217 rename carry our precision under the
+    /// legacy `mean_precisions` key; charting them must keep working.
+    #[test]
+    fn parse_points_reads_legacy_mean_precisions_key() {
+        let json = serde_json::json!({
+            "search_results": [
                 {"mean_precisions": 0.8, "rps": 100.0},
                 {"mean_precisions": 0.95, "rps": 60.0}
             ]
         });
-        assert_eq!(parse_points(&json).len(), 2);
+        let mut pts = parse_points(&json);
+        pts.sort_by(|a, b| a.precision.partial_cmp(&b.precision).unwrap());
+        assert_eq!(pts.len(), 2);
+        assert!((pts[0].precision - 0.8).abs() < 1e-9);
+    }
+
+    /// A file carrying both keys must prefer the new one (a hand-merged or
+    /// re-written summary must not silently fall back to the legacy value).
+    #[test]
+    fn parse_points_prefers_new_key_over_legacy() {
+        let json = serde_json::json!({
+            "search_results": [
+                {"mean_precision_at_returned": 0.42, "mean_precisions": 0.99, "rps": 10.0}
+            ]
+        });
+        let pts = parse_points(&json);
+        assert_eq!(pts.len(), 1);
+        assert!(
+            (pts[0].precision - 0.42).abs() < 1e-9,
+            "{}",
+            pts[0].precision
+        );
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/summary.rs
+++ b/src/bin/vector_db_benchmark/summary.rs
@@ -20,6 +20,10 @@ pub struct SearchEntry {
     pub ef: String,
     pub parallel: i64,
     pub results: SearchResults,
+    /// Calibration outcome for this config, when it was calibrated. Carried into
+    /// the summary so a run whose target was never reached is visible in the
+    /// artifact a human reads, not only in a stderr line that scrolled away.
+    pub calibration: Option<serde_json::Value>,
 }
 
 /// Precision analysis result for a single precision bucket.
@@ -516,6 +520,7 @@ pub fn save_summary(
                 "oversubscribed": e.results.oversubscribed,
                 "available_cores": e.results.available_cores,
                 "client_cpu_cores_used": e.results.client_cpu_cores_used,
+                "calibration": e.calibration,
             })
         })
         .collect();
@@ -544,12 +549,49 @@ pub fn save_summary(
         })
         .collect();
 
+    // Configs whose calibration never reached its target. A sweep with a target
+    // the dataset makes unreachable exits 0 and the stderr warning has long
+    // scrolled away by then, so the artifact itself has to carry it (#217).
+    let uncalibrated: Vec<serde_json::Value> = entries
+        .iter()
+        .filter_map(|e| {
+            let cal = e.calibration.as_ref()?;
+            if cal.get("reached_target").and_then(|v| v.as_bool()) == Some(false) {
+                Some(json!({
+                    "search_id": e.search_id,
+                    "param": cal.get("param"),
+                    "value": cal.get("value"),
+                    "target": cal.get("target"),
+                    "achieved": cal.get("achieved"),
+                    "note": cal.get("note"),
+                }))
+            } else {
+                None
+            }
+        })
+        .collect();
+
     let mut summary = json!({
         "engine": engine_name,
         "dataset": dataset_name,
+        // Which definitions the quality fields in this file use (#217). Version 2
+        // renamed our `mean_precisions` — the key upstream qdrant/vector-db-benchmark
+        // uses for recall@top — to `mean_precision_at_returned`. A summary WITHOUT
+        // this marker is either one of ours from before the rename (its
+        // `mean_precisions` / `precision_summary` keys are precision-at-returned) or
+        // an upstream file (they are recall@top); the two cannot be told apart, so
+        // they must not be charted on one axis.
+        "metrics_schema_version": 2,
+        "metrics_definitions": {
+            "mean_precision_at_returned": "hits / |deduped results kept (<= top)|",
+            "mean_recall": "hits / |valid, deduped ground-truth ids in expected[:top]|",
+            "precision_summary": "keyed by mean_precision_at_returned buckets",
+            "upstream_qdrant_mean_precisions": "len(ids & expected[:top]) / top — never emitted under that key here",
+        },
         "search_results": search_results,
         "precision_summary": precision_summary,
         "concurrency_curve": concurrency_curve,
+        "uncalibrated_configs": uncalibrated,
     });
 
     if let Some(upload) = upload_json {
@@ -652,6 +694,60 @@ fn create_ascii_scatter_plot(engine_name: &str, dataset_name: &str, buckets: &[P
 mod tests {
     use super::*;
 
+    /// The summary is what `--chart` and external dashboards read, so the #217
+    /// definitions have to travel with it too: no upstream key name, an explicit
+    /// schema version, and any calibration that never reached its target.
+    #[test]
+    fn summary_carries_schema_version_and_unreached_calibrations() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut calibrated = prec_entry(0.24, 100.0, false);
+        calibrated.search_id = 3;
+        calibrated.calibration = Some(json!({
+            "param": "ef", "value": 1000, "target": 0.95, "achieved": 0.24,
+            "reached_target": false, "ground_truth_ceiling": 0.2334,
+            "note": "target precision 0.9500 is above the ceiling this dataset allows",
+        }));
+        let plain = prec_entry(0.90, 500.0, false);
+
+        save_summary(
+            "redis-test",
+            "h-and-m",
+            &[calibrated, plain],
+            None,
+            dir.path(),
+        )
+        .unwrap();
+        let raw = fs::read_to_string(dir.path().join("redis-test-h-and-m-summary.json")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+        assert_eq!(v["metrics_schema_version"], 2);
+        assert!(!raw.contains("\"mean_precisions\""), "{}", raw);
+        assert!(v["search_results"][0]["mean_precision_at_returned"].is_number());
+
+        let un = v["uncalibrated_configs"].as_array().unwrap();
+        assert_eq!(un.len(), 1, "only the unreached target is listed");
+        assert_eq!(un[0]["search_id"], 3);
+        assert_eq!(un[0]["target"], 0.95);
+    }
+
+    #[test]
+    fn summary_without_calibration_lists_no_uncalibrated_configs() {
+        let dir = tempfile::tempdir().unwrap();
+        save_summary(
+            "redis-test",
+            "glove",
+            &[prec_entry(0.99, 100.0, false)],
+            None,
+            dir.path(),
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(dir.path().join("redis-test-glove-summary.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(v["uncalibrated_configs"].as_array().unwrap().is_empty());
+    }
+
     #[test]
     fn test_format_precision_key_low() {
         assert_eq!(format_precision_key(0.50), "0.50");
@@ -685,6 +781,7 @@ mod tests {
                 saturation_reason: sat_reason.to_string(),
                 ..Default::default()
             },
+            calibration: None,
         }
     }
 
@@ -776,6 +873,7 @@ mod tests {
                     p95_time: 0.02,
                     ..Default::default()
                 },
+                calibration: None,
             },
             SearchEntry {
                 search_id: 1,
@@ -788,6 +886,7 @@ mod tests {
                     p95_time: 0.025,
                     ..Default::default()
                 },
+                calibration: None,
             },
         ];
         let buckets = analyze_precision_performance(&entries);
@@ -809,6 +908,7 @@ mod tests {
                 client_saturated: saturated,
                 ..Default::default()
             },
+            calibration: None,
         }
     }
 

--- a/src/bin/vector_db_benchmark/summary.rs
+++ b/src/bin/vector_db_benchmark/summary.rs
@@ -59,13 +59,13 @@ fn analyze_precision_performance(entries: &[SearchEntry]) -> Vec<PrecisionBucket
     let mut buckets: BTreeMap<String, PrecisionBucket> = BTreeMap::new();
 
     for entry in entries {
-        let key = format_precision_key(entry.results.mean_precision);
+        let key = format_precision_key(entry.results.mean_precision_at_returned);
 
         let candidate = PrecisionBucket {
             qps: entry.results.rps,
             p50_ms: entry.results.p50_time * 1000.0,
             p95_ms: entry.results.p95_time * 1000.0,
-            precision: entry.results.mean_precision,
+            precision: entry.results.mean_precision_at_returned,
             recall: entry.results.mean_recall,
             mrr: entry.results.mean_mrr,
             ndcg: entry.results.mean_ndcg,
@@ -139,7 +139,7 @@ fn concurrency_curves(entries: &[SearchEntry]) -> Vec<ConcurrencyCurve> {
     let mut groups: BTreeMap<String, BTreeMap<i64, ConcurrencyPoint>> = BTreeMap::new();
     for e in entries {
         // Filter-only runs have no precision/recall curve to speak of; skip them.
-        if e.results.mean_precision < 0.0 {
+        if e.results.mean_precision_at_returned < 0.0 {
             continue;
         }
         let point = ConcurrencyPoint {
@@ -321,8 +321,10 @@ pub fn display_results_summary(engine_name: &str, dataset_name: &str, entries: &
 
     print_saturation_warnings(entries);
 
-    // Filter-only mode: precision is not applicable (mean_precision == -1.0)
-    let filter_only = entries.iter().all(|e| e.results.mean_precision < 0.0);
+    // Filter-only mode: precision is not applicable (mean_precision_at_returned == -1.0)
+    let filter_only = entries
+        .iter()
+        .all(|e| e.results.mean_precision_at_returned < 0.0);
 
     if filter_only {
         println!("{}", "-".repeat(40));
@@ -431,7 +433,7 @@ pub fn display_mixed_summary(entries: &[SearchEntry]) {
             "{:<14} {:<8.4} {:<8.4} {:<8.4} {:<8.4} {:<10.1} {:<12.3} {:<12.3} {:<10} {:<12}",
             key,
             best.results.mean_recall,
-            best.results.mean_precision,
+            best.results.mean_precision_at_returned,
             best.results.mean_mrr,
             best.results.mean_ndcg,
             best.results.rps,
@@ -495,7 +497,11 @@ pub fn save_summary(
                 "search_id": e.search_id,
                 "ef": e.ef,
                 "parallel": e.parallel,
-                "mean_precisions": e.results.mean_precision,
+                // Not `mean_precisions`: upstream qdrant/vector-db-benchmark
+                // publishes recall@top under that key, and this is precision with
+                // "results returned" as its denominator (#217). See
+                // `metrics_schema` in the per-search result files for the formulas.
+                "mean_precision_at_returned": e.results.mean_precision_at_returned,
                 "mean_recall": e.results.mean_recall,
                 "recall_p10": e.results.recall_p10,
                 "mean_mrr": e.results.mean_mrr,
@@ -764,7 +770,7 @@ mod tests {
                 ef: "64".to_string(),
                 parallel: 100,
                 results: SearchResults {
-                    mean_precision: 0.90,
+                    mean_precision_at_returned: 0.90,
                     rps: 5000.0,
                     p50_time: 0.01,
                     p95_time: 0.02,
@@ -776,7 +782,7 @@ mod tests {
                 ef: "128".to_string(),
                 parallel: 100,
                 results: SearchResults {
-                    mean_precision: 0.91,
+                    mean_precision_at_returned: 0.91,
                     rps: 4000.0,
                     p50_time: 0.012,
                     p95_time: 0.025,
@@ -798,7 +804,7 @@ mod tests {
             ef: "64".to_string(),
             parallel: 1,
             results: SearchResults {
-                mean_precision: precision,
+                mean_precision_at_returned: precision,
                 rps,
                 client_saturated: saturated,
                 ..Default::default()
@@ -973,12 +979,12 @@ mod tests {
 
     #[test]
     fn concurrency_curve_excludes_filter_only_runs() {
-        // Filter-only runs carry mean_precision == -1.0 (sentinel) and have no
+        // Filter-only runs carry mean_precision_at_returned == -1.0 (sentinel) and have no
         // recall/precision curve — they must not appear in the saturation curve.
         let mut a = entry("64", 1, 100.0, 0.01, "");
         let mut b = entry("64", 2, 200.0, 0.01, "");
-        a.results.mean_precision = -1.0;
-        b.results.mean_precision = -1.0;
+        a.results.mean_precision_at_returned = -1.0;
+        b.results.mean_precision_at_returned = -1.0;
         assert!(concurrency_curves(&[a, b]).is_empty());
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,14 +1,64 @@
 //! Retrieval quality metrics: recall@K, precision@K, MRR, NDCG@K.
+//!
+//! # Three different denominators — read this before comparing numbers
+//!
+//! Let `hits = |deduped results[:K] ∩ valid ground-truth ids in expected[:K]|`.
+//! Three quantities are computed from it and they are NOT interchangeable:
+//!
+//! | quantity     | formula                | emitted as                    |
+//! |--------------|------------------------|-------------------------------|
+//! | `precision`  | `hits / |results|`     | `mean_precision_at_returned`  |
+//! | `recall`     | `hits / |valid truth|` | `mean_recall`                 |
+//! | `recall_at_top` | `hits / K`          | (upstream's `mean_precisions`)|
+//!
+//! Upstream `qdrant/vector-db-benchmark` (`engine/base_client/search.py`) computes
+//! `len(ids.intersection(query.expected_result[:top])) / top` — i.e. `recall_at_top`
+//! — and emits it under the JSON key `mean_precisions`. Our `mean_precisions` key
+//! used to carry `precision` instead: the same key name for a different formula.
+//! That key no longer exists in our output (see #217); we emit
+//! `mean_precision_at_returned` and `mean_recall`.
+//!
+//! Worked examples of how far apart they land:
+//!
+//! * Engine asked for `top = 10`, returns only 5 results, all correct, truth has
+//!   10 ids: `precision = 5/5 = 1.00`, `recall = 5/10 = 0.50`,
+//!   `recall_at_top = 5/10 = 0.50`. Upstream reports 0.50 under `mean_precisions`;
+//!   we used to report 1.00 under the same key.
+//! * Filtered query with a single true neighbour, `top = 100`, engine returns 100
+//!   results including that neighbour: `precision = 1/100 = 0.01`,
+//!   `recall = 1/1 = 1.00`, `recall_at_top = 1/100 = 0.01`. Our `recall` and
+//!   upstream's `mean_precisions` diverge by 100x on identical data, because
+//!   upstream always divides by `top` while we divide by the ground truth that
+//!   actually exists.
 
 use std::collections::HashSet;
 
 /// Per-query retrieval quality metrics.
+///
+/// See the module docs for why `precision`, `recall` and `recall_at_top` are
+/// three different numbers and which one upstream calls "precision".
 #[derive(Debug, Clone, Default)]
 pub struct QueryMetrics {
-    /// recall@K: |retrieved ∩ truth_top_K| / K
+    /// recall@K: `hits / |valid, deduped ground-truth ids in expected[:K]|`.
+    ///
+    /// The denominator is the ground truth that actually exists, so a query with
+    /// fewer than K true neighbours can still reach 1.0. This is the field
+    /// emitted as `mean_recall`.
     pub recall: f64,
-    /// precision@K: |retrieved ∩ truth_top_K| / |retrieved|
+    /// precision@K: `hits / |deduped results kept|` (denominator = what the
+    /// engine returned, at most K). Emitted as `mean_precision_at_returned`.
     pub precision: f64,
+    /// recall@top with upstream's denominator: `hits / K`, exactly
+    /// `len(ids & expected[:top]) / top` from upstream's `search.py`.
+    ///
+    /// Provided so the upstream definition has one canonical implementation here
+    /// and so the divergence is pinned by tests. It is not aggregated into the
+    /// results JSON today: every engine harness collects per-query samples into
+    /// its own `Vec<f64>`s, so adding a fifth vector would have to touch all 15
+    /// engines at once. `mean_recall` equals the mean of this field whenever every
+    /// ground-truth row has at least K valid ids — which the emitted
+    /// `metrics_schema.ground_truth` block reports per run.
+    pub recall_at_top: f64,
     /// Mean Reciprocal Rank: 1/rank of the first relevant result
     pub mrr: f64,
     /// Normalized Discounted Cumulative Gain @ K
@@ -25,6 +75,7 @@ pub fn compute_metrics(result_ids_ordered: &[i64], ground_truth: &[i64], k: usiz
         return QueryMetrics {
             recall: 1.0,
             precision: 1.0,
+            recall_at_top: 1.0,
             mrr: 1.0,
             ndcg: 1.0,
         };
@@ -44,11 +95,15 @@ pub fn compute_metrics(result_ids_ordered: &[i64], ground_truth: &[i64], k: usiz
     let truth_count = truth_set.len();
 
     // No valid ground truth (e.g. a filtered query with no matching points):
-    // nothing to retrieve, so this query is not penalized.
+    // nothing to retrieve, so this query is not penalized. Note upstream would
+    // score this query 0 (its denominator is `top` regardless of how much truth
+    // exists); `recall_at_top` follows our not-penalized convention here so the
+    // three fields stay mutually consistent within one run.
     if truth_count == 0 {
         return QueryMetrics {
             recall: 1.0,
             precision: 1.0,
+            recall_at_top: 1.0,
             mrr: 1.0,
             ndcg: 1.0,
         };
@@ -69,12 +124,17 @@ pub fn compute_metrics(result_ids_ordered: &[i64], ground_truth: &[i64], k: usiz
         .filter(|id| truth_set.contains(id))
         .count();
 
+    // Three denominators, three different numbers — see the module docs.
+    //   recall:        the ground truth that actually exists (<= k)
+    //   precision:     what the engine actually returned (<= k)
+    //   recall_at_top: k itself — upstream's `mean_precisions`
     let recall = hits as f64 / truth_count as f64;
     let precision = if results_topk.is_empty() {
         0.0
     } else {
         hits as f64 / results_topk.len() as f64
     };
+    let recall_at_top = hits as f64 / k as f64;
 
     // MRR: 1/rank of the first relevant result within the top K.
     let mrr = results_topk
@@ -107,6 +167,7 @@ pub fn compute_metrics(result_ids_ordered: &[i64], ground_truth: &[i64], k: usiz
     QueryMetrics {
         recall,
         precision,
+        recall_at_top,
         mrr,
         ndcg,
     }
@@ -206,5 +267,91 @@ mod tests {
     fn test_empty_ground_truth_not_penalized() {
         let m = compute_metrics(&[9, 8, 7], &[], 5);
         assert!((m.recall - 1.0).abs() < 1e-9);
+    }
+
+    /// #217 canonical case: engine asked for 10, returns 5, all correct.
+    ///
+    /// Upstream `qdrant/vector-db-benchmark` reports 0.50 under the JSON key
+    /// `mean_precisions` (`len(ids & expected[:top]) / top`). Our precision is
+    /// 1.00 because its denominator is what came back. Both are correct numbers
+    /// for their own definition; publishing them under one key name was the bug.
+    #[test]
+    fn precision_and_upstream_recall_diverge_on_short_result_set() {
+        let results = vec![1, 2, 3, 4, 5]; // only 5 of the 10 requested came back
+        let truth = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let m = compute_metrics(&results, &truth, 10);
+
+        // ours, emitted as `mean_precision_at_returned`: 5 hits / 5 returned
+        assert!(
+            (m.precision - 1.0).abs() < 1e-9,
+            "precision={}",
+            m.precision
+        );
+        // ours, emitted as `mean_recall`: 5 hits / 10 valid truth ids
+        assert!((m.recall - 0.5).abs() < 1e-9, "recall={}", m.recall);
+        // upstream's `mean_precisions`: 5 hits / top=10
+        assert!(
+            (m.recall_at_top - 0.5).abs() < 1e-9,
+            "recall_at_top={}",
+            m.recall_at_top
+        );
+        // The precise 2x gap that made overlaid charts lie.
+        assert!((m.precision / m.recall_at_top - 2.0).abs() < 1e-9);
+    }
+
+    /// #217 second case: ground truth narrower than `top` (filtered/sparse sets).
+    ///
+    /// One true neighbour, `top = 100`, engine returns a full page of 100 that
+    /// contains it. Upstream caps at 1/100; our recall reaches 1.0; our precision
+    /// is also 0.01 — which is why a `calibration_precision: 0.95` target is
+    /// unreachable by construction on such a dataset.
+    #[test]
+    fn short_ground_truth_row_pins_all_three_denominators() {
+        let mut results: Vec<i64> = (1000..1099).collect();
+        results.push(7); // the single true neighbour, last on the page
+        let truth = vec![7];
+        let m = compute_metrics(&results, &truth, 100);
+
+        assert!(
+            (m.precision - 0.01).abs() < 1e-9,
+            "precision={}",
+            m.precision
+        );
+        assert!((m.recall - 1.0).abs() < 1e-9, "recall={}", m.recall);
+        assert!(
+            (m.recall_at_top - 0.01).abs() < 1e-9,
+            "recall_at_top={}",
+            m.recall_at_top
+        );
+        // 100x apart on identical data, on the same query.
+        assert!((m.recall / m.recall_at_top - 100.0).abs() < 1e-6);
+    }
+
+    /// When the ground truth is full width (>= `top` valid ids) and the engine
+    /// returns a full page, all three collapse onto the same number — which is
+    /// why the two tools appeared to agree on standard HDF5 datasets.
+    #[test]
+    fn full_width_ground_truth_makes_all_three_agree() {
+        let results = vec![1, 2, 3, 99, 98];
+        let truth = vec![1, 2, 3, 4, 5];
+        let m = compute_metrics(&results, &truth, 5);
+        assert!((m.precision - 0.6).abs() < 1e-9);
+        assert!((m.recall - 0.6).abs() < 1e-9);
+        assert!((m.recall_at_top - 0.6).abs() < 1e-9);
+    }
+
+    /// Sentinel padding shrinks OUR denominator but never upstream's: upstream
+    /// divides by `top` whether or not the row is padded with `-1`.
+    #[test]
+    fn sentinel_padding_shrinks_only_our_recall_denominator() {
+        let results = vec![1, 2, 9, 8, 7];
+        let truth = vec![1, 2, -1, -1, -1];
+        let m = compute_metrics(&results, &truth, 5);
+        assert!((m.recall - 1.0).abs() < 1e-9, "recall={}", m.recall);
+        assert!(
+            (m.recall_at_top - 0.4).abs() < 1e-9,
+            "recall_at_top={}",
+            m.recall_at_top
+        );
     }
 }

--- a/src/redisearch/search.rs
+++ b/src/redisearch/search.rs
@@ -335,6 +335,12 @@ impl RustRedisSearcher {
             let dict = PyDict::new_bound(py);
             dict.set_item("total_time", total_time)?;
             dict.set_item("mean_time", mean_time)?;
+            // NOTE (#217): this legacy PyO3 accelerator (not part of the Rust
+            // binary and not compiled today) fills Python v0's `mean_precisions`
+            // key with OUR precision (hits / results returned), while pure-Python
+            // v0 fills it with recall@top (hits / top). If this path is ever
+            // revived, feed it `mean_recall` — or rename the key — before any of
+            // its output is compared with upstream numbers.
             dict.set_item("mean_precisions", mean_precision)?;
             dict.set_item("mean_recall", mean_recall)?;
             dict.set_item("mean_mrr", mean_mrr)?;
@@ -542,6 +548,7 @@ fn search_one_rust(
         crate::metrics::QueryMetrics {
             recall: 1.0,
             precision: 1.0,
+            recall_at_top: 1.0,
             mrr: 1.0,
             ndcg: 1.0,
         }

--- a/src/vectorsets/search.rs
+++ b/src/vectorsets/search.rs
@@ -273,6 +273,12 @@ impl RustVsetSearcher {
             let dict = PyDict::new_bound(py);
             dict.set_item("total_time", total_time)?;
             dict.set_item("mean_time", mean_time)?;
+            // NOTE (#217): this legacy PyO3 accelerator (not part of the Rust
+            // binary and not compiled today) fills Python v0's `mean_precisions`
+            // key with OUR precision (hits / results returned), while pure-Python
+            // v0 fills it with recall@top (hits / top). If this path is ever
+            // revived, feed it `mean_recall` — or rename the key — before any of
+            // its output is compared with upstream numbers.
             dict.set_item("mean_precisions", mean_precision)?;
             dict.set_item("mean_recall", mean_recall)?;
             dict.set_item("mean_mrr", mean_mrr)?;
@@ -361,6 +367,7 @@ fn search_one_rust(conn: &mut redis::Connection, query: &RustQuery, ef: i64) -> 
         crate::metrics::QueryMetrics {
             recall: 1.0,
             precision: 1.0,
+            recall_at_top: 1.0,
             mrr: 1.0,
             ndcg: 1.0,
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1457,7 +1457,7 @@ pub fn run_binary_extra(
 
 /// Read the whole `results` object from an engine's search result JSON, so a
 /// test can assert on any field (percentiles, requested/failed_queries,
-/// update_* metrics, the mean_precisions sentinel, …). `engine` is the result
+/// update_* metrics, the mean_precision_at_returned sentinel, …). `engine` is the result
 /// filename prefix — note `--skip-vector-index` renames the engine to
 /// `<engine_type>-no-vector`, so pass that prefix for filter-only runs.
 pub fn read_results_obj(root: &Path, engine: &str) -> serde_json::Value {

--- a/tests/integration_mongodb.rs
+++ b/tests/integration_mongodb.rs
@@ -641,7 +641,7 @@ fn create_test_project(
     root
 }
 
-/// Parse a search result JSON and return mean_precisions
+/// Parse a search result JSON and return mean_precision_at_returned
 fn read_search_precision(results_dir: &PathBuf, engine_name: &str) -> f64 {
     let pattern = format!("{}-*-search-*.json", engine_name);
     let mut found = Vec::new();
@@ -660,9 +660,9 @@ fn read_search_precision(results_dir: &PathBuf, engine_name: &str) -> f64 {
 
     let content = fs::read_to_string(&found[0]).unwrap();
     let result: serde_json::Value = serde_json::from_str(&content).unwrap();
-    result["results"]["mean_precisions"]
+    result["results"]["mean_precision_at_returned"]
         .as_f64()
-        .expect("mean_precisions not found in result JSON")
+        .expect("mean_precision_at_returned not found in result JSON")
 }
 
 /// Brute-force L2 nearest neighbors for building ground truth.
@@ -1047,7 +1047,7 @@ fn test_binary_mongodb_mixed_parallel() {
 
     let r = common::read_results_obj(&proj.root, "mongo-mx");
     let recall = r["mean_recall"].as_f64().unwrap();
-    let precision = r["mean_precisions"].as_f64().unwrap();
+    let precision = r["mean_precision_at_returned"].as_f64().unwrap();
     let update_count = r["update_count"].as_u64().unwrap();
     let update_rps = r["update_rps"].as_f64().unwrap();
     let p50 = r["p50_time"].as_f64().unwrap();
@@ -1072,7 +1072,7 @@ fn test_binary_mongodb_mixed_parallel() {
 /// End-to-end FILTER-ONLY harness (`--skip-vector-index`) at `parallel: 4` with
 /// `--queries 1000`: MongoDB has no `check_commandstats` backstop, so this is the
 /// primary guard that failed `$vectorSearch`/`find` calls are counted (not folded
-/// into RPS/percentiles). Asserts the filter-only sentinel (`mean_precisions ==
+/// into RPS/percentiles). Asserts the filter-only sentinel (`mean_precision_at_returned ==
 /// -1`), full query accounting (requested == succeeded, failed == 0) on a healthy
 /// run, positive RPS, and monotone linear percentiles, with the per-worker sample
 /// buffers merged across threads.
@@ -1114,7 +1114,7 @@ fn test_binary_mongodb_filter_only() {
     );
 
     let r = common::read_results_obj(&proj.root, "mongodb-no-vector");
-    let mp = r["mean_precisions"].as_f64().unwrap();
+    let mp = r["mean_precision_at_returned"].as_f64().unwrap();
     let rps = r["rps"].as_f64().unwrap();
     let p50 = r["p50_time"].as_f64().unwrap();
     let p95 = r["p95_time"].as_f64().unwrap();
@@ -1123,7 +1123,7 @@ fn test_binary_mongodb_filter_only() {
     let succeeded = r["succeeded_queries"].as_u64().unwrap();
     let failed = r["failed_queries"].as_u64().unwrap();
     println!(
-        "mongodb filter-only: mean_precisions={mp} rps={rps:.1} p50={p50} p95={p95} p99={p99} \
+        "mongodb filter-only: mean_precision_at_returned={mp} rps={rps:.1} p50={p50} p95={p95} p99={p99} \
          requested={requested} succeeded={succeeded} failed={failed}"
     );
     assert_eq!(mp, -1.0, "filter-only sentinel lost");

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -530,7 +530,7 @@ fn read_precision(root: &std::path::Path, engine: &str) -> f64 {
         })
         .unwrap_or_else(|| panic!("no search result for {}", engine));
     let v: serde_json::Value = serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
-    v["results"]["mean_precisions"].as_f64().unwrap()
+    v["results"]["mean_precision_at_returned"].as_f64().unwrap()
 }
 
 /// End-to-end via the real engine: a plain search (covers the query_points

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -1413,7 +1413,7 @@ fn binary_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/release/vector-db-benchmark")
 }
 
-/// Parse the search result JSON and return mean_precisions
+/// Parse the search result JSON and return mean_precision_at_returned
 fn read_search_precision(results_dir: &PathBuf, engine_name: &str) -> f64 {
     let pattern = format!("{}-*-search-*.json", engine_name);
     let mut found = Vec::new();
@@ -1433,9 +1433,9 @@ fn read_search_precision(results_dir: &PathBuf, engine_name: &str) -> f64 {
     // Read the first matching result file
     let content = fs::read_to_string(&found[0]).unwrap();
     let result: serde_json::Value = serde_json::from_str(&content).unwrap();
-    result["results"]["mean_precisions"]
+    result["results"]["mean_precision_at_returned"]
         .as_f64()
-        .expect("mean_precisions not found in result JSON")
+        .expect("mean_precision_at_returned not found in result JSON")
 }
 
 #[test]
@@ -2007,7 +2007,7 @@ fn test_binary_redis_mixed_benchmark() {
 /// `search_filter_only`, driven at `parallel: 4` with `--queries 1000` so the
 /// thread-local per-worker latency buffers are genuinely merged across threads
 /// (the join-merge path — the actual rewrite). Asserts the filter-only sentinel
-/// (`mean_precisions == -1`), that every dispatched query is accounted for
+/// (`mean_precision_at_returned == -1`), that every dispatched query is accounted for
 /// (`requested == succeeded`, `failed == 0`) on a healthy run, positive RPS, and
 /// monotone linear percentiles (p50 <= p95 <= p99).
 #[test]
@@ -2042,7 +2042,7 @@ fn test_binary_redis_filter_only() {
 
     // --skip-vector-index renames the engine to "<type>-no-vector".
     let r = common::read_results_obj(&proj.root, "redis-no-vector");
-    let mp = r["mean_precisions"].as_f64().unwrap();
+    let mp = r["mean_precision_at_returned"].as_f64().unwrap();
     let rps = r["rps"].as_f64().unwrap();
     let p50 = r["p50_time"].as_f64().unwrap();
     let p95 = r["p95_time"].as_f64().unwrap();
@@ -2051,7 +2051,7 @@ fn test_binary_redis_filter_only() {
     let succeeded = r["succeeded_queries"].as_u64().unwrap();
     let failed = r["failed_queries"].as_u64().unwrap();
     println!(
-        "redis filter-only: mean_precisions={mp} rps={rps:.1} p50={p50} p95={p95} p99={p99} \
+        "redis filter-only: mean_precision_at_returned={mp} rps={rps:.1} p50={p50} p95={p95} p99={p99} \
          requested={requested} succeeded={succeeded} failed={failed}"
     );
     assert_eq!(mp, -1.0, "filter-only sentinel lost");
@@ -2105,7 +2105,7 @@ fn test_binary_redis_mixed_parallel() {
 
     let r = common::read_results_obj(&proj.root, "redis-mx");
     let recall = r["mean_recall"].as_f64().unwrap();
-    let precision = r["mean_precisions"].as_f64().unwrap();
+    let precision = r["mean_precision_at_returned"].as_f64().unwrap();
     let update_count = r["update_count"].as_u64().unwrap();
     let update_rps = r["update_rps"].as_f64().unwrap();
     let p50 = r["p50_time"].as_f64().unwrap();

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -1201,7 +1201,7 @@ fn test_binary_valkey_match_any_resp3() {
 /// End-to-end FILTER-ONLY harness (`--skip-vector-index`) at `parallel: 4` with
 /// `--queries 1000`, so the per-worker thread-local latency buffers are merged
 /// across threads (the join-merge path). Asserts the filter-only sentinel
-/// (`mean_precisions == -1`), full query accounting (requested == succeeded,
+/// (`mean_precision_at_returned == -1`), full query accounting (requested == succeeded,
 /// failed == 0) on a healthy run, positive RPS, and monotone linear percentiles.
 #[test]
 fn test_binary_valkey_filter_only() {
@@ -1234,7 +1234,7 @@ fn test_binary_valkey_filter_only() {
     );
 
     let r = common::read_results_obj(&proj.root, "valkey-no-vector");
-    let mp = r["mean_precisions"].as_f64().unwrap();
+    let mp = r["mean_precision_at_returned"].as_f64().unwrap();
     let rps = r["rps"].as_f64().unwrap();
     let p50 = r["p50_time"].as_f64().unwrap();
     let p95 = r["p95_time"].as_f64().unwrap();
@@ -1243,7 +1243,7 @@ fn test_binary_valkey_filter_only() {
     let succeeded = r["succeeded_queries"].as_u64().unwrap();
     let failed = r["failed_queries"].as_u64().unwrap();
     println!(
-        "valkey filter-only: mean_precisions={mp} rps={rps:.1} p50={p50} p95={p95} p99={p99} \
+        "valkey filter-only: mean_precision_at_returned={mp} rps={rps:.1} p50={p50} p95={p95} p99={p99} \
          requested={requested} succeeded={succeeded} failed={failed}"
     );
     assert_eq!(mp, -1.0, "filter-only sentinel lost");
@@ -1299,7 +1299,7 @@ fn test_binary_valkey_mixed_benchmark() {
 
     let r = common::read_results_obj(&proj.root, "valkey-mx");
     let recall = r["mean_recall"].as_f64().unwrap();
-    let precision = r["mean_precisions"].as_f64().unwrap();
+    let precision = r["mean_precision_at_returned"].as_f64().unwrap();
     let update_count = r["update_count"].as_u64().unwrap();
     let update_rps = r["update_rps"].as_f64().unwrap();
     let p50 = r["p50_time"].as_f64().unwrap();

--- a/tests/integration_vectorsets.rs
+++ b/tests/integration_vectorsets.rs
@@ -364,7 +364,7 @@ fn test_binary_vectorsets_mixed_benchmark() {
 
     let r = common::read_results_obj(&proj.root, name);
     let recall = r["mean_recall"].as_f64().unwrap();
-    let precision = r["mean_precisions"].as_f64().unwrap();
+    let precision = r["mean_precision_at_returned"].as_f64().unwrap();
     let update_count = r["update_count"].as_u64().unwrap();
     let update_rps = r["update_rps"].as_f64().unwrap();
     let p50 = r["p50_time"].as_f64().unwrap();

--- a/v0/tools/upload_results_postgres.sh
+++ b/v0/tools/upload_results_postgres.sh
@@ -52,7 +52,12 @@ if [[ -z "$ROOT_API_RESPONSE_FILE" ]]; then
 fi
 
 RPS=$(jq -r '.results.rps' "$SEARCH_RESULTS_FILE")
-MEAN_PRECISIONS=$(jq -r '.results.mean_precisions' "$SEARCH_RESULTS_FILE")
+# Python v0 stores recall@top (len(ids & expected[:top]) / top) under
+# `mean_precisions`. Rust result files (schema version 2, #217) do not use that
+# key at all: `mean_recall` is the same quantity, while
+# `mean_precision_at_returned` is a different one (denominator = results
+# returned) and must NOT be loaded into this column.
+MEAN_PRECISIONS=$(jq -r '.results.mean_precisions // .results.mean_recall' "$SEARCH_RESULTS_FILE")
 P95_TIME=$(jq -r '.results.p95_time' "$SEARCH_RESULTS_FILE")
 P99_TIME=$(jq -r '.results.p99_time' "$SEARCH_RESULTS_FILE")
 


### PR DESCRIPTION
Closes #217.

## The bug

Our results JSON emitted `"mean_precisions"` carrying `results.mean_precision` = `hits / |results returned|`. Upstream `qdrant/vector-db-benchmark` (`engine/base_client/search.py:49-52`) emits a key of the **same name** defined as `len(ids & expected[:top]) / top` — recall@top, which is our `mean_recall`.

An engine returning 5 of 10 requested results, all correct, reported `mean_precisions = 0.50` upstream and `1.00` here. The shared key name actively invites overlaying the two tools' files on one chart, which silently compared precision against recall.

## Rename, not dual-emit — and why

The issue offers "rename" and/or "additionally emit an upstream-compatible `recall_at_top`". This PR renames, and deliberately does **not** keep `mean_precisions` alive:

1. **Keeping the name is the one option ruled out.** Any variant that keeps emitting `mean_precisions` — with either definition — leaves a key that means two things across the two tools. Re-pointing it at recall@top would be worse: our own historical files would then hold two different quantities under one name.
2. **A true `mean_recall_at_top` aggregate cannot be added without breaking the query→ground-truth pairing.** There *appears* to be a free derivation: `recall_at_top_i = recall_i · t_i / k`, reusing the per-query `results.recalls` we already keep and the per-row truth widths `t_i` that `GroundTruthProfile` already loads. It does not work, and the reason is structural rather than cosmetic: every engine's parallel harness pulls query indices off a shared atomic counter and merges per-thread sample buffers **in thread-join order** (e.g. `redis.rs:2416-2424`). `recalls[j]` therefore has no correspondence to ground-truth row `j` — the pairing is destroyed before aggregation. Recovering it means either re-keying every engine's sample buffers by query index or threading a fifth per-query vector through all 15 harnesses, two of which (`elasticsearch.rs`, `opensearch.rs`) are frozen behind PRs #246 and #248.

So instead: the upstream formula gets one canonical, test-pinned implementation (`QueryMetrics::recall_at_top` in `src/metrics.rs`), and **every result file names the field that IS upstream's number**, when one is. `comparable_to_upstream_mean_precisions: "mean_recall"` is not a hint that the two are similar — it asserts that our `mean_recall` and upstream's `mean_precisions` are the same quantity computed the same way for this dataset and `top`, and may be overlaid directly. It is `null` exactly when no field in the file can be.

## Emitted key changes (schema version 2)

| before | after | definition |
|---|---|---|
| `results.mean_precisions` | `results.mean_precision_at_returned` | `hits / \|deduped results kept\|` |
| `results.precisions` (only under `--dump-raw-latencies`) | `results.precisions_at_returned` | per-query array of the above |
| `results.precision_dist` | `results.precision_at_returned_dist` | digest of that array |
| — | `metrics_schema` (new, top-level) | formulas + ground-truth width profile + `comparable_to_upstream_mean_precisions` |
| — | `params.calibration` (new, when calibrating) | param, target, achieved, `reached_target`, ceiling, note |

`mean_recall`, `recall_p10`, `recall_dist`, `mrr`/`ndcg` and every timing field are unchanged. Summary files rename the same key inside `search_results[]` and additionally carry `metrics_schema_version: 2`, `metrics_definitions`, and `uncalibrated_configs`.

## Which published numbers are affected, and what stops being comparable

- **No measured value changes.** `mean_precision_at_returned` is bit-for-bit the number that used to be called `mean_precisions`; the filter-only `-1.0` sentinel is unchanged. Nothing about how any engine is measured moved.
- **Every previously published `mean_precisions` value was precision, not recall@top.** Any chart, table or dashboard that put our `mean_precisions` on the same axis as upstream's (or Python v0's) was comparing precision to recall. Where the ground truth is full width and the engine returned a full page, the two coincide numerically, so most published dense-benchmark curves are unaffected in value. Where they diverge — short/filtered ground truth, or engines returning fewer than `top` — the old overlays were wrong and re-reading them against `mean_recall` is the fix.
- **Old result files stay readable but need a mapping**: their `mean_precisions` is today's `mean_precision_at_returned`. `--chart` handles this itself (`plot.rs` reads the new key, falling back to the legacy one, and warns when a summary lacks `metrics_schema_version` because our pre-v2 files and upstream's files are then indistinguishable). Any external SQL/notebook selecting `results.mean_precisions` from *new* files gets NULL and must be pointed at `mean_precision_at_returned` — or at `mean_recall`, if what it wanted was the upstream-comparable quantity.
- **`v0/tools/upload_results_postgres.sh`** loads `.results.mean_precisions` into a `mean_precisions` column; it now falls back to `.results.mean_recall` for Rust files, which is the quantity that column has always held for Python v0 rows. Rows previously loaded from *Rust* files into that column held precision and are not comparable with the Python-loaded rows.
- **`scripts/v0_check.sh`** compared Python `mean_precisions` against Rust `mean_precisions` — i.e. recall against precision. It now maps to Rust `mean_recall`. It passed only because its datasets have full-width ground truth.

## Calibrator (second half of the issue) — and no, the shipped calibrations are not fiction

`calibrate()` binary-searches on `mean_precision_at_returned`, whose denominator is results returned. On a dataset whose ground truth is narrower than `top`, the metric is hard-capped and the target is unreachable no matter how high `ef` goes — the sweep walked `ef` to the 1000 bound and printed `Calibrated ef=1000 → precision=0.24` as if it had succeeded.

**Are any shipped/published calibration numbers actually affected? No — verified, not assumed.** Only two shipped configs set `calibration_precision` (both 0.95 at `"top": 100`): `cohere-calibration.json` and `dbpedia-calibration.json`. Both were profiled directly from the real dataset files:

| dataset | queries × neighbours | width | ceiling @ top=100 |
|---|---|---|---|
| `cohere-768-1M` (full 2.9 GB download, decompressed) | 10,000 × 100 | all rows full | **1.000000** |
| `dbpedia-openai-1M-{512,1024,1536,2048,3072}-angular` (HDF5 `neighbors` read over HTTP range requests, ~3 MB each) | 1,000 × 100 | all rows full, all five variants | **1.000000** |

So a 0.95 target is fully reachable on both, and **no published `cohere-cal-*` / `dbpedia-cal-*` number is a fake calibration**. The suspicion that the base DBpedia HDF5 lacked 100 neighbours (raised because a separate `dbpedia-openai-1M-1536-angular-100neighbors` entry exists) is disproved: the base file has 1000×100 full-width ground truth; the `-100neighbors` entry is a different packaging (`tar`), not a repair.

The h-and-m case is therefore a **latent trap that no shipped config currently steps in**, not evidence of a fake published number. It is still worse than hypothetical, in two ways:

- On the shipped `h-and-m-2048-angular/hnm/tests.jsonl`, **all 10,000 rows are narrower than 100** (931 narrower than 25; min 1, max 25), so at `top: 100` the ceiling is **0.2334** — and no shipped config pairs h-and-m with calibration only because none happens to.
- At h-and-m's *natural* `top: 25` (every other shipped config leaves `top` unset, so it is derived from the ground-truth row width) the ceiling is **0.9337** — still below 0.95. Any 0.95 calibration on h-and-m is unreachable at either `top`. It only becomes reachable at `top: 10`, where the ceiling is 0.9592.

What the code now does:
- the ground-truth width profile is computed once per experiment (`ground_truth.rs`) and the target is bounded against it **before** the first search, printing the full arithmetic when it is unreachable;
- on termination, a target that was not met prints a second warning naming the achieved value and whether the knob was pinned at the maximum swept value;
- the same warning is **repeated at the end of the run** (the up-front one is ~10 sweep iterations of scrollback away by then) and recorded in both `params.calibration.reached_target` per search file and `uncalibrated_configs` in the summary — so a CI sweep that "calibrated" against an unreachable target no longer exits 0 with a silent artifact.

The ceiling is treated as a warning, not a hard error: a filtered query that legitimately returns fewer than `top` results can score above it, so failing the run would break valid filtered-dataset calibrations. A `--fail-on-uncalibrated` gate (mirroring `--fail-on-dropped-queries`) is a reasonable follow-up but is not in this PR.

## Documentation correctness

`README.md` claimed both H&M-2048 rows have **100** neighbours per query and 2,000 test queries. Measured on the shipped files:

| dataset | test queries | ground-truth width |
|---|---|---|
| `h-and-m-2048-angular-filters` | 10,000 | **1 to 25**, mean 23.4 (931 queries below 25) |
| `h-and-m-2048-angular-no-filters` | 10,000 | **10**, uniform |

Neither is 100, and neither is 2,000 queries. That false line is exactly the belief that produced this bug, so it is corrected here — with a footnote explaining that the column bounds what recall can mean — rather than left to outlive the fix.

## Performance

`GroundTruthProfile::load` is skipped when nothing consumes it (`--skip-search`, filter-only runs). Otherwise an upload-only run would pay a full query-file parse per config — on the compound h-and-m dataset that parses every 2048-dim query vector only to drop it (~22 s warm / ~137 s cold per config; a 12-config sweep pays it twelve times). It is not inside any timed window, but it was a real `--skip-search` regression.

## Tests

- `src/metrics.rs`: the canonical 5-of-10 case (precision 1.00 / recall 0.50 / upstream 0.50), a short-ground-truth row (`top=100`, one true neighbour: 0.01 / 1.00 / 0.01 — a 100x split on identical data), the full-width case where all three agree, and sentinel padding shrinking only our denominator.
- `src/bin/vector_db_benchmark/ground_truth.rs`: width profiling, ceiling arithmetic, dedup/sentinel handling, unreachable-target detection (NaN excluded, `+inf` still flagged).
- `src/bin/vector_db_benchmark/experiment.rs`: the emitted document must not contain `mean_precisions`, `precisions` or `precision_dist`; must contain the new names, `metrics_schema` and the calibration block; calibration outcomes reported both ways.
- `src/bin/vector_db_benchmark/summary.rs`: summaries carry `metrics_schema_version: 2`, no upstream key name, and list only genuinely unreached calibrations.
- `plot.rs`: legacy `mean_precisions` summaries still chart, and the new key wins when both are present.

`cargo test --lib --bins` (694 + 98 + 2 pass), `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean. `elasticsearch.rs` and `opensearch.rs` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
