### PR TITLE
fix(harness): thread-spawn failure and worker panics deadlocked the search start barrier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,13 @@ jobs:
       # job smoke-tests, now in the blocking suite.
       run: cargo test --test integration_cli --release
 
+    - name: Run measurement-overhead invariants (no container)
+      # `--lib --bins` does NOT build `tests/*.rs` integration targets, and no
+      # job named this one, so INV-2/INV-3 — the source-shape tripwires that
+      # keep the per-query timed loops lock-free and the percentiles unbiased —
+      # had never run in CI. INV-4/INV-4b (#214) join them here.
+      run: cargo test --test overhead_invariants --release
+
   integration-redis:
     name: Integration tests (Redis)
     runs-on: ubuntu-latest

--- a/src/bin/vector_db_benchmark/engine/chroma.rs
+++ b/src/bin/vector_db_benchmark/engine/chroma.rs
@@ -24,6 +24,7 @@ use crate::dataset::Dataset;
 use crate::engine::{Engine, SearchResults, UploadStats};
 use vector_db_benchmark::parsers::datetime_to_epoch_secs;
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
+use vector_db_benchmark::start_gate::WorkerPool;
 
 const DEFAULT_COLLECTION: &str = "benchmark";
 
@@ -666,16 +667,13 @@ impl Engine for ChromaEngine {
         let query_idx = Arc::new(AtomicUsize::new(0));
         let pb = self.progress_bar(num_to_run);
 
-        // Barrier-synchronized start so per-worker HTTP client construction AND the
-        // cold first query fall OUTSIDE the measured window (mirrors redis/vertex).
-        // Every worker builds its client + primes, then blocks on `ready`; the main
-        // thread stamps the shared start instant into `start_cell` and releases `go`,
-        // so the measurement clock starts only once all workers are warm. A worker
-        // that fails to build its client MUST still pass both barriers before
-        // returning, or the run would deadlock.
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // Gate-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window. Every worker connects + primes, then
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant and
+        // releases everyone, so the measurement clock starts only once all workers
+        // are warm and poised. The gate is count-agnostic: a worker that fails to
+        // set up, panics, or is never started by the OS settles its ticket and turns
+        // the run into a hard error instead of a hang (#214).
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -685,8 +683,8 @@ impl Engine for ChromaEngine {
 
         let query_url = format!("{}/collections/{}/query", self.api_base, self.collection_id);
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "chroma-search");
             for _ in 0..parallel {
                 let query_url = query_url.clone();
                 let timeout = self.timeout;
@@ -694,11 +692,10 @@ impl Engine for ChromaEngine {
                 let tops = &tops;
                 let bodies = &bodies;
                 let query_idx = Arc::clone(&query_idx);
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
+                let ticket = pool.ticket();
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -710,10 +707,11 @@ impl Engine for ChromaEngine {
                         .build()
                     {
                         Ok(c) => c,
-                        Err(_) => {
-                            // Still cross both barriers so peers aren't stranded.
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("chroma-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -732,10 +730,11 @@ impl Engine for ChromaEngine {
                             .and_then(|resp| resp.text());
                     }
 
-                    // Signal "ready + primed", then block until the main thread stamps
+                    // Signal "ready + primed", then block until the coordinator stamps
                     // the shared measurement start and releases everyone.
-                    ready.wait();
-                    go.wait();
+                    if ticket.arrive_and_wait().is_none() {
+                        return (t, p, r, mr, nd);
+                    }
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -779,33 +778,27 @@ impl Engine for ChromaEngine {
                         pb.inc(1);
                     }
                     (t, p, r, mr, nd)
-                }));
+                })?;
             }
 
-            // All workers spawned: wait until every one has built its client and
-            // primed, stamp the shared measurement start, then release them together.
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // Every worker is connected + primed and parked at the gate.
+            // Stamp the shared measurement start and release them together.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+            for (t, p, r, mr, nd) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrr_vals.extend(mr);
                 ndcg_vals.extend(nd);
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
         // total_time excludes connection setup and the cold first query: it is
-        // measured from the barrier release (start_cell), not a pre-scope instant.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        // measured from the gate release, not a pre-scope instant.
+        let total_time = measured_start.elapsed().as_secs_f64();
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(
             &times, &precs, &recs, &mrr_vals, &ndcg_vals, total_time, top, parallel, num_to_run,

--- a/src/bin/vector_db_benchmark/engine/chroma.rs
+++ b/src/bin/vector_db_benchmark/engine/chroma.rs
@@ -684,7 +684,7 @@ impl Engine for ChromaEngine {
         let query_url = format!("{}/collections/{}/query", self.api_base, self.collection_id);
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "chroma-search");
+            let mut pool = WorkerPool::new(s, "chroma-search", parallel);
             for _ in 0..parallel {
                 let query_url = query_url.clone();
                 let timeout = self.timeout;
@@ -692,10 +692,9 @@ impl Engine for ChromaEngine {
                 let tops = &tops;
                 let bodies = &bodies;
                 let query_idx = Arc::clone(&query_idx);
-                let ticket = pool.ticket();
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/dragonfly.rs
+++ b/src/bin/vector_db_benchmark/engine/dragonfly.rs
@@ -52,6 +52,7 @@ use crate::engine::{Engine, SearchResults, UploadStats};
 use crate::metrics::compute_metrics;
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, doc_key_to_id, doc_key_to_id_opt};
 use vector_db_benchmark::readers::metadata::MetadataItem;
+use vector_db_benchmark::start_gate::WorkerPool;
 
 /// Dragonfly engine configuration.
 #[derive(Clone)]
@@ -1015,16 +1016,13 @@ impl Engine for DragonflyEngine {
 
         let pb = self.create_progress_bar(num_to_run);
 
-        // Barrier-synchronized start so connection setup AND the cold first query
-        // fall OUTSIDE the measured window (mirrors redis.rs/vertex.rs). Every
-        // worker connects + primes, then blocks on `ready`; the main thread stamps
-        // the shared start instant into `start_cell` and releases `go`, so the
-        // measurement clock starts only once all workers are warm and poised. A
-        // worker that fails to connect MUST still pass both barriers before
-        // returning, or the run would deadlock.
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // Gate-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window. Every worker connects + primes, then
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant and
+        // releases everyone, so the measurement clock starts only once all workers
+        // are warm and poised. The gate is count-agnostic: a worker that fails to
+        // set up, panics, or is never started by the OS settles its ticket and turns
+        // the run into a hard error instead of a hang (#214).
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -1032,8 +1030,8 @@ impl Engine for DragonflyEngine {
         let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "dragonfly-search");
             for _ in 0..parallel {
                 let host = self.host.clone();
                 let port = self.port;
@@ -1044,11 +1042,10 @@ impl Engine for DragonflyEngine {
                 let algorithm = algorithm.as_str();
                 let index_name = index_name.as_str();
                 let query_idx = Arc::clone(&query_idx);
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
+                let ticket = pool.ticket();
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -1058,10 +1055,11 @@ impl Engine for DragonflyEngine {
 
                     let mut conn = match DragonflyEngine::connect(&host, port) {
                         Ok(c) => c,
-                        Err(_) => {
-                            // Still cross both barriers so peers aren't stranded.
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("dragonfly-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -1084,10 +1082,11 @@ impl Engine for DragonflyEngine {
                         );
                     }
 
-                    // Signal "connected + primed", then block until the main thread
+                    // Signal "connected + primed", then block until the coordinator
                     // stamps the shared measurement start and releases everyone.
-                    ready.wait();
-                    go.wait();
+                    if ticket.arrive_and_wait().is_none() {
+                        return (t, p, r, mr, nd);
+                    }
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1145,32 +1144,26 @@ impl Engine for DragonflyEngine {
                         pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd)
-                }));
+                })?;
             }
 
-            // All workers are connected + primed once they clear `ready`; stamp the
-            // shared measurement start and release them together via `go`.
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // Every worker is connected + primed and parked at the gate.
+            // Stamp the shared measurement start and release them together.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+            for (t, p, r, mr, nd) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrr_vals.extend(mr);
                 ndcg_vals.extend(nd);
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
         // total_time excludes connection setup and the cold first query.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         if times.is_empty() {
             return Err("No searches completed".to_string());

--- a/src/bin/vector_db_benchmark/engine/dragonfly.rs
+++ b/src/bin/vector_db_benchmark/engine/dragonfly.rs
@@ -1031,7 +1031,7 @@ impl Engine for DragonflyEngine {
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "dragonfly-search");
+            let mut pool = WorkerPool::new(s, "dragonfly-search", parallel);
             for _ in 0..parallel {
                 let host = self.host.clone();
                 let port = self.port;
@@ -1042,10 +1042,9 @@ impl Engine for DragonflyEngine {
                 let algorithm = algorithm.as_str();
                 let index_name = index_name.as_str();
                 let query_idx = Arc::clone(&query_idx);
-                let ticket = pool.ticket();
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -1059,7 +1059,7 @@ impl Engine for ElasticsearchEngine {
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "elasticsearch-search");
+            let mut pool = WorkerPool::new(s, "elasticsearch-search", parallel);
             for _ in 0..parallel {
                 let base_url = base_url.clone();
                 let index_name = index_name.clone();
@@ -1067,10 +1067,9 @@ impl Engine for ElasticsearchEngine {
                 let tops = &tops;
                 let raw_bodies = &raw_bodies;
                 let query_idx = Arc::clone(&query_idx);
-                let ticket = pool.ticket();
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -15,6 +15,7 @@ use elasticsearch::params::WaitForStatus;
 use elasticsearch::{BulkParts, Elasticsearch, SearchParts};
 use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 use uuid::Uuid;
+use vector_db_benchmark::start_gate::WorkerPool;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
@@ -1043,17 +1044,13 @@ impl Engine for ElasticsearchEngine {
         let timeout = self.timeout;
         let index_name = self.index_name.clone();
 
-        // Barrier-synchronized start so connection setup AND the cold first query
-        // fall OUTSIDE the measured window (mirrors redis/vertex). Every worker
-        // builds its runtime + client and primes ONE discarded query, then blocks
-        // on `ready`; the main thread stamps the shared start instant into
-        // `start_cell` and releases `go`, so the measurement clock starts only once
-        // all workers are warm and poised. A worker that fails to build its runtime
-        // or client MUST still pass both barriers before returning, or the run
-        // would deadlock.
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // Gate-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window. Every worker connects + primes, then
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant and
+        // releases everyone, so the measurement clock starts only once all workers
+        // are warm and poised. The gate is count-agnostic: a worker that fails to
+        // set up, panics, or is never started by the OS settles its ticket and turns
+        // the run into a hard error instead of a hang (#214).
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -1061,8 +1058,8 @@ impl Engine for ElasticsearchEngine {
         let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "elasticsearch-search");
             for _ in 0..parallel {
                 let base_url = base_url.clone();
                 let index_name = index_name.clone();
@@ -1070,11 +1067,10 @@ impl Engine for ElasticsearchEngine {
                 let tops = &tops;
                 let raw_bodies = &raw_bodies;
                 let query_idx = Arc::clone(&query_idx);
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
+                let ticket = pool.ticket();
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -1086,18 +1082,21 @@ impl Engine for ElasticsearchEngine {
                         .build()
                     {
                         Ok(rt) => rt,
-                        Err(_) => {
-                            // Still cross both barriers so peers aren't stranded.
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("elasticsearch-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
                     let client = match create_es_client(&base_url, timeout) {
                         Ok(c) => c,
-                        Err(_) => {
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("elasticsearch-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -1109,10 +1108,11 @@ impl Engine for ElasticsearchEngine {
                         let _ = knn_send(&rt, &client, &index_name, &raw_bodies[0]);
                     }
 
-                    // Signal "connected + primed", then block until the main thread
+                    // Signal "connected + primed", then block until the coordinator
                     // stamps the shared measurement start and releases everyone.
-                    ready.wait();
-                    go.wait();
+                    if ticket.arrive_and_wait().is_none() {
+                        return (t, p, r, mr, nd);
+                    }
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1151,33 +1151,27 @@ impl Engine for ElasticsearchEngine {
                         pb.inc(1);
                     }
                     (t, p, r, mr, nd)
-                }));
+                })?;
             }
 
-            // All workers are spawned; wait until each is connected + primed, then
-            // stamp the shared measurement start and release everyone at once.
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // Every worker is connected + primed and parked at the gate.
+            // Stamp the shared measurement start and release them together.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+            for (t, p, r, mr, nd) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrr_vals.extend(mr);
                 ndcg_vals.extend(nd);
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
         // total_time excludes connection setup and the cold first query — it is
-        // measured from the barrier release stamped into start_cell.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        // measured from the gate release stamp.
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/kividb.rs
+++ b/src/bin/vector_db_benchmark/engine/kividb.rs
@@ -73,6 +73,7 @@ use crate::engine::{Engine, SearchResults, UploadStats};
 use crate::metrics::compute_metrics;
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, doc_key_to_id, doc_key_to_id_opt};
 use vector_db_benchmark::readers::metadata::{is_multivalued_keyword_field, MetadataItem};
+use vector_db_benchmark::start_gate::WorkerPool;
 
 /// KiviDB engine configuration.
 #[derive(Clone)]
@@ -2158,11 +2159,13 @@ impl Engine for KividbEngine {
 
         let pb = self.create_progress_bar(num_to_run);
 
-        // Barrier-synchronized start so connection setup AND the cold first query
-        // fall OUTSIDE the measured window (mirrors redis.rs/dragonfly.rs).
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // Gate-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window. Every worker connects + primes, then
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant and
+        // releases everyone, so the measurement clock starts only once all workers
+        // are warm and poised. The gate is count-agnostic: a worker that fails to
+        // set up, panics, or is never started by the OS settles its ticket and turns
+        // the run into a hard error instead of a hang (#214).
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -2170,8 +2173,8 @@ impl Engine for KividbEngine {
         let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "kividb-search");
             for _ in 0..parallel {
                 let host = self.host.clone();
                 let port = self.port;
@@ -2181,11 +2184,10 @@ impl Engine for KividbEngine {
                 let algorithm = algorithm.as_str();
                 let index_name = index_name.as_str();
                 let query_idx = Arc::clone(&query_idx);
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
+                let ticket = pool.ticket();
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -2195,9 +2197,11 @@ impl Engine for KividbEngine {
 
                     let mut conn = match KividbEngine::connect(&host, port) {
                         Ok(c) => c,
-                        Err(_) => {
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("kividb-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -2218,8 +2222,9 @@ impl Engine for KividbEngine {
                         );
                     }
 
-                    ready.wait();
-                    go.wait();
+                    if ticket.arrive_and_wait().is_none() {
+                        return (t, p, r, mr, nd);
+                    }
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -2274,29 +2279,25 @@ impl Engine for KividbEngine {
                         pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd)
-                }));
+                })?;
             }
 
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // Every worker is connected + primed and parked at the gate.
+            // Stamp the shared measurement start and release them together.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+            for (t, p, r, mr, nd) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrr_vals.extend(mr);
                 ndcg_vals.extend(nd);
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         if times.is_empty() {
             return Err("No searches completed".to_string());

--- a/src/bin/vector_db_benchmark/engine/kividb.rs
+++ b/src/bin/vector_db_benchmark/engine/kividb.rs
@@ -2174,7 +2174,7 @@ impl Engine for KividbEngine {
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "kividb-search");
+            let mut pool = WorkerPool::new(s, "kividb-search", parallel);
             for _ in 0..parallel {
                 let host = self.host.clone();
                 let port = self.port;
@@ -2184,10 +2184,9 @@ impl Engine for KividbEngine {
                 let algorithm = algorithm.as_str();
                 let index_name = index_name.as_str();
                 let query_idx = Arc::clone(&query_idx);
-                let ticket = pool.ticket();
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -1532,7 +1532,7 @@ impl Engine for MilvusEngine {
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "milvus-search");
+            let mut pool = WorkerPool::new(s, "milvus-search", parallel);
             for _ in 0..parallel {
                 let base_url = self.base_url.clone();
                 let timeout = self.timeout;
@@ -1540,10 +1540,9 @@ impl Engine for MilvusEngine {
                 let tops = &tops;
                 let bodies = &bodies;
                 let query_idx = Arc::clone(&query_idx);
-                let ticket = pool.ticket();
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -16,6 +16,7 @@ use crate::dataset::Dataset;
 use crate::engine::{Engine, SearchResults, UploadStats};
 use vector_db_benchmark::parsers::datetime_to_epoch_secs;
 use vector_db_benchmark::readers::metadata::{is_multivalued_keyword_field, MetadataItem};
+use vector_db_benchmark::start_gate::WorkerPool;
 
 const DEFAULT_COLLECTION: &str = "Benchmark";
 
@@ -1516,16 +1517,13 @@ impl Engine for MilvusEngine {
 
         let pb = self.create_progress_bar(num_to_run);
 
-        // Barrier-synchronized start so connection setup AND the cold first query
-        // fall OUTSIDE the measured window (mirrors the Redis/Vertex engines).
-        // Every worker builds its client + primes one discarded query, then blocks
-        // on `ready`; the main thread stamps the shared start instant into
-        // `start_cell` and releases `go`, so the measurement clock starts only once
-        // all workers are warm and poised. A worker that fails to build its client
-        // MUST still pass both barriers before returning, or the run deadlocks.
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // Gate-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window. Every worker connects + primes, then
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant and
+        // releases everyone, so the measurement clock starts only once all workers
+        // are warm and poised. The gate is count-agnostic: a worker that fails to
+        // set up, panics, or is never started by the OS settles its ticket and turns
+        // the run into a hard error instead of a hang (#214).
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -1533,8 +1531,8 @@ impl Engine for MilvusEngine {
         let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "milvus-search");
             for _ in 0..parallel {
                 let base_url = self.base_url.clone();
                 let timeout = self.timeout;
@@ -1542,12 +1540,10 @@ impl Engine for MilvusEngine {
                 let tops = &tops;
                 let bodies = &bodies;
                 let query_idx = Arc::clone(&query_idx);
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
-                let start_cell = Arc::clone(&start_cell);
+                let ticket = pool.ticket();
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -1559,10 +1555,11 @@ impl Engine for MilvusEngine {
                         .build()
                     {
                         Ok(c) => c,
-                        Err(_) => {
-                            // Still cross both barriers so peers aren't stranded.
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("milvus-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -1574,11 +1571,11 @@ impl Engine for MilvusEngine {
                         let _ = send_search(&client, &base_url, &bodies[0]);
                     }
 
-                    // Signal "connected + primed", then block until the main thread
+                    // Signal "connected + primed", then block until the coordinator
                     // stamps the shared measurement start and releases everyone.
-                    ready.wait();
-                    go.wait();
-                    let _start_time = *start_cell.get().unwrap();
+                    let Some(_start_time) = ticket.arrive_and_wait() else {
+                        return (t, p, r, mr, nd);
+                    };
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1617,34 +1614,27 @@ impl Engine for MilvusEngine {
                         pb.inc(1);
                     }
                     (t, p, r, mr, nd)
-                }));
+                })?;
             }
 
-            // All workers are spawned; wait until each has connected + primed,
-            // then stamp the shared start instant and release them together so the
-            // measurement clock excludes connection setup and the cold first query.
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // Every worker is connected + primed and parked at the gate.
+            // Stamp the shared measurement start and release them together.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+            for (t, p, r, mr, nd) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrr_vals.extend(mr);
                 ndcg_vals.extend(nd);
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
         // total_time excludes connection setup and the cold first query: it is
-        // measured from the barrier release stamped into `start_cell`.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        // measured from the gate release stamp.
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -1410,7 +1410,7 @@ impl Engine for MongoDBEngine {
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "mongodb-search");
+            let mut pool = WorkerPool::new(s, "mongodb-search", parallel);
             for _ in 0..parallel {
                 let uri = uri.clone();
                 let db_name = db_name.clone();
@@ -1419,10 +1419,9 @@ impl Engine for MongoDBEngine {
                 let tops = &tops;
                 let pipelines = &pipelines;
                 let query_idx = Arc::clone(&query_idx);
-                let ticket = pool.ticket();
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -18,6 +18,7 @@ use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::{Engine, SearchResults, UpdateSearchRatio, UploadStats};
 use vector_db_benchmark::readers::metadata::MetadataItem;
+use vector_db_benchmark::start_gate::WorkerPool;
 
 const DEFAULT_DB: &str = "bench";
 const DEFAULT_COLLECTION: &str = "vectors";
@@ -1390,16 +1391,13 @@ impl Engine for MongoDBEngine {
 
         let pb = self.create_progress_bar(num_to_run);
 
-        // Barrier-synchronized start so connection setup AND the cold first query
-        // fall OUTSIDE the measured window (mirrors the Redis/Vertex engines).
-        // Every worker connects + primes, then blocks on `ready`; the main thread
-        // stamps the shared start instant into `start_cell` and releases `go`, so
-        // the measurement clock starts only once all workers are warm and poised.
-        // A worker that fails to connect MUST still pass both barriers before
-        // returning, or the run would deadlock.
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // Gate-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window. Every worker connects + primes, then
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant and
+        // releases everyone, so the measurement clock starts only once all workers
+        // are warm and poised. The gate is count-agnostic: a worker that fails to
+        // set up, panics, or is never started by the OS settles its ticket and turns
+        // the run into a hard error instead of a hang (#214).
 
         let uri = self.uri.clone();
         let db_name = self.db_name.clone();
@@ -1411,8 +1409,8 @@ impl Engine for MongoDBEngine {
         let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "mongodb-search");
             for _ in 0..parallel {
                 let uri = uri.clone();
                 let db_name = db_name.clone();
@@ -1421,12 +1419,10 @@ impl Engine for MongoDBEngine {
                 let tops = &tops;
                 let pipelines = &pipelines;
                 let query_idx = Arc::clone(&query_idx);
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
-                let start_cell = Arc::clone(&start_cell);
+                let ticket = pool.ticket();
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -1436,10 +1432,11 @@ impl Engine for MongoDBEngine {
 
                     let client = match Client::with_uri_str(&uri) {
                         Ok(c) => c,
-                        Err(_) => {
-                            // Still cross both barriers so peers aren't stranded.
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("mongodb-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -1454,11 +1451,11 @@ impl Engine for MongoDBEngine {
                         let _ = send_search(&coll, prime_pipeline);
                     }
 
-                    // Signal "connected + primed", then block until the main thread
+                    // Signal "connected + primed", then block until the coordinator
                     // stamps the shared measurement start and releases everyone.
-                    ready.wait();
-                    go.wait();
-                    let _start_time = *start_cell.get().unwrap();
+                    let Some(_start_time) = ticket.arrive_and_wait() else {
+                        return (t, p, r, mr, nd);
+                    };
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1507,33 +1504,26 @@ impl Engine for MongoDBEngine {
                         pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd)
-                }));
+                })?;
             }
 
-            // All workers are connected + primed and waiting on `ready`. Stamp the
-            // shared start instant, then release everyone via `go` so the measured
-            // window excludes connection setup and the cold first query.
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // Every worker is connected + primed and parked at the gate.
+            // Stamp the shared measurement start and release them together.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+            for (t, p, r, mr, nd) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrr_vals.extend(mr);
                 ndcg_vals.extend(nd);
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
         // total_time excludes connection setup and the cold first query.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -16,6 +16,7 @@ use opensearch::indices::{
 };
 use opensearch::{BulkParts, OpenSearch, SearchParts};
 use uuid::Uuid;
+use vector_db_benchmark::start_gate::WorkerPool;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
@@ -1505,17 +1506,13 @@ impl Engine for OpenSearchEngine {
         let timeout = self.timeout;
         let index_name = self.index_name.clone();
 
-        // Barrier-synchronized start so connection setup AND the cold first query
-        // fall OUTSIDE the measured window (mirrors the Redis/Vertex engines).
-        // Every worker builds its runtime + client and primes with one discarded
-        // query, then blocks on `ready`; the main thread stamps the shared start
-        // instant into `start_cell` and releases `go`, so the measurement clock
-        // starts only once all workers are warm and poised. A worker that fails to
-        // set up MUST still pass both barriers before returning, or the run would
-        // deadlock.
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // Gate-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window. Every worker connects + primes, then
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant and
+        // releases everyone, so the measurement clock starts only once all workers
+        // are warm and poised. The gate is count-agnostic: a worker that fails to
+        // set up, panics, or is never started by the OS settles its ticket and turns
+        // the run into a hard error instead of a hang (#214).
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -1523,8 +1520,8 @@ impl Engine for OpenSearchEngine {
         let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "opensearch-search");
             for _ in 0..parallel {
                 let base_url = base_url.clone();
                 let index_name = index_name.clone();
@@ -1532,12 +1529,11 @@ impl Engine for OpenSearchEngine {
                 let tops = &tops;
                 let raw_bodies = &raw_bodies;
                 let query_idx = Arc::clone(&query_idx);
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
+                let ticket = pool.ticket();
                 let retried_queries = Arc::clone(&retried_queries);
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -1549,18 +1545,21 @@ impl Engine for OpenSearchEngine {
                         .build()
                     {
                         Ok(rt) => rt,
-                        Err(_) => {
-                            // Still cross both barriers so peers aren't stranded.
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("opensearch-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
                     let client = match create_os_client(&base_url, timeout) {
                         Ok(c) => c,
-                        Err(_) => {
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("opensearch-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -1572,10 +1571,11 @@ impl Engine for OpenSearchEngine {
                         let _ = knn_send(&rt, &client, &index_name, &raw_bodies[0], search_policy);
                     }
 
-                    // Signal "connected + primed", then block until the main thread
+                    // Signal "connected + primed", then block until the coordinator
                     // stamps the shared measurement start and releases everyone.
-                    ready.wait();
-                    go.wait();
+                    if ticket.arrive_and_wait().is_none() {
+                        return (t, p, r, mr, nd);
+                    }
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1628,34 +1628,27 @@ impl Engine for OpenSearchEngine {
                         pb.inc(1);
                     }
                     (t, p, r, mr, nd)
-                }));
+                })?;
             }
 
-            // All workers are connected + primed and blocked on `go`. Stamp the
-            // shared measurement start and release them simultaneously. The cold
-            // setup is already behind the barrier.
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // Every worker is connected + primed and parked at the gate.
+            // Stamp the shared measurement start and release them together.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+            for (t, p, r, mr, nd) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrr_vals.extend(mr);
                 ndcg_vals.extend(nd);
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
-        // Measure from the post-barrier start stamp (workers already primed), so
+        // Measure from the post-gate start stamp (workers already primed), so
         // total_time excludes connection setup and the cold first query.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         // Dropped queries are NOT refused here. `compute_search_stats` derives
         // `failed_queries` as `requested_queries - times.len()` for every engine,

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -1521,7 +1521,7 @@ impl Engine for OpenSearchEngine {
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "opensearch-search");
+            let mut pool = WorkerPool::new(s, "opensearch-search", parallel);
             for _ in 0..parallel {
                 let base_url = base_url.clone();
                 let index_name = index_name.clone();
@@ -1529,11 +1529,10 @@ impl Engine for OpenSearchEngine {
                 let tops = &tops;
                 let raw_bodies = &raw_bodies;
                 let query_idx = Arc::clone(&query_idx);
-                let ticket = pool.ticket();
                 let retried_queries = Arc::clone(&retried_queries);
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -19,6 +19,66 @@ use vector_db_benchmark::readers::metadata::{
 };
 use vector_db_benchmark::start_gate::WorkerPool;
 
+/// Warn when `parallel` cannot fit in the server's connection budget.
+///
+/// Best effort: any failure to read the budget is silently ignored — this must
+/// never be the thing that stops a run.
+fn warn_if_over_connection_budget(conn_str: &str, parallel: usize) {
+    let Ok(mut client) = postgres::Client::connect(conn_str, postgres::NoTls) else {
+        return;
+    };
+    let scalar = |client: &mut postgres::Client, sql: &str| -> Option<i64> {
+        let row = client.query_one(sql, &[]).ok()?;
+        row.try_get::<_, String>(0).ok()?.parse().ok()
+    };
+    let Some(max_conns) = scalar(&mut client, "SHOW max_connections") else {
+        return;
+    };
+    let reserved = scalar(&mut client, "SHOW superuser_reserved_connections").unwrap_or(0);
+    let in_use: i64 = client
+        .query_one("SELECT count(*) FROM pg_stat_activity", &[])
+        .ok()
+        .and_then(|r| r.try_get(0).ok())
+        .unwrap_or(0);
+    // `in_use` counts this advisory connection, which is closed on return.
+    let available = (max_conns - reserved - in_use + 1).max(0);
+    if (parallel as i64) > available {
+        eprintln!(
+            "\t⚠ WARNING: parallel={parallel} exceeds this server's connection budget \
+             (max_connections={max_conns}, superuser_reserved={reserved}, {in_use} in use \
+             → {available} available). Each search worker holds one connection for the whole \
+             run, so the run will FAIL rather than quietly measure fewer workers. Raise \
+             max_connections or lower parallel."
+        );
+    }
+}
+
+/// Render a `postgres::Error` usefully.
+///
+/// `postgres::Error`'s own `Display` is the literal string `"db error"`; the
+/// server's message — `FATAL: sorry, too many clients already`, the single most
+/// likely reason a worker cannot connect at high `parallel` — lives in the
+/// `DbError` behind it. Without this, the whole diagnostic for a `parallel` that
+/// exceeds `max_connections` reads `36 failed setup: ... db error`.
+fn describe_pg_error(e: &postgres::Error) -> String {
+    if let Some(db) = e.as_db_error() {
+        let mut msg = format!("{}: {}", db.severity(), db.message());
+        if let Some(hint) = db.hint() {
+            msg.push_str(&format!(" (hint: {hint})"));
+        }
+        return msg;
+    }
+    // Not a server-side error (TLS, DNS, refused socket): walk the source chain,
+    // whose leaf carries the real cause.
+    let mut msg = e.to_string();
+    let mut src: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(e);
+    while let Some(cause) = src {
+        msg.push_str(&format!(": {cause}"));
+        src = cause.source();
+    }
+    msg
+}
+
 /// Map a dataset schema field type to a Postgres column type. Returns None for
 /// types pgvector can't filter on with a plain scalar column (e.g. geo).
 fn pg_column_type(field_type: &str) -> Option<&'static str> {
@@ -444,6 +504,18 @@ impl Engine for PgVectorEngine {
         let conn_str = self.connection_string();
         let distance_op = self.distance_op.clone();
 
+        // Every worker holds its own connection for the whole run, so `parallel`
+        // is a claim on the server's connection budget. Exceeding it used to
+        // publish a run labelled `parallel=N` that N-k workers actually ran; it
+        // is now a hard error, which is correct but opaque at the point of
+        // failure. Warn here, with the arithmetic, rather than leaving the
+        // operator to infer it from k identical "too many clients" strings.
+        //
+        // Advisory only: this is racy by construction, and a pooler in front of
+        // Postgres makes `max_connections` meaningless. The start gate remains
+        // the authority.
+        warn_if_over_connection_budget(&conn_str, parallel);
+
         // Gate-synchronized start so connection setup AND the cold first query
         // fall OUTSIDE the measured window. Every worker connects + primes, then
         // parks at the gate; `WorkerPool::start` stamps the shared start instant and
@@ -459,7 +531,7 @@ impl Engine for PgVectorEngine {
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "pgvector-search");
+            let mut pool = WorkerPool::new(s, "pgvector-search", parallel);
             for _ in 0..parallel {
                 let conn_str = conn_str.clone();
                 let distance_op = distance_op.clone();
@@ -467,10 +539,9 @@ impl Engine for PgVectorEngine {
                 let neighbors = &neighbors;
                 let parsed_filters = &parsed_filters;
                 let query_idx = Arc::clone(&query_idx);
-                let ticket = pool.ticket();
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -483,7 +554,10 @@ impl Engine for PgVectorEngine {
                             // A worker that cannot set itself up would leave the run at a
                             // lower real concurrency than the `parallel` it reports. Settle
                             // the ticket with the reason; the coordinator makes it an error.
-                            ticket.fail(format!("pgvector-search worker setup failed: {e}"));
+                            ticket.fail(format!(
+                                "pgvector-search worker connect failed: {}",
+                                describe_pg_error(&e)
+                            ));
                             return (t, p, r, mr, nd);
                         }
                     };

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -17,6 +17,7 @@ use crate::engine::{Engine, SearchResults, UploadStats};
 use vector_db_benchmark::readers::metadata::{
     is_multivalued_keyword_field, MetadataItem, MetadataValue,
 };
+use vector_db_benchmark::start_gate::WorkerPool;
 
 /// Map a dataset schema field type to a Postgres column type. Returns None for
 /// types pgvector can't filter on with a plain scalar column (e.g. geo).
@@ -443,16 +444,13 @@ impl Engine for PgVectorEngine {
         let conn_str = self.connection_string();
         let distance_op = self.distance_op.clone();
 
-        // Barrier-synchronized start so per-worker connection setup AND the cold
-        // first query fall OUTSIDE the measured window (mirrors redis/vertex).
-        // Every worker connects + primes, then blocks on `ready`; the main thread
-        // stamps the shared start instant into `start_cell` and releases `go`, so
-        // the measurement clock starts only once all workers are warm and poised.
-        // A worker that fails to connect MUST still pass both barriers before
-        // returning, or the run would deadlock.
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // Gate-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window. Every worker connects + primes, then
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant and
+        // releases everyone, so the measurement clock starts only once all workers
+        // are warm and poised. The gate is count-agnostic: a worker that fails to
+        // set up, panics, or is never started by the OS settles its ticket and turns
+        // the run into a hard error instead of a hang (#214).
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -460,8 +458,8 @@ impl Engine for PgVectorEngine {
         let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "pgvector-search");
             for _ in 0..parallel {
                 let conn_str = conn_str.clone();
                 let distance_op = distance_op.clone();
@@ -469,11 +467,10 @@ impl Engine for PgVectorEngine {
                 let neighbors = &neighbors;
                 let parsed_filters = &parsed_filters;
                 let query_idx = Arc::clone(&query_idx);
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
+                let ticket = pool.ticket();
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -482,10 +479,11 @@ impl Engine for PgVectorEngine {
 
                     let mut conn = match postgres::Client::connect(&conn_str, postgres::NoTls) {
                         Ok(c) => c,
-                        Err(_) => {
-                            // Still cross both barriers so peers aren't stranded.
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("pgvector-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -533,10 +531,11 @@ impl Engine for PgVectorEngine {
                         let _ = conn.query(&prime_sql, &prime_params);
                     }
 
-                    // Signal "connected + primed", then block until the main thread
+                    // Signal "connected + primed", then block until the coordinator
                     // stamps the shared measurement start and releases everyone.
-                    ready.wait();
-                    go.wait();
+                    if ticket.arrive_and_wait().is_none() {
+                        return (t, p, r, mr, nd);
+                    }
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -607,34 +606,27 @@ impl Engine for PgVectorEngine {
                         pb.inc(1);
                     }
                     (t, p, r, mr, nd)
-                }));
+                })?;
             }
 
-            // All workers spawned. Wait until every one is connected + primed,
-            // stamp the shared start instant, then release them together so the
-            // measurement clock excludes connection setup and the cold first query.
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // Every worker is connected + primed and parked at the gate.
+            // Stamp the shared measurement start and release them together.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+            for (t, p, r, mr, nd) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrr_vals.extend(mr);
                 ndcg_vals.extend(nd);
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
         // total_time excludes connection setup and the cold first query: it is
-        // measured from the barrier release stamped into `start_cell`.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        // measured from the gate release stamp.
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -1989,7 +1989,7 @@ impl Engine for QdrantEngine {
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "qdrant-search");
+            let mut pool = WorkerPool::new(s, "qdrant-search", parallel);
             for _ in 0..parallel {
                 let grpc_url = grpc_url.clone();
                 let api_key = api_key.clone();
@@ -1999,10 +1999,9 @@ impl Engine for QdrantEngine {
                 let neighbors = &neighbors;
                 let parsed_filters = &parsed_filters;
                 let query_idx = Arc::clone(&query_idx);
-                let ticket = pool.ticket();
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -24,6 +24,7 @@ use qdrant_client::qdrant::{
     VectorParamsBuilder, VectorsConfig, VectorsConfigBuilder,
 };
 use qdrant_client::{Payload, Qdrant};
+use vector_db_benchmark::start_gate::WorkerPool;
 
 use crate::config::{EngineConfig, HnswConfig, SearchParams};
 use crate::dataset::Dataset;
@@ -1966,17 +1967,13 @@ impl Engine for QdrantEngine {
 
         let pb = self.create_progress_bar(num_to_run);
 
-        // Barrier-synchronized start so per-worker client/runtime setup AND the cold
-        // first query fall OUTSIDE the measured window (mirrors redis/vertex). Every
-        // worker builds its runtime + client and primes with one discarded query,
-        // then blocks on `ready`; the main thread stamps the shared start instant
-        // into `start_cell` and releases `go`, so the measurement clock starts only
-        // once all workers are warm and poised. A worker that fails to build its
-        // runtime/client MUST still pass both barriers before returning, or the run
-        // would deadlock.
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // Gate-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window. Every worker connects + primes, then
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant and
+        // releases everyone, so the measurement clock starts only once all workers
+        // are warm and poised. The gate is count-agnostic: a worker that fails to
+        // set up, panics, or is never started by the OS settles its ticket and turns
+        // the run into a hard error instead of a hang (#214).
 
         // Each worker builds its own client/connection (like ES/OpenSearch) rather
         // than sharing one gRPC connection, which would serialize parallel queries.
@@ -1991,8 +1988,8 @@ impl Engine for QdrantEngine {
         let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "qdrant-search");
             for _ in 0..parallel {
                 let grpc_url = grpc_url.clone();
                 let api_key = api_key.clone();
@@ -2002,11 +1999,10 @@ impl Engine for QdrantEngine {
                 let neighbors = &neighbors;
                 let parsed_filters = &parsed_filters;
                 let query_idx = Arc::clone(&query_idx);
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
+                let ticket = pool.ticket();
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -2127,10 +2123,11 @@ impl Engine for QdrantEngine {
                         .build()
                     {
                         Ok(rt) => rt,
-                        Err(_) => {
-                            // Still cross both barriers so peers aren't stranded.
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("qdrant-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -2147,8 +2144,10 @@ impl Engine for QdrantEngine {
                         Ok(c) => c,
                         Err(e) => {
                             eprintln!("Qdrant worker client build failed: {}", e);
-                            ready.wait();
-                            go.wait();
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("qdrant-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -2162,9 +2161,10 @@ impl Engine for QdrantEngine {
                     }
 
                     // Signal "runtime + client built + primed", then block until the
-                    // main thread stamps the shared measurement start and releases all.
-                    ready.wait();
-                    go.wait();
+                    // coordinator stamps the shared measurement start and releases all.
+                    if ticket.arrive_and_wait().is_none() {
+                        return (t, p, r, mr, nd);
+                    }
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -2224,34 +2224,27 @@ impl Engine for QdrantEngine {
                         pb.inc(1);
                     }
                     (t, p, r, mr, nd)
-                }));
+                })?;
             }
 
-            // All workers are built + primed and blocked on `go`. Stamp the shared
-            // measurement start and release them simultaneously, so connection setup
-            // and the cold first query are already behind the barrier.
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // Every worker is connected + primed and parked at the gate.
+            // Stamp the shared measurement start and release them together.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+            for (t, p, r, mr, nd) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrr_vals.extend(mr);
                 ndcg_vals.extend(nd);
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
-        // Measure from the post-barrier start stamp (workers already primed), so
+        // Measure from the post-gate start stamp (workers already primed), so
         // total_time excludes connection setup and the cold first query.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -25,6 +25,7 @@ use crate::engine::{
 use crate::metrics::compute_metrics;
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, parse_ft_search_response};
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
+use vector_db_benchmark::start_gate::WorkerPool;
 
 /// Redis engine configuration
 #[derive(Clone)]
@@ -2129,16 +2130,14 @@ impl Engine for RedisEngine {
         // environment inside the per-query timed window.
         let index_name = self.config.index_name.clone();
 
-        // Barrier-synchronized start so connection setup AND the cold first query
+        // Gate-synchronized start so connection setup AND the cold first query
         // fall OUTSIDE the measured window — for open-loop and closed-loop-duration
         // alike (mirrors the Vertex engine). Every worker connects + primes, then
-        // blocks on `ready`; the main thread stamps the shared start instant into
-        // `start_cell` and releases `go`, so the measurement clock starts only once
-        // all workers are warm and poised. A worker that fails to connect MUST
-        // still pass both barriers before returning, or the run would deadlock.
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant
+        // and releases everyone, so the measurement clock starts only once all
+        // workers are warm and poised. The gate is count-agnostic: a worker that
+        // fails to connect, panics, or is never started by the OS settles its
+        // ticket and turns the run into an error instead of a hang (#214).
 
         let sample_capacity = if closed_loop_duration.is_some() {
             queries.len()
@@ -2164,8 +2163,8 @@ impl Engine for RedisEngine {
             return Err("dataset ground-truth shorter than query set".into());
         }
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "redis-search");
             for _ in 0..parallel {
                 let redis_url = self.redis_url.clone();
                 let algorithm = self.config.algorithm.clone();
@@ -2176,12 +2175,10 @@ impl Engine for RedisEngine {
                 let query_strs = &query_strs;
                 let query_idx = Arc::clone(&query_idx);
                 let index_name = index_name.as_str();
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
-                let start_cell = Arc::clone(&start_cell);
+                let ticket = pool.ticket();
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     // Thread-local sample buffers — no cross-thread synchronization
                     // in the timed loop.
                     let mut t = Vec::new();
@@ -2197,18 +2194,19 @@ impl Engine for RedisEngine {
 
                     let client = match redis::Client::open(redis_url.as_str()) {
                         Ok(c) => c,
-                        Err(_) => {
-                            // Still cross both barriers so peers aren't stranded.
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the
+                            // run at parallel-1 real concurrency while still being
+                            // reported as `parallel`. Settle the ticket with the
+                            // reason; the coordinator turns it into a hard error.
+                            ticket.fail(format!("redis client open failed: {e}"));
                             return (t, p, r, mr, nd, sd, e2e, dropped, late);
                         }
                     };
                     let mut conn = match client.get_connection() {
                         Ok(c) => c,
-                        Err(_) => {
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            ticket.fail(format!("redis connect failed: {e}"));
                             return (t, p, r, mr, nd, sd, e2e, dropped, late);
                         }
                     };
@@ -2237,11 +2235,11 @@ impl Engine for RedisEngine {
                         let _ = exec_ft_search(&mut conn, &prime_cmd);
                     }
 
-                    // Signal "connected + primed", then block until the main thread
+                    // Signal "connected + primed", then block until the coordinator
                     // stamps the shared measurement start and releases everyone.
-                    ready.wait();
-                    go.wait();
-                    let start_time = *start_cell.get().unwrap();
+                    let Some(start_time) = ticket.arrive_and_wait() else {
+                        return (t, p, r, mr, nd, sd, e2e, dropped, late);
+                    };
 
                     loop {
                         if closed_loop_duration
@@ -2355,19 +2353,15 @@ impl Engine for RedisEngine {
                         pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd, sd, e2e, dropped, late)
-                }));
+                })?;
             }
 
-            // All workers are connected + primed and blocked on `go`. Stamp the
+            // Every worker is connected + primed and parked at the gate. Stamp the
             // shared measurement start and release them simultaneously. No arrival
-            // offset is needed now — the cold setup is already behind the barrier.
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // offset is needed now — the cold setup is already behind the gate.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd, sd, e2e, dropped, late) = h.join().unwrap();
+            for (t, p, r, mr, nd, sd, e2e, dropped, late) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
@@ -2378,15 +2372,13 @@ impl Engine for RedisEngine {
                 dropped_queries += dropped;
                 late_queries += late;
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
-        // Measure from the post-barrier start stamp (workers already primed), so
+        // Measure from the post-gate start stamp (workers already primed), so
         // total_time excludes connection setup and the cold first query.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         let attempted_queries = query_idx

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -2164,7 +2164,7 @@ impl Engine for RedisEngine {
         }
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "redis-search");
+            let mut pool = WorkerPool::new(s, "redis-search", parallel);
             for _ in 0..parallel {
                 let redis_url = self.redis_url.clone();
                 let algorithm = self.config.algorithm.clone();
@@ -2175,10 +2175,9 @@ impl Engine for RedisEngine {
                 let query_strs = &query_strs;
                 let query_idx = Arc::clone(&query_idx);
                 let index_name = index_name.as_str();
-                let ticket = pool.ticket();
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     // Thread-local sample buffers — no cross-thread synchronization
                     // in the timed loop.
                     let mut t = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -1829,7 +1829,7 @@ impl Engine for ValkeyEngine {
         let index_name = self.config.index_name.clone();
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "valkey-search");
+            let mut pool = WorkerPool::new(s, "valkey-search", parallel);
             for _ in 0..parallel {
                 let host = self.host.clone();
                 let port = self.port;
@@ -1841,10 +1841,9 @@ impl Engine for ValkeyEngine {
                 let query_strs = &query_strs;
                 let query_idx = Arc::clone(&query_idx);
                 let index_name = index_name.as_str();
-                let ticket = pool.ticket();
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -37,6 +37,7 @@ use crate::engine::index_naming::{derive_index_name, derive_key_prefix};
 use crate::engine::{Engine, SearchResults, UpdateSearchRatio, UploadStats};
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, doc_key_to_id, doc_key_to_id_opt};
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
+use vector_db_benchmark::start_gate::WorkerPool;
 
 /// Valkey engine configuration
 #[derive(Clone)]
@@ -1810,16 +1811,13 @@ impl Engine for ValkeyEngine {
 
         let pb = self.create_progress_bar(num_to_run);
 
-        // Barrier-synchronized start so connection setup AND the cold first query
-        // fall OUTSIDE the measured window (mirrors redis.rs/vertex.rs). Every
-        // worker connects + primes, then blocks on `ready`; the main thread stamps
-        // the shared start instant into `start_cell` and releases `go`, so the
-        // measurement clock starts only once all workers are warm and poised. A
-        // worker that fails to connect MUST still pass both barriers before
-        // returning, or the run would deadlock.
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // Gate-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window. Every worker connects + primes, then
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant and
+        // releases everyone, so the measurement clock starts only once all workers
+        // are warm and poised. The gate is count-agnostic: a worker that fails to
+        // set up, panics, or is never started by the OS settles its ticket and turns
+        // the run into a hard error instead of a hang (#214).
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -1830,8 +1828,8 @@ impl Engine for ValkeyEngine {
         // Resolve the per-config index name once (not per query / per worker).
         let index_name = self.config.index_name.clone();
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "valkey-search");
             for _ in 0..parallel {
                 let host = self.host.clone();
                 let port = self.port;
@@ -1843,11 +1841,10 @@ impl Engine for ValkeyEngine {
                 let query_strs = &query_strs;
                 let query_idx = Arc::clone(&query_idx);
                 let index_name = index_name.as_str();
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
+                let ticket = pool.ticket();
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -1871,18 +1868,21 @@ impl Engine for ValkeyEngine {
                     );
                     let client = match redis::Client::open(url.as_str()) {
                         Ok(c) => c,
-                        Err(_) => {
-                            // Still cross both barriers so peers aren't stranded.
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("valkey-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
                     let mut conn = match client.get_connection() {
                         Ok(c) => c,
-                        Err(_) => {
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("valkey-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -1906,10 +1906,11 @@ impl Engine for ValkeyEngine {
                         );
                     }
 
-                    // Signal "connected + primed", then block until the main thread
+                    // Signal "connected + primed", then block until the coordinator
                     // stamps the shared measurement start and releases everyone.
-                    ready.wait();
-                    go.wait();
+                    if ticket.arrive_and_wait().is_none() {
+                        return (t, p, r, mr, nd);
+                    }
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -1974,32 +1975,26 @@ impl Engine for ValkeyEngine {
                         pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd)
-                }));
+                })?;
             }
 
-            // All workers are spawned; wait until every one has connected + primed,
-            // then stamp the shared measurement start and release them together.
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // Every worker is connected + primed and parked at the gate.
+            // Stamp the shared measurement start and release them together.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+            for (t, p, r, mr, nd) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrr_vals.extend(mr);
                 ndcg_vals.extend(nd);
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
         // total_time excludes connection setup and the cold first query.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         if times.is_empty() {
             return Err("No searches completed".to_string());

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -598,17 +598,16 @@ impl Engine for VectorSetsEngine {
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "vectorsets-search");
+            let mut pool = WorkerPool::new(s, "vectorsets-search", parallel);
             for _ in 0..parallel {
                 let redis_url = self.redis_url.clone();
                 let neighbors = &neighbors;
                 let filters = &filters;
                 let encoded_queries = &encoded_queries;
                 let query_idx = Arc::clone(&query_idx);
-                let ticket = pool.ticket();
                 let pb = &pb;
 
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -18,6 +18,7 @@ use crate::dataset::Dataset;
 use crate::engine::{Engine, SearchResults, UpdateSearchRatio, UploadStats};
 use vector_db_benchmark::parsers::datetime_to_epoch_secs;
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
+use vector_db_benchmark::start_gate::WorkerPool;
 
 /// VectorSets engine configuration
 #[derive(Clone)]
@@ -582,16 +583,13 @@ impl Engine for VectorSetsEngine {
 
         let pb = self.create_progress_bar(num_to_run);
 
-        // Barrier-synchronized start so connection setup AND the cold first query
-        // fall OUTSIDE the measured window (mirrors the Redis/Vertex engines).
-        // Every worker connects + primes, then blocks on `ready`; the main thread
-        // stamps the shared start instant into `start_cell` and releases `go`, so
-        // the measurement clock starts only once all workers are warm and poised.
-        // A worker that fails to connect MUST still pass both barriers before
-        // returning, or the run would deadlock.
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // Gate-synchronized start so connection setup AND the cold first query
+        // fall OUTSIDE the measured window. Every worker connects + primes, then
+        // parks at the gate; `WorkerPool::start` stamps the shared start instant and
+        // releases everyone, so the measurement clock starts only once all workers
+        // are warm and poised. The gate is count-agnostic: a worker that fails to
+        // set up, panics, or is never started by the OS settles its ticket and turns
+        // the run into a hard error instead of a hang (#214).
 
         let mut times: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut precs: Vec<f64> = Vec::with_capacity(num_to_run);
@@ -599,19 +597,18 @@ impl Engine for VectorSetsEngine {
         let mut mrr_vals: Vec<f64> = Vec::with_capacity(num_to_run);
         let mut ndcg_vals: Vec<f64> = Vec::with_capacity(num_to_run);
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(parallel);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "vectorsets-search");
             for _ in 0..parallel {
                 let redis_url = self.redis_url.clone();
                 let neighbors = &neighbors;
                 let filters = &filters;
                 let encoded_queries = &encoded_queries;
                 let query_idx = Arc::clone(&query_idx);
-                let ready = Arc::clone(&ready);
-                let go = Arc::clone(&go);
+                let ticket = pool.ticket();
                 let pb = &pb;
 
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -621,18 +618,21 @@ impl Engine for VectorSetsEngine {
 
                     let client = match redis::Client::open(redis_url.as_str()) {
                         Ok(c) => c,
-                        Err(_) => {
-                            // Still cross both barriers so peers aren't stranded.
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("vectorsets-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
                     let mut conn = match client.get_connection() {
                         Ok(c) => c,
-                        Err(_) => {
-                            ready.wait();
-                            go.wait();
+                        Err(e) => {
+                            // A worker that cannot set itself up would leave the run at a
+                            // lower real concurrency than the `parallel` it reports. Settle
+                            // the ticket with the reason; the coordinator makes it an error.
+                            ticket.fail(format!("vectorsets-search worker setup failed: {e}"));
                             return (t, p, r, mr, nd);
                         }
                     };
@@ -652,10 +652,11 @@ impl Engine for VectorSetsEngine {
                         );
                     }
 
-                    // Signal "connected + primed", then block until the main thread
+                    // Signal "connected + primed", then block until the coordinator
                     // stamps the shared measurement start and releases everyone.
-                    ready.wait();
-                    go.wait();
+                    if ticket.arrive_and_wait().is_none() {
+                        return (t, p, r, mr, nd);
+                    }
 
                     loop {
                         let idx = query_idx.fetch_add(1, Ordering::Relaxed);
@@ -719,33 +720,27 @@ impl Engine for VectorSetsEngine {
                         pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd)
-                }));
+                })?;
             }
 
-            // All workers are spawned; wait until each has connected + primed,
-            // stamp the shared measurement start, then release them together.
-            ready.wait();
-            let st = Instant::now();
-            start_cell.set(st).ok();
-            go.wait();
+            // Every worker is connected + primed and parked at the gate.
+            // Stamp the shared measurement start and release them together.
+            let (per_worker, measured_start) = pool.start()?;
 
-            for h in handles {
-                let (t, p, r, mr, nd) = h.join().unwrap();
+            for (t, p, r, mr, nd) in per_worker {
                 times.extend(t);
                 precs.extend(p);
                 recs.extend(r);
                 mrr_vals.extend(mr);
                 ndcg_vals.extend(nd);
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
         // total_time excludes connection setup and the cold first query — it is
-        // measured from the barrier release stamped into `start_cell`.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        // measured from the gate release stamp.
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         if times.is_empty() {
             return Err("No searches completed".to_string());

--- a/src/bin/vector_db_benchmark/engine/vertex.rs
+++ b/src/bin/vector_db_benchmark/engine/vertex.rs
@@ -28,7 +28,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Barrier, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
@@ -46,6 +46,7 @@ use crate::engine::{
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
+use vector_db_benchmark::start_gate::WorkerPool;
 
 const DEFAULT_REGION: &str = "us-central1";
 const DEFAULT_MACHINE_TYPE: &str = "e2-standard-16";
@@ -1840,9 +1841,11 @@ impl Engine for VertexEngine {
         } else {
             num_to_run
         });
-        let closed_loop_start = Instant::now();
-        let open_loop_start = Arc::new(OnceLock::<Instant>::new());
-        let worker_ready = Arc::new(Barrier::new(workers + 1));
+        // Gate-synchronized start: every worker connects + primes, then parks at
+        // the gate, and the coordinator stamps one shared measurement start. The
+        // gate is count-agnostic, so a worker that fails to build its client,
+        // panics, or is never started by the OS makes the run a hard error rather
+        // than deadlocking the coordinator (#214).
 
         let queries = &queries;
         let neighbors = &neighbors;
@@ -1864,14 +1867,13 @@ impl Engine for VertexEngine {
         let mut dropped_queries = 0usize;
         let mut late_queries = 0usize;
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(workers);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "vertex-search");
             for worker_id in 0..workers {
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
-                let open_loop_start = Arc::clone(&open_loop_start);
-                let worker_ready = Arc::clone(&worker_ready);
-                handles.push(s.spawn(move || {
+                let ticket = pool.ticket();
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -1893,20 +1895,19 @@ impl Engine for VertexEngine {
                     }) {
                         Ok(c) => c,
                         Err(e) => {
-                            eprintln!("Vertex worker client build failed: {}", e);
-                            // Always release the barrier (even on failure) so the
-                            // main thread isn't left blocked — the barrier and
-                            // connection-prime below are now unconditional, not
-                            // gated on timed_mode.
-                            worker_ready.wait();
+                            // A worker that cannot build its client would leave the
+                            // run at a lower real concurrency than the `parallel` it
+                            // reports; settle the ticket with the reason and let the
+                            // coordinator turn it into a hard error.
+                            ticket.fail(format!("vertex worker client build failed: {e}"));
                             return (t, p, r, mr, nd, sd, e2e, dropped, late);
                         }
                     };
 
-                    // Prime the connection with one discarded request, then wait at
-                    // the barrier, in EVERY mode (not just timed_mode). This keeps
-                    // the per-worker gRPC/TLS handshake + cold first RPC OUT of the
-                    // measured window: the main thread stamps the measurement start
+                    // Prime the connection with one discarded request, then park at
+                    // the gate, in EVERY mode (not just timed_mode). This keeps the
+                    // per-worker gRPC/TLS handshake + cold first RPC OUT of the
+                    // measured window: the coordinator stamps the measurement start
                     // only after all workers have connected. Previously the default
                     // closed-loop path skipped this, so its rps denominator included
                     // connection setup and understated QPS (#151-audit).
@@ -1923,17 +1924,12 @@ impl Engine for VertexEngine {
                         if let Err(e) = client.execute(prime_request) {
                             eprintln!("Vertex worker connection prime failed: {}", e);
                         }
-                        worker_ready.wait();
                     }
 
-                    // Measurement start is always set by the main thread after the
-                    // barrier; spin until it is visible so no measured request
-                    // predates the timer.
-                    let schedule_start = loop {
-                        if let Some(start) = open_loop_start.get() {
-                            break *start;
-                        }
-                        std::thread::yield_now();
+                    // Block until the coordinator stamps the shared measurement
+                    // start, so no measured request predates the timer.
+                    let Some(schedule_start) = ticket.arrive_and_wait() else {
+                        return (t, p, r, mr, nd, sd, e2e, dropped, late);
                     };
 
                     loop {
@@ -2025,23 +2021,20 @@ impl Engine for VertexEngine {
                         pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd, sd, e2e, dropped, late)
-                }));
+                })?;
             }
-            {
-                // Wait for every worker to finish connecting (barrier), then stamp
-                // the measurement start — unconditional now, so the default
-                // closed-loop rps denominator excludes connection setup, matching
-                // the open-loop/duration path.
-                worker_ready.wait();
-                let measurement_start = if open_loop.is_some() {
+            // Wait for every worker to finish connecting, then stamp the
+            // measurement start — unconditional, so the default closed-loop rps
+            // denominator excludes connection setup, matching the
+            // open-loop/duration path.
+            let (per_worker, measured_start) = pool.start_with(|| {
+                if open_loop.is_some() {
                     Instant::now() + Duration::from_millis(100)
                 } else {
                     Instant::now()
-                };
-                let _ = open_loop_start.set(measurement_start);
-            }
-            for h in handles {
-                let (t, p, r, mr, nd, sd, e2e, dropped, late) = h.join().unwrap();
+                }
+            })?;
+            for (t, p, r, mr, nd, sd, e2e, dropped, late) in per_worker {
                 latencies.extend(t);
                 precisions.extend(p);
                 recalls.extend(r);
@@ -2052,11 +2045,11 @@ impl Engine for VertexEngine {
                 dropped_queries += dropped;
                 late_queries += late;
             }
-        });
+            Ok(measured_start)
+        })?;
 
         pb.finish_and_clear();
-        let total_start = open_loop_start.get().copied().unwrap_or(closed_loop_start);
-        let total_time = total_start.elapsed().as_secs_f64();
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         let succeeded = latencies.len();
         let attempted_queries = query_idx
@@ -2219,12 +2212,11 @@ impl Engine for VertexEngine {
         let search_idx = Arc::new(AtomicUsize::new(0));
         let update_idx = Arc::new(AtomicUsize::new(0));
         let pb = self.create_progress_bar(num_to_run);
-        // Fallback start; the measured window actually begins at `measured_start`,
-        // stamped after every worker has connected (below), so the rps denominator
-        // excludes per-worker gRPC/TLS connection setup (#151-audit).
-        let start_time = Instant::now();
-        let worker_ready = Arc::new(Barrier::new(workers + 1));
-        let measured_start = Arc::new(OnceLock::<Instant>::new());
+        // The measured window begins at the instant stamped after every worker has
+        // connected (below), so the rps denominator excludes per-worker gRPC/TLS
+        // connection setup (#151-audit). The gate is count-agnostic, so a worker
+        // that fails to build its clients, panics, or is never started by the OS
+        // makes the run a hard error instead of deadlocking it (#214).
 
         let queries = &queries;
         let neighbors = &neighbors;
@@ -2244,15 +2236,14 @@ impl Engine for VertexEngine {
         let mut ndcgs: Vec<f64> = Vec::new();
         let mut update_times: Vec<f64> = Vec::new();
 
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(workers);
+        let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+            let mut pool = WorkerPool::new(s, "vertex-mixed");
             for _ in 0..workers {
                 let search_idx = Arc::clone(&search_idx);
                 let update_idx = Arc::clone(&update_idx);
-                let worker_ready = Arc::clone(&worker_ready);
-                let measured_start = Arc::clone(&measured_start);
+                let ticket = pool.ticket();
                 let pb = &pb;
-                handles.push(s.spawn(move || {
+                pool.spawn(move || {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -2271,8 +2262,9 @@ impl Engine for VertexEngine {
                     }) {
                         Ok(c) => c,
                         Err(e) => {
-                            eprintln!("Vertex mixed worker build failed: {e}");
-                            worker_ready.wait();
+                            // Settle the ticket so the run fails loudly rather than
+                            // silently measuring one worker short of `parallel`.
+                            ticket.fail(format!("vertex mixed worker build failed: {e}"));
                             return (t, p, r, mr, nd, ut);
                         }
                     };
@@ -2282,14 +2274,13 @@ impl Engine for VertexEngine {
                     {
                         Ok(c) => c,
                         Err(e) => {
-                            eprintln!("Vertex mixed update client build failed: {e}");
-                            worker_ready.wait();
+                            ticket.fail(format!("vertex mixed update client build failed: {e}"));
                             return (t, p, r, mr, nd, ut);
                         }
                     };
 
                     // Prime the query connection with one discarded search, then
-                    // wait at the barrier, so the measured window excludes the
+                    // park at the gate, so the measured window excludes the
                     // per-worker gRPC/TLS handshake + cold first RPC — both search
                     // rps and update_rps use total_time as denominator. Mirrors the
                     // closed-loop search() path.
@@ -2306,13 +2297,9 @@ impl Engine for VertexEngine {
                             eprintln!("Vertex mixed worker connection prime failed: {e}");
                         }
                     }
-                    worker_ready.wait();
                     // Don't issue a measured request before the timer starts.
-                    loop {
-                        if measured_start.get().is_some() {
-                            break;
-                        }
-                        std::thread::yield_now();
+                    if ticket.arrive_and_wait().is_none() {
+                        return (t, p, r, mr, nd, ut);
                     }
 
                     'outer: loop {
@@ -2389,14 +2376,12 @@ impl Engine for VertexEngine {
                         pb.inc(pb_pending);
                     }
                     (t, p, r, mr, nd, ut)
-                }));
+                })?;
             }
             // All workers have connected + primed; stamp the measured start now so
             // total_time excludes connection setup.
-            worker_ready.wait();
-            let _ = measured_start.set(Instant::now());
-            for h in handles {
-                let (t, p, r, mr, nd, ut) = h.join().unwrap();
+            let (per_worker, measured_start) = pool.start()?;
+            for (t, p, r, mr, nd, ut) in per_worker {
                 latencies.extend(t);
                 precisions.extend(p);
                 recalls.extend(r);
@@ -2404,14 +2389,10 @@ impl Engine for VertexEngine {
                 ndcgs.extend(nd);
                 update_times.extend(ut);
             }
-        });
+            Ok(measured_start)
+        })?;
         pb.finish_and_clear();
-        let total_time = measured_start
-            .get()
-            .copied()
-            .unwrap_or(start_time)
-            .elapsed()
-            .as_secs_f64();
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         if latencies.is_empty() {
             return Err("No searches completed (all mixed queries failed)".to_string());

--- a/src/bin/vector_db_benchmark/engine/vertex.rs
+++ b/src/bin/vector_db_benchmark/engine/vertex.rs
@@ -1868,12 +1868,11 @@ impl Engine for VertexEngine {
         let mut late_queries = 0usize;
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "vertex-search");
+            let mut pool = WorkerPool::new(s, "vertex-search", workers);
             for worker_id in 0..workers {
                 let query_idx = Arc::clone(&query_idx);
                 let pb = &pb;
-                let ticket = pool.ticket();
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();
@@ -2237,13 +2236,12 @@ impl Engine for VertexEngine {
         let mut update_times: Vec<f64> = Vec::new();
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-            let mut pool = WorkerPool::new(s, "vertex-mixed");
+            let mut pool = WorkerPool::new(s, "vertex-mixed", workers);
             for _ in 0..workers {
                 let search_idx = Arc::clone(&search_idx);
                 let update_idx = Arc::clone(&update_idx);
-                let ticket = pool.ticket();
                 let pb = &pb;
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     let mut t = Vec::new();
                     let mut p = Vec::new();
                     let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -27,6 +27,7 @@ use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::{Engine, SearchResults, UploadStats};
 use vector_db_benchmark::readers::metadata::MetadataItem;
+use vector_db_benchmark::start_gate::{StartGate, WorkerPool};
 
 const DEFAULT_CLASS_NAME: &str = "Benchmark";
 
@@ -1481,19 +1482,17 @@ impl Engine for WeaviateEngine {
         let graphql_bodies = Arc::new(graphql_bodies);
         let grpc_requests = Arc::new(grpc_requests);
 
-        // Barrier-synchronized start so connection setup AND the cold first query
+        // Gate-synchronized start so connection setup AND the cold first query
         // fall OUTSIDE the measured window (mirrors redis.rs / vertex.rs). Every
-        // worker connects + primes one discarded query, then blocks on `ready`;
-        // the main thread stamps the shared start instant into `start_cell` and
-        // releases `go`, so the measurement clock starts only once all workers are
-        // warm and poised. A worker that fails to connect MUST still cross both
-        // barriers before returning, or the run would deadlock. `total_time` is
-        // read from `start_cell` below, so it excludes connection setup and the
-        // cold first query. Both transports (gRPC tasks / GraphQL threads) use the
-        // same `parallel + 1` barrier counts (main thread is the +1).
-        let ready = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let go = Arc::new(std::sync::Barrier::new(parallel + 1));
-        let start_cell = Arc::new(std::sync::OnceLock::<Instant>::new());
+        // worker connects + primes one discarded query, then parks at the gate;
+        // the coordinator stamps the shared start instant and releases everyone,
+        // so the measurement clock starts only once all workers are warm and
+        // poised. `total_time` is measured from that stamp, so it excludes
+        // connection setup and the cold first query. Both transports (gRPC tasks /
+        // GraphQL threads) use the same count-agnostic gate: a worker that fails
+        // to connect, panics, or is never started settles its ticket and turns the
+        // run into a hard error instead of a hang (#214).
+        let measured_start: Instant;
 
         // Per-thread sample buffers merged after the workers finish — no per-query
         // Mutex<Vec> contention in the timed loop (see redis.rs::search). Both the
@@ -1513,15 +1512,19 @@ impl Engine for WeaviateEngine {
             //     This scales with concurrency (unlike thread-per-block_on). ──
             let endpoint = grpc_ep.unwrap();
             // Size the pool at `parallel + 1` so every worker task can block on the
-            // std start-barrier concurrently (the main future is the +1). With the
-            // default (num-CPU) pool a `parallel` larger than the CPU count would
-            // strand un-scheduled tasks behind barrier-blocked threads and deadlock.
+            // start gate concurrently (the main future is the +1). With the default
+            // (num-CPU) pool a `parallel` larger than the CPU count would strand
+            // un-scheduled tasks behind gate-blocked threads and deadlock.
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(parallel + 1)
                 .enable_all()
                 .build()
                 .map_err(|e| format!("failed to build tokio runtime: {}", e))?;
-            let collected: Vec<SampleBuffers> = rt.block_on(async {
+            // `tokio::spawn` cannot fail, but a task can still panic before
+            // reaching the gate, so the same count-agnostic ticket accounting
+            // applies here as in the thread-based harnesses.
+            let gate = Arc::new(StartGate::new());
+            let (collected, grpc_start): (Vec<SampleBuffers>, Instant) = rt.block_on(async {
                 let mut tasks = Vec::with_capacity(parallel);
                 for _ in 0..parallel {
                     let endpoint = endpoint.clone();
@@ -1530,8 +1533,7 @@ impl Engine for WeaviateEngine {
                     let neighbors = Arc::clone(&neighbors);
                     let tops = Arc::clone(&tops);
                     let query_idx = Arc::clone(&query_idx);
-                    let ready = Arc::clone(&ready);
-                    let go = Arc::clone(&go);
+                    let ticket = gate.ticket();
                     let pb = pb.clone();
                     tasks.push(tokio::spawn(async move {
                         let mut t = Vec::new();
@@ -1543,11 +1545,11 @@ impl Engine for WeaviateEngine {
                         let channel = match endpoint.connect().await {
                             Ok(c) => c,
                             Err(e) => {
-                                eprintln!("gRPC connect failed: {}", e);
-                                // Still cross both barriers so peers + main aren't
-                                // stranded (the barrier count includes this task).
-                                ready.wait();
-                                go.wait();
+                                // A task that cannot connect would leave the run at
+                                // a lower real concurrency than the `parallel` it
+                                // reports; settle the ticket with the reason and let
+                                // the coordinator turn it into a hard error.
+                                ticket.fail(format!("weaviate gRPC connect failed: {e}"));
                                 return (t, p, r, mr, nd);
                             }
                         };
@@ -1562,10 +1564,11 @@ impl Engine for WeaviateEngine {
                             let _ = grpc_search(&mut client, prime, api_key.as_deref()).await;
                         }
 
-                        // Signal "connected + primed", then block until the main
-                        // thread stamps the shared start and releases everyone.
-                        ready.wait();
-                        go.wait();
+                        // Signal "connected + primed", then block until the
+                        // coordinator stamps the shared start and releases everyone.
+                        if ticket.arrive_and_wait().is_none() {
+                            return (t, p, r, mr, nd);
+                        }
                         loop {
                             let idx = query_idx.fetch_add(1, Ordering::Relaxed);
                             if idx >= num_to_run {
@@ -1602,21 +1605,35 @@ impl Engine for WeaviateEngine {
                         (t, p, r, mr, nd)
                     }));
                 }
-                // All tasks have connected + primed and are poised on `ready`.
-                // Stamp the measurement start, then release everyone via `go`; the
-                // barrier count includes this main future (the +1).
-                ready.wait();
-                start_cell.set(Instant::now()).ok();
-                go.wait();
+                // All tasks have connected + primed and are parked at the gate.
+                // Stamp the measurement start, then release everyone.
+                let start_err = gate.wait_ready(tasks.len()).err();
+                let started_at = Instant::now();
+                if start_err.is_none() {
+                    gate.release(started_at);
+                }
+                // Await every task even when the start failed, so none outlives the
+                // runtime and a panic is counted rather than silently discarded.
                 let mut out = Vec::with_capacity(tasks.len());
+                let mut panicked = 0usize;
                 for task in tasks {
                     match task.await {
                         Ok(buf) => out.push(buf),
-                        Err(e) => eprintln!("gRPC search task failed: {}", e),
+                        Err(_) => panicked += 1,
                     }
                 }
-                out
-            });
+                if let Some(e) = start_err {
+                    return Err(e);
+                }
+                if panicked > 0 {
+                    return Err(format!(
+                        "{panicked} of {parallel} weaviate gRPC search tasks panicked mid-run; \
+                         discarding the run rather than reporting partial results"
+                    ));
+                }
+                Ok((out, started_at))
+            })?;
+            measured_start = grpc_start;
             for (t, p, r, mr, nd) in collected {
                 times.extend(t);
                 precs.extend(p);
@@ -1626,8 +1643,8 @@ impl Engine for WeaviateEngine {
             }
         } else {
             // ── GraphQL: blocking OS-thread fan-out (each thread its own client). ──
-            std::thread::scope(|s| {
-                let mut handles = Vec::with_capacity(parallel);
+            measured_start = std::thread::scope(|s| -> Result<Instant, String> {
+                let mut pool = WorkerPool::new(s, "weaviate-search");
                 for _ in 0..parallel {
                     let base_url = self.base_url.clone();
                     let class_name = self.class_name.clone();
@@ -1637,11 +1654,10 @@ impl Engine for WeaviateEngine {
                     let tops = Arc::clone(&tops);
                     let graphql_bodies = Arc::clone(&graphql_bodies);
                     let query_idx = Arc::clone(&query_idx);
-                    let ready = Arc::clone(&ready);
-                    let go = Arc::clone(&go);
+                    let ticket = pool.ticket();
                     let pb = &pb;
 
-                    handles.push(s.spawn(move || {
+                    pool.spawn(move || {
                         let mut t = Vec::new();
                         let mut p = Vec::new();
                         let mut r = Vec::new();
@@ -1653,11 +1669,12 @@ impl Engine for WeaviateEngine {
                             .build()
                         {
                             Ok(c) => c,
-                            Err(_) => {
-                                // Still cross both barriers so peers + main aren't
-                                // stranded (the barrier count includes this worker).
-                                ready.wait();
-                                go.wait();
+                            Err(e) => {
+                                // A worker that cannot build its client would leave
+                                // the run at a lower real concurrency than the
+                                // `parallel` it reports; settle the ticket with the
+                                // reason and let the coordinator make it an error.
+                                ticket.fail(format!("weaviate client build failed: {e}"));
                                 return (t, p, r, mr, nd);
                             }
                         };
@@ -1675,10 +1692,11 @@ impl Engine for WeaviateEngine {
                             );
                         }
 
-                        // Signal "connected + primed", then block until the main
-                        // thread stamps the shared start and releases everyone.
-                        ready.wait();
-                        go.wait();
+                        // Signal "connected + primed", then block until the
+                        // coordinator stamps the shared start and releases everyone.
+                        if ticket.arrive_and_wait().is_none() {
+                            return (t, p, r, mr, nd);
+                        }
                         loop {
                             let idx = query_idx.fetch_add(1, Ordering::Relaxed);
                             if idx >= num_to_run {
@@ -1718,32 +1736,26 @@ impl Engine for WeaviateEngine {
                             pb.inc(1);
                         }
                         (t, p, r, mr, nd)
-                    }));
+                    })?;
                 }
-                // All workers have connected + primed and are poised on `ready`.
-                // Stamp the measurement start, then release everyone via `go`; the
-                // barrier count includes this main thread (the +1).
-                ready.wait();
-                start_cell.set(Instant::now()).ok();
-                go.wait();
-                for h in handles {
-                    let (t, p, r, mr, nd) = h.join().unwrap();
+                // All workers have connected + primed and are parked at the gate.
+                // Stamp the measurement start, then release everyone together.
+                let (per_worker, started_at) = pool.start()?;
+                for (t, p, r, mr, nd) in per_worker {
                     times.extend(t);
                     precs.extend(p);
                     recs.extend(r);
                     mrr_vals.extend(mr);
                     ndcg_vals.extend(nd);
                 }
-            });
+                Ok(started_at)
+            })?;
         }
 
         pb.finish_and_clear();
-        // total_time is measured from the barrier release (start_cell), so it
-        // excludes connection setup and the cold first (primed) query.
-        let total_time = start_cell
-            .get()
-            .map(|st| st.elapsed().as_secs_f64())
-            .unwrap_or(0.0);
+        // total_time is measured from the gate release, so it excludes connection
+        // setup and the cold first (primed) query.
+        let total_time = measured_start.elapsed().as_secs_f64();
 
         let top = explicit_top.unwrap_or_else(|| neighbors.first().map(|n| n.len()).unwrap_or(10));
         crate::engine::compute_search_stats(

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -27,7 +27,7 @@ use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::{Engine, SearchResults, UploadStats};
 use vector_db_benchmark::readers::metadata::MetadataItem;
-use vector_db_benchmark::start_gate::{StartGate, WorkerPool};
+use vector_db_benchmark::start_gate::{AbortGateOnDrop, StartGate, WorkerPool};
 
 const DEFAULT_CLASS_NAME: &str = "Benchmark";
 
@@ -1520,10 +1520,26 @@ impl Engine for WeaviateEngine {
                 .enable_all()
                 .build()
                 .map_err(|e| format!("failed to build tokio runtime: {}", e))?;
+            // This is the one harness that drives a bare `StartGate` rather than
+            // `WorkerPool`: it fans out `tokio` tasks, not scoped threads.
             // `tokio::spawn` cannot fail, but a task can still panic before
             // reaching the gate, so the same count-agnostic ticket accounting
-            // applies here as in the thread-based harnesses.
+            // applies. Two hazards `WorkerPool` would otherwise cover:
+            //
+            //  * `AbortGateOnDrop` is declared AFTER `rt`, so it drops FIRST on
+            //    unwind. Without it, a panic in the coordinator future between
+            //    the first `ticket()` and `wait_ready` would leave the parked
+            //    tasks on a condvar nobody notifies, and `Runtime::drop` would
+            //    then join them forever — #214's own shape (found in review).
+            //  * the ticket/task pairing is by hand here; `WorkerPool::spawn`
+            //    mints the ticket itself precisely so it cannot be missed.
+            //
+            // Note also that `Builder::build()` above PANICS rather than
+            // returning `Err` when the OS refuses a thread, so this harness
+            // reports EAGAIN as a panic, not as the friendly message the
+            // thread-based harnesses produce. Loud, not hung.
             let gate = Arc::new(StartGate::new());
+            let _gate_guard = AbortGateOnDrop::new(&gate);
             let (collected, grpc_start): (Vec<SampleBuffers>, Instant) = rt.block_on(async {
                 let mut tasks = Vec::with_capacity(parallel);
                 for _ in 0..parallel {
@@ -1607,7 +1623,7 @@ impl Engine for WeaviateEngine {
                 }
                 // All tasks have connected + primed and are parked at the gate.
                 // Stamp the measurement start, then release everyone.
-                let start_err = gate.wait_ready(tasks.len()).err();
+                let start_err = gate.wait_ready("weaviate-grpc-search", tasks.len()).err();
                 let started_at = Instant::now();
                 if start_err.is_none() {
                     gate.release(started_at);
@@ -1644,7 +1660,7 @@ impl Engine for WeaviateEngine {
         } else {
             // ── GraphQL: blocking OS-thread fan-out (each thread its own client). ──
             measured_start = std::thread::scope(|s| -> Result<Instant, String> {
-                let mut pool = WorkerPool::new(s, "weaviate-search");
+                let mut pool = WorkerPool::new(s, "weaviate-search", parallel);
                 for _ in 0..parallel {
                     let base_url = self.base_url.clone();
                     let class_name = self.class_name.clone();
@@ -1654,10 +1670,9 @@ impl Engine for WeaviateEngine {
                     let tops = Arc::clone(&tops);
                     let graphql_bodies = Arc::clone(&graphql_bodies);
                     let query_idx = Arc::clone(&query_idx);
-                    let ticket = pool.ticket();
                     let pb = &pb;
 
-                    pool.spawn(move || {
+                    pool.spawn(move |ticket| {
                         let mut t = Vec::new();
                         let mut p = Vec::new();
                         let mut r = Vec::new();

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -549,6 +549,14 @@ fn run_single_experiment(
     // Configs that lost queries, collected so --fail-on-dropped-queries can fail
     // the run *after* every result file is written rather than instead of it.
     let mut dropped_query_failures: Vec<String> = Vec::new();
+    // A search point whose every repetition failed. Recorded rather than
+    // returned on the spot: an early `return` here would drop `pending_saves`
+    // on the floor, throwing away every point that already succeeded. The
+    // repo's stated policy for --fail-on-dropped-queries — "results files are
+    // still written before the run fails, so the evidence survives" — applies
+    // just as much to a hard search failure, and matters more now that a
+    // short-staffed worker pool is one of them (#214).
+    let mut fatal_search_error: Option<String> = None;
     let skip_vector_index = args.skip_vector_index;
 
     if !args.skip_search {
@@ -604,7 +612,7 @@ fn run_single_experiment(
             all_search_params.into_iter().enumerate().collect()
         };
 
-        for phase in &search_phases {
+        'search_phase: for phase in &search_phases {
             // --skip-vector-index: skip mixed phases (no vector updates to benchmark)
             if skip_vector_index && phase.is_some() {
                 continue;
@@ -975,7 +983,8 @@ fn run_single_experiment(
                         );
                         eprintln!("\t{}", msg);
                         if args.exit_on_error {
-                            return Err(msg);
+                            fatal_search_error = Some(msg);
+                            break 'search_phase;
                         }
                     }
                 }
@@ -1002,6 +1011,18 @@ fn run_single_experiment(
             ground_truth.as_ref(),
             calibration.as_ref(),
         )?;
+    }
+
+    // Only now that the completed points are on disk may a hard search failure
+    // end the run.
+    if let Some(msg) = fatal_search_error {
+        if !pending_saves.is_empty() {
+            eprintln!(
+                "\t↳ wrote {} completed search point(s) before failing, so the evidence survives",
+                pending_saves.len()
+            );
+        }
+        return Err(msg);
     }
 
     // Now that the evidence is on disk, honour --fail-on-dropped-queries. Every

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod metrics;
 pub mod parsers;
 pub mod readers;
 pub mod redis_client;
+pub mod start_gate;
 pub mod synthetic;
 
 // Re-export commonly used types

--- a/src/start_gate.rs
+++ b/src/start_gate.rs
@@ -1,0 +1,871 @@
+//! Deadlock-free synchronized start for the parallel search harnesses.
+//!
+//! # Why this exists
+//!
+//! Every engine's `search()` warms its workers (connect + one discarded "prime"
+//! query) *outside* the measured window and then starts them all at the same
+//! instant. That used to be spelled as two fixed-count barriers:
+//!
+//! ```ignore
+//! let ready = Arc::new(Barrier::new(parallel + 1));
+//! let go = Arc::new(Barrier::new(parallel + 1));
+//! std::thread::scope(|s| {
+//!     for _ in 0..parallel { s.spawn(move || { /* warm */ ready.wait(); go.wait(); /* run */ }); }
+//!     ready.wait();                      // <-- needs exactly `parallel + 1` arrivals
+//!     start_cell.set(Instant::now()).ok();
+//!     go.wait();
+//! });
+//! ```
+//!
+//! A `Barrier` is sized *before* the workers exist, so the count is a promise
+//! the harness cannot keep. Two ordinary failures break it, and both produce a
+//! **permanent hang with no output** rather than an error (issue #214):
+//!
+//! 1. **The OS refuses a thread.** `Scope::spawn` panics on `EAGAIN`
+//!    (`ulimit -u`, cgroup `pids.max` — i.e. any CI container with a large
+//!    `parallel`). The panic unwinds into `thread::scope`'s drop, which joins
+//!    the `k` workers already spawned; they are parked in `ready.wait()`
+//!    waiting for `parallel + 1` arrivals that can never happen.
+//! 2. **A worker panics before the barrier.** It never arrives either, so the
+//!    coordinator parks in `ready.wait()` forever.
+//!
+//! `--search-timeout` defaults to `0.0` (disabled), so nothing breaks the hang.
+//!
+//! # What replaces it
+//!
+//! [`WorkerPool`] pairs a *count-agnostic* gate ([`StartGate`]: `Mutex` +
+//! `Condvar`) with a spawn that reports failure instead of panicking
+//! (`thread::Builder::spawn_scoped`, which returns [`io::Result`]).
+//!
+//! Every worker is issued a [`WorkerTicket`] **before** it is spawned, and the
+//! gate only ever waits for *tickets to settle*, never for a number fixed in
+//! advance. A ticket settles in exactly one of three ways:
+//!
+//! | outcome | how | effect |
+//! |---|---|---|
+//! | ready | [`WorkerTicket::arrive_and_wait`] | worker parks until the start instant is stamped |
+//! | failed setup | [`WorkerTicket::fail`] | reason recorded, run aborts |
+//! | lost | `Drop` without either of the above | counted as lost, run aborts |
+//!
+//! The `Drop` arm is what makes a panic (or a never-started thread, whose
+//! closure — and therefore ticket — is dropped by the failed `spawn_scoped`)
+//! settle its ticket during unwind. Progress is therefore guaranteed: the
+//! coordinator's wait is satisfied by *any* terminal outcome, so there is no
+//! arrival count left unmet.
+//!
+//! # Failure semantics: hard error, never "carry on with fewer"
+//!
+//! A worker that never started, or died before the start gate, means the run
+//! executed at a lower concurrency than the `parallel` it reports. That changes
+//! the reported number, so per the repo's settled policy it is a hard error —
+//! [`WorkerPool::start`] returns `Err` naming what happened. It does not
+//! silently proceed at `parallel - k`, and it does not hang.
+
+#[cfg(test)]
+use std::io;
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::thread::{Scope, ScopedJoinHandle};
+use std::time::Instant;
+
+/// Lifecycle of the shared start signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Workers are still warming up; nobody may start.
+    Waiting,
+    /// Every worker warmed successfully; the measured window began at this instant.
+    Released(Instant),
+    /// The run is being torn down. Parked workers must leave immediately.
+    Aborted,
+}
+
+#[derive(Debug)]
+struct GateState {
+    /// Tickets that reached a terminal startup outcome (ready + failed + lost).
+    settled: usize,
+    /// Tickets parked at the gate, warmed and ready to run.
+    ready: usize,
+    /// Tickets dropped without arriving or failing — a panic, or a thread the
+    /// OS never started.
+    lost: usize,
+    /// Setup errors reported by workers that did start (connect/client build).
+    failures: Vec<String>,
+    phase: Phase,
+}
+
+/// A start signal whose wait is satisfied by *outcomes*, not by a count fixed
+/// before the workers exist. See the module docs.
+#[derive(Debug)]
+pub struct StartGate {
+    state: Mutex<GateState>,
+    cv: Condvar,
+}
+
+impl Default for StartGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StartGate {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(GateState {
+                settled: 0,
+                ready: 0,
+                lost: 0,
+                failures: Vec::new(),
+                phase: Phase::Waiting,
+            }),
+            cv: Condvar::new(),
+        }
+    }
+
+    /// Lock the state, ignoring poisoning.
+    ///
+    /// A poisoned mutex here means some thread panicked while holding it. The
+    /// state is a handful of counters that are always left consistent, and
+    /// refusing the lock would reintroduce exactly the hang this module exists
+    /// to remove — so recover the guard and keep making progress. The panic
+    /// itself is still reported: the panicking worker's ticket lands in `lost`
+    /// (or its join returns `Err`), and both are hard errors.
+    fn lock(&self) -> MutexGuard<'_, GateState> {
+        self.state.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Issue a ticket for one worker. Call this **before** spawning, so the
+    /// ticket exists even if the spawn itself fails.
+    pub fn ticket(self: &Arc<Self>) -> WorkerTicket {
+        WorkerTicket {
+            gate: Arc::clone(self),
+            settled: false,
+        }
+    }
+
+    /// Block until all `expected` tickets have settled.
+    ///
+    /// `Ok(())` means every worker is warmed and parked at the gate. `Err`
+    /// means at least one worker was lost or failed setup; the gate is put into
+    /// [`Phase::Aborted`] first, so any parked peers wake and return promptly.
+    ///
+    /// Public because not every harness fans out over scoped threads: the
+    /// Weaviate gRPC path drives `tokio` tasks and coordinates the same gate by
+    /// hand. Thread-based harnesses should use [`WorkerPool`] instead.
+    pub fn wait_ready(&self, expected: usize) -> Result<(), String> {
+        let mut st = self.lock();
+        while st.settled < expected && st.phase != Phase::Aborted {
+            st = self.cv.wait(st).unwrap_or_else(|e| e.into_inner());
+        }
+
+        if st.lost == 0 && st.failures.is_empty() && st.phase != Phase::Aborted {
+            return Ok(());
+        }
+
+        st.phase = Phase::Aborted;
+        let mut parts = Vec::new();
+        if st.lost > 0 {
+            parts.push(format!(
+                "{} never reached the start gate (thread not started, or panicked during setup)",
+                st.lost
+            ));
+        }
+        if !st.failures.is_empty() {
+            parts.push(format!("{} failed setup: {}", st.failures.len(), {
+                let mut reasons = st.failures.clone();
+                reasons.sort();
+                reasons.dedup();
+                reasons.join("; ")
+            }));
+        }
+        let ready = st.ready;
+        drop(st);
+        self.cv.notify_all();
+
+        Err(format!(
+            "only {ready} of {expected} search workers reached the start gate — {}. \
+             Refusing to report a run at parallel={expected} that measured fewer workers",
+            parts.join(", ")
+        ))
+    }
+
+    /// Stamp the measured-window start and release every parked worker.
+    pub fn release(&self, at: Instant) {
+        let mut st = self.lock();
+        if st.phase == Phase::Waiting {
+            st.phase = Phase::Released(at);
+        }
+        drop(st);
+        self.cv.notify_all();
+    }
+
+    /// Tear the gate down: parked workers wake and return `None`.
+    ///
+    /// Idempotent, and a no-op once the gate has been released — aborting a
+    /// run that already started would be a lie.
+    pub fn abort(&self) {
+        let mut st = self.lock();
+        if st.phase == Phase::Waiting {
+            st.phase = Phase::Aborted;
+        }
+        drop(st);
+        self.cv.notify_all();
+    }
+
+    fn settle(&self, outcome: Outcome) {
+        let mut st = self.lock();
+        st.settled += 1;
+        match outcome {
+            Outcome::Ready => st.ready += 1,
+            Outcome::Lost => st.lost += 1,
+            Outcome::Failed(reason) => st.failures.push(reason),
+        }
+        drop(st);
+        self.cv.notify_all();
+    }
+}
+
+enum Outcome {
+    Ready,
+    Lost,
+    Failed(String),
+}
+
+/// One worker's claim on the start gate.
+///
+/// Created before the thread is spawned and moved into it. However the worker
+/// ends — arriving, reporting a setup failure, panicking, or never running at
+/// all — the ticket settles, so the coordinator's wait always completes.
+#[derive(Debug)]
+pub struct WorkerTicket {
+    gate: Arc<StartGate>,
+    settled: bool,
+}
+
+impl WorkerTicket {
+    /// Report "warmed and ready", then park until the measured window opens.
+    ///
+    /// Returns the shared start instant, or `None` if the run was aborted (a
+    /// peer was lost or failed setup) — in which case the worker must return
+    /// immediately without measuring anything.
+    #[must_use = "None means the run was aborted; the worker must return without measuring"]
+    pub fn arrive_and_wait(mut self) -> Option<Instant> {
+        self.settled = true;
+        let gate = Arc::clone(&self.gate);
+        gate.settle(Outcome::Ready);
+
+        let mut st = gate.lock();
+        loop {
+            match st.phase {
+                Phase::Released(at) => return Some(at),
+                Phase::Aborted => return None,
+                Phase::Waiting => st = gate.cv.wait(st).unwrap_or_else(|e| e.into_inner()),
+            }
+        }
+    }
+
+    /// Report that this worker could not set itself up (connect, client build,
+    /// runtime build). The run is aborted: a search reported at `parallel=N`
+    /// must not have been executed by fewer than `N` workers.
+    pub fn fail(mut self, reason: impl Into<String>) {
+        self.settled = true;
+        self.gate.settle(Outcome::Failed(reason.into()));
+    }
+}
+
+impl Drop for WorkerTicket {
+    fn drop(&mut self) {
+        if !self.settled {
+            // Reached by a panic unwinding out of the worker before it arrived,
+            // and by `spawn_scoped` dropping the closure of a thread the OS
+            // refused to create. Either way the ticket settles, so the
+            // coordinator is never left waiting on an arrival that cannot come.
+            self.gate.settle(Outcome::Lost);
+        }
+    }
+}
+
+// Test-only seam: number of further spawns this thread is allowed before
+// `WorkerPool::spawn` starts reporting `EAGAIN`-shaped failures.
+//
+// Thread-local, so tests running in parallel in one binary cannot disturb each
+// other. `#[cfg(test)]`, so the shipped binary has neither the counter nor the
+// check — this is a test seam, not a runtime backdoor.
+#[cfg(test)]
+thread_local! {
+    static SPAWN_BUDGET: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+/// Allow `n` more spawns on this thread, then fail every subsequent one.
+#[cfg(test)]
+fn set_spawn_budget(n: usize) {
+    SPAWN_BUDGET.with(|b| b.set(Some(n)));
+}
+
+#[cfg(test)]
+fn clear_spawn_budget() {
+    SPAWN_BUDGET.with(|b| b.set(None));
+}
+
+/// Consume one unit of spawn budget; `true` means "pretend the OS refused".
+#[cfg(test)]
+fn injected_spawn_failure() -> bool {
+    SPAWN_BUDGET.with(|b| match b.get() {
+        None => false,
+        Some(0) => true,
+        Some(n) => {
+            b.set(Some(n - 1));
+            false
+        }
+    })
+}
+
+/// A set of scoped worker threads with a synchronized, deadlock-free start.
+///
+/// Usage inside `std::thread::scope`:
+///
+/// ```ignore
+/// let (results, measured_start) = std::thread::scope(|s| {
+///     let mut pool = WorkerPool::new(s, "redis-search");
+///     for _ in 0..parallel {
+///         let ticket = pool.ticket();
+///         pool.spawn(move || {
+///             // ... connect + prime ...
+///             let Some(start) = ticket.arrive_and_wait() else { return Default::default() };
+///             // ... measured loop ...
+///         })?;
+///     }
+///     pool.start()
+/// })?;
+/// ```
+pub struct WorkerPool<'scope, 'env: 'scope, T: Send + 'scope> {
+    scope: &'scope Scope<'scope, 'env>,
+    gate: Arc<StartGate>,
+    handles: Vec<ScopedJoinHandle<'scope, T>>,
+    label: &'static str,
+}
+
+impl<'scope, 'env: 'scope, T: Send + 'scope> WorkerPool<'scope, 'env, T> {
+    pub fn new(scope: &'scope Scope<'scope, 'env>, label: &'static str) -> Self {
+        Self {
+            scope,
+            gate: Arc::new(StartGate::new()),
+            handles: Vec::new(),
+            label,
+        }
+    }
+
+    /// Issue this worker's ticket. Must be called before [`Self::spawn`] and
+    /// moved into the worker closure.
+    pub fn ticket(&self) -> WorkerTicket {
+        self.gate.ticket()
+    }
+
+    /// Spawn one worker.
+    ///
+    /// Unlike `Scope::spawn`, an OS refusal (`EAGAIN` under `ulimit -u` or
+    /// cgroup `pids.max`) is returned as `Err`, not a panic. The gate is
+    /// aborted first, so the workers already parked at it wake up and return
+    /// instead of being stranded when `thread::scope` joins them.
+    pub fn spawn<F>(&mut self, f: F) -> Result<(), String>
+    where
+        F: FnOnce() -> T + Send + 'scope,
+    {
+        let index = self.handles.len();
+        let name = format!("{}-{index}", self.label);
+
+        #[cfg(test)]
+        let spawned = if injected_spawn_failure() {
+            drop(f); // as `spawn_scoped` does on failure — settles the ticket
+            Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "injected spawn failure",
+            ))
+        } else {
+            std::thread::Builder::new()
+                .name(name)
+                .spawn_scoped(self.scope, f)
+        };
+        #[cfg(not(test))]
+        let spawned = std::thread::Builder::new()
+            .name(name)
+            .spawn_scoped(self.scope, f);
+
+        match spawned {
+            Ok(handle) => {
+                self.handles.push(handle);
+                Ok(())
+            }
+            Err(e) => {
+                self.gate.abort();
+                Err(format!(
+                    "could not start {} worker {} of {}: {e}. \
+                     The OS refused the thread — lower `parallel`, or raise the thread/process \
+                     limit (ulimit -u, cgroup pids.max)",
+                    self.label,
+                    index + 1,
+                    index + 1
+                ))
+            }
+        }
+    }
+
+    /// Wait for every worker to warm up, stamp and release the shared start
+    /// instant, then join them all.
+    ///
+    /// Returns each worker's value in spawn order plus the instant the measured
+    /// window opened. `Err` if any worker never reached the gate, failed setup,
+    /// or panicked mid-run — all of which would make a result labelled
+    /// `parallel=N` untrue.
+    pub fn start(&mut self) -> Result<(Vec<T>, Instant), String> {
+        self.start_with(Instant::now)
+    }
+
+    /// [`Self::start`] with a caller-chosen start instant.
+    ///
+    /// `stamp` runs once, after every worker has warmed, and its result becomes
+    /// the shared measurement start. The Vertex open-loop harness uses it to
+    /// schedule the window a fixed lead-time in the future.
+    pub fn start_with(
+        &mut self,
+        stamp: impl FnOnce() -> Instant,
+    ) -> Result<(Vec<T>, Instant), String> {
+        let expected = self.handles.len();
+        if let Err(e) = self.gate.wait_ready(expected) {
+            // `wait_ready` has already aborted the gate, so the parked workers
+            // are on their way out. Join them here rather than leaving it to
+            // `thread::scope`, which re-panics on an unjoined panicking thread
+            // and would turn our diagnostic into a bare "a scoped thread
+            // panicked".
+            self.drain();
+            return Err(e);
+        }
+
+        let at = stamp();
+        self.gate.release(at);
+
+        // Join every worker even after one panics, so no thread outlives the
+        // scope and the failure is reported once, with a count.
+        let mut values = Vec::with_capacity(expected);
+        let mut panicked = 0usize;
+        for handle in std::mem::take(&mut self.handles) {
+            match handle.join() {
+                Ok(v) => values.push(v),
+                Err(_) => panicked += 1,
+            }
+        }
+        if panicked > 0 {
+            return Err(format!(
+                "{panicked} of {expected} {} workers panicked mid-run; \
+                 discarding the run rather than reporting partial results",
+                self.label
+            ));
+        }
+        Ok((values, at))
+    }
+
+    /// Join and discard every outstanding worker. Panic payloads are swallowed
+    /// deliberately: the caller is already returning a more specific error.
+    fn drain(&mut self) {
+        for handle in std::mem::take(&mut self.handles) {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl<T: Send> Drop for WorkerPool<'_, '_, T> {
+    fn drop(&mut self) {
+        // Any early exit from the enclosing `thread::scope` closure — a `?` on
+        // `spawn`, on `start`, or on anything else in between — drops the pool
+        // before `scope` joins the workers. Abort so parked workers leave the
+        // gate; without this the `?` would hand control straight to the same
+        // deadlock this module removes. No-op once the gate is released.
+        self.gate.abort();
+        self.drain();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Barrier;
+    use std::time::Duration;
+
+    /// How long a call must fail within to count as "prompt" rather than hung.
+    const PROMPT: Duration = Duration::from_secs(5);
+    /// How long we watch a known-deadlocked shape before declaring it hung.
+    const HANG_PROOF: Duration = Duration::from_secs(2);
+
+    // ---------------------------------------------------------------------
+    // Part 1 — the pre-fix shape really does hang.
+    //
+    // These replicate the exact primitive that was in every engine
+    // (`Barrier::new(parallel + 1)`) under the two failure modes of #214, and
+    // assert the coordinator NEVER returns. They pin down what the rest of this
+    // module is buying: without them, "the new code returns Err" would not be
+    // evidence that the old code hung.
+    //
+    // The deadlocked coordinator thread is deliberately never joined — it
+    // cannot be, that is the bug. It parks on a condvar and is reclaimed at
+    // process exit.
+    // ---------------------------------------------------------------------
+
+    /// Run `body` on a detached thread; `true` if it finished within `limit`.
+    fn finishes_within(limit: Duration, body: impl FnOnce() + Send + 'static) -> bool {
+        let done = Arc::new((Mutex::new(false), Condvar::new()));
+        let signal = Arc::clone(&done);
+        std::thread::spawn(move || {
+            body();
+            let (lock, cv) = &*signal;
+            *lock.lock().unwrap() = true;
+            cv.notify_all();
+        });
+
+        let (lock, cv) = &*done;
+        let (guard, _) = cv
+            .wait_timeout_while(lock.lock().unwrap(), limit, |finished| !*finished)
+            .unwrap();
+        *guard
+    }
+
+    #[test]
+    fn legacy_fixed_count_barrier_hangs_when_a_spawn_fails() {
+        // Pre-fix shape: the barrier is sized for `parallel + 1` arrivals, but
+        // the OS refused worker 3, so only 2 workers + the coordinator ever
+        // reach it. `thread::scope` then joins two threads parked forever.
+        let hung = !finishes_within(HANG_PROOF, || {
+            let parallel = 4;
+            let spawned = 2;
+            let ready = Arc::new(Barrier::new(parallel + 1));
+            std::thread::scope(|s| {
+                for _ in 0..spawned {
+                    let ready = Arc::clone(&ready);
+                    s.spawn(move || {
+                        ready.wait();
+                    });
+                }
+                ready.wait(); // never returns: 3 arrivals, needs 5
+            });
+        });
+        assert!(
+            hung,
+            "the pre-fix Barrier shape was expected to deadlock but completed — \
+             this test no longer proves anything"
+        );
+    }
+
+    #[test]
+    fn legacy_fixed_count_barrier_hangs_when_a_worker_panics() {
+        // Pre-fix shape: all workers spawn, but one panics before reaching the
+        // barrier, so the coordinator waits for an arrival that never comes.
+        let hung = !finishes_within(HANG_PROOF, || {
+            let parallel = 3;
+            let ready = Arc::new(Barrier::new(parallel + 1));
+            std::thread::scope(|s| {
+                for i in 0..parallel {
+                    let ready = Arc::clone(&ready);
+                    s.spawn(move || {
+                        if i == 1 {
+                            // Silence the default hook for this one expected panic.
+                            std::panic::panic_any(());
+                        }
+                        ready.wait();
+                    });
+                }
+                ready.wait(); // never returns: 3 arrivals, needs 4
+            });
+        });
+        assert!(
+            hung,
+            "the pre-fix Barrier shape was expected to deadlock but completed — \
+             this test no longer proves anything"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Part 2 — the same two failure modes through `WorkerPool`, which must fail
+    // promptly and informatively instead.
+    // ---------------------------------------------------------------------
+
+    /// Drive the pool exactly the way an engine's `search()` does.
+    fn run_pool(
+        parallel: usize,
+        worker: impl Fn(usize, WorkerTicket) -> usize + Sync,
+    ) -> Result<(Vec<usize>, Instant), String> {
+        std::thread::scope(|s| {
+            let mut pool = WorkerPool::new(s, "test");
+            for i in 0..parallel {
+                let ticket = pool.ticket();
+                let worker = &worker;
+                pool.spawn(move || worker(i, ticket))?;
+            }
+            pool.start()
+        })
+    }
+
+    #[test]
+    fn spawn_failure_is_a_prompt_error_not_a_hang() {
+        // The first two workers spawn and park at the gate; the third is
+        // refused. Pre-fix this deadlocked (see `legacy_..._when_a_spawn_fails`).
+        let started = Instant::now();
+        let finished = finishes_within(PROMPT, || {
+            set_spawn_budget(2);
+            let err = run_pool(4, |_, ticket| {
+                let _ = ticket.arrive_and_wait();
+                0
+            })
+            .expect_err("a refused spawn must be an error");
+            clear_spawn_budget();
+            assert!(
+                err.contains("could not start test worker 3"),
+                "error should name the worker that could not start: {err}"
+            );
+            assert!(
+                err.contains("ulimit -u"),
+                "error should tell the operator how to fix it: {err}"
+            );
+        });
+        assert!(
+            finished,
+            "spawn failure hung for {:?} instead of erroring",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn worker_panic_before_the_gate_is_a_prompt_error_not_a_hang() {
+        // All four workers spawn; worker 1 panics during "setup", before
+        // arriving. Pre-fix the coordinator parked forever (see
+        // `legacy_..._when_a_worker_panics`).
+        let finished = finishes_within(PROMPT, || {
+            let err = run_pool(4, |i, ticket| {
+                if i == 1 {
+                    std::panic::panic_any(());
+                }
+                let _ = ticket.arrive_and_wait();
+                0
+            })
+            .expect_err("a worker that panics before the gate must be an error");
+            assert!(
+                err.contains("only 3 of 4 search workers reached the start gate"),
+                "error should quantify the shortfall: {err}"
+            );
+            assert!(
+                err.contains("never reached the start gate"),
+                "error should say why: {err}"
+            );
+        });
+        assert!(finished, "a pre-gate worker panic hung instead of erroring");
+    }
+
+    #[test]
+    fn worker_panic_after_the_gate_is_reported_not_swallowed() {
+        // Panicking mid-run cannot deadlock the gate, but it still means the
+        // run is short of the concurrency it claims — so it must not be
+        // silently folded into the results.
+        let finished = finishes_within(PROMPT, || {
+            let err = run_pool(3, |i, ticket| {
+                let _ = ticket.arrive_and_wait();
+                if i == 2 {
+                    std::panic::panic_any(());
+                }
+                0
+            })
+            .expect_err("a worker that panics mid-run must be an error");
+            assert!(
+                err.contains("1 of 3 test workers panicked mid-run"),
+                "error should count the panicking workers: {err}"
+            );
+        });
+        assert!(finished, "a mid-run worker panic hung instead of erroring");
+    }
+
+    #[test]
+    fn worker_setup_failure_is_a_hard_error_not_a_quieter_run() {
+        // The old code had failing workers cross both barriers and return
+        // empty, so the run executed at `parallel - k` while still being
+        // labelled `parallel`. That is a changed reported number → hard error.
+        let finished = finishes_within(PROMPT, || {
+            let err = run_pool(3, |i, ticket| {
+                if i == 0 {
+                    ticket.fail("connection refused");
+                    return 0;
+                }
+                let _ = ticket.arrive_and_wait();
+                0
+            })
+            .expect_err("a worker that cannot connect must be an error");
+            assert!(
+                err.contains("connection refused"),
+                "error should carry the underlying reason: {err}"
+            );
+            assert!(
+                err.contains("1 failed setup"),
+                "error should count the failures: {err}"
+            );
+        });
+        assert!(finished, "a setup failure hung instead of erroring");
+    }
+
+    // ---------------------------------------------------------------------
+    // Part 3 — the happy path still does what the barriers did.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn all_workers_observe_one_shared_start_after_every_worker_warmed() {
+        let warmed = Arc::new(AtomicUsize::new(0));
+        let warmed_at_start = Arc::new(Mutex::new(Vec::new()));
+
+        let (values, start) = {
+            let warmed = Arc::clone(&warmed);
+            let warmed_at_start = Arc::clone(&warmed_at_start);
+            run_pool(6, move |i, ticket| {
+                // Stagger warm-up so a barrier-less implementation that let the
+                // first worker run immediately would be caught.
+                std::thread::sleep(Duration::from_millis(5 * i as u64));
+                warmed.fetch_add(1, Ordering::SeqCst);
+                let observed = ticket.arrive_and_wait().expect("run must not abort");
+                warmed_at_start
+                    .lock()
+                    .unwrap()
+                    .push((warmed.load(Ordering::SeqCst), observed));
+                i
+            })
+            .expect("happy path must succeed")
+        };
+
+        assert_eq!(
+            values,
+            vec![0, 1, 2, 3, 4, 5],
+            "values come back in spawn order"
+        );
+        let seen = warmed_at_start.lock().unwrap();
+        assert_eq!(seen.len(), 6);
+        for (warmed_count, observed_start) in seen.iter() {
+            assert_eq!(
+                *warmed_count, 6,
+                "no worker may start before every worker has warmed up"
+            );
+            assert_eq!(
+                *observed_start, start,
+                "every worker must measure from the same start instant"
+            );
+        }
+    }
+
+    #[test]
+    fn start_with_hands_every_worker_the_caller_chosen_instant() {
+        // The Vertex open-loop harness schedules the window 100ms ahead of the
+        // warm-up so no request predates the timer; the gate must hand workers
+        // that instant, not `Instant::now()`.
+        let lead = Duration::from_millis(120);
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (_, start) = {
+            let seen = Arc::clone(&seen);
+            std::thread::scope(|s| {
+                let mut pool = WorkerPool::new(s, "test");
+                for _ in 0..3 {
+                    let ticket = pool.ticket();
+                    let seen = Arc::clone(&seen);
+                    pool.spawn(move || {
+                        let at = ticket.arrive_and_wait().expect("run must not abort");
+                        seen.lock().unwrap().push(at);
+                    })?;
+                }
+                pool.start_with(|| Instant::now() + lead)
+            })
+            .expect("happy path must succeed")
+        };
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 3);
+        assert!(seen.iter().all(|at| *at == start));
+        assert!(
+            start > Instant::now() - lead,
+            "the stamp must be the caller's future instant, not `now`"
+        );
+    }
+
+    #[test]
+    fn zero_workers_is_not_a_hang() {
+        let finished = finishes_within(PROMPT, || {
+            let (values, _) = run_pool(0, |_, ticket| {
+                let _ = ticket.arrive_and_wait();
+                0
+            })
+            .expect("an empty pool starts trivially");
+            assert!(values.is_empty());
+        });
+        assert!(finished, "an empty pool hung");
+    }
+
+    #[test]
+    fn abort_releases_workers_already_parked_at_the_gate() {
+        // The ordering that used to strand peers: two workers reach the gate
+        // first and park, and only then does the run fail. Both must wake.
+        let woke = Arc::new(AtomicUsize::new(0));
+        let gate_reached = Arc::new(Barrier::new(3));
+
+        let finished = finishes_within(PROMPT, {
+            let woke = Arc::clone(&woke);
+            let gate_reached = Arc::clone(&gate_reached);
+            move || {
+                let err = std::thread::scope(|s| {
+                    let mut pool: WorkerPool<'_, '_, ()> = WorkerPool::new(s, "test");
+                    for _ in 0..2 {
+                        let ticket = pool.ticket();
+                        let woke = Arc::clone(&woke);
+                        let gate_reached = Arc::clone(&gate_reached);
+                        pool.spawn(move || {
+                            gate_reached.wait();
+                            assert!(
+                                ticket.arrive_and_wait().is_none(),
+                                "an aborted run must not hand out a start instant"
+                            );
+                            woke.fetch_add(1, Ordering::SeqCst);
+                        })?;
+                    }
+                    // Both workers are now parked at the gate.
+                    gate_reached.wait();
+                    let ticket = pool.ticket();
+                    ticket.fail("simulated late failure");
+                    pool.start()
+                })
+                .expect_err("the run must fail");
+                assert!(err.contains("simulated late failure"), "{err}");
+            }
+        });
+
+        assert!(finished, "aborting the gate stranded the parked workers");
+        assert_eq!(
+            woke.load(Ordering::SeqCst),
+            2,
+            "both parked workers must wake"
+        );
+    }
+
+    #[test]
+    fn early_return_from_the_scope_closure_does_not_strand_parked_workers() {
+        // Guards the `Drop for WorkerPool` safety net: a `?` on something other
+        // than `spawn`/`start` must not leave workers parked while
+        // `thread::scope` tries to join them.
+        let finished = finishes_within(PROMPT, || {
+            let gate_reached = Arc::new(Barrier::new(2));
+            let err: Result<(), String> = std::thread::scope(|s| {
+                let mut pool: WorkerPool<'_, '_, ()> = WorkerPool::new(s, "test");
+                let ticket = pool.ticket();
+                let reached = Arc::clone(&gate_reached);
+                pool.spawn(move || {
+                    reached.wait();
+                    let _ = ticket.arrive_and_wait();
+                })?;
+                gate_reached.wait();
+                Err("something else went wrong".to_string())
+            });
+            assert_eq!(err.unwrap_err(), "something else went wrong");
+        });
+        assert!(
+            finished,
+            "an unrelated early return stranded a parked worker"
+        );
+    }
+}

--- a/src/start_gate.rs
+++ b/src/start_gate.rs
@@ -56,12 +56,22 @@
 //! worker can *finish* — normally, by failing setup, or by panicking — settles
 //! its ticket.
 //!
-//! **What this does not cover.** A worker that never finishes still blocks the
-//! coordinator: [`StartGate::wait_ready`] has no deadline, so a setup step that
-//! hangs forever (a `connect()` against a blackholed endpoint with no timeout,
-//! say) hangs the run exactly as the barrier did. That is not a regression, and
-//! `--search-timeout` is the intended backstop, but it defaults to `0.0`. A
-//! gate-level deadline is tracked separately.
+//! **What this does not cover.**
+//!
+//! * A worker that never *finishes* still blocks the coordinator:
+//!   [`StartGate::wait_ready`] has no deadline, so a setup step that hangs
+//!   forever (a `connect()` against a blackholed endpoint with no timeout, say)
+//!   hangs the run exactly as the barrier did. That is not a regression, and
+//!   `--search-timeout` is the intended backstop, but it defaults to `0.0`.
+//!   A gate-level deadline is tracked separately.
+//! * `WorkerPool::spawn` minting the ticket defeats *accidental* omission — you
+//!   cannot forget to create one, mint one too few, or pair the wrong ticket
+//!   with the wrong worker, and the compiler enforces all three. It is not a
+//!   defence against a determined caller: `std::mem::forget(ticket)`, or
+//!   sending the ticket out of the closure over a channel, leaves it unsettled
+//!   and hangs `wait_ready` forever. Both require going out of your way, and
+//!   neither is reachable from the shape every harness uses; treat the ticket
+//!   as something the worker must consume before it returns.
 //!
 //! # Failure semantics: hard error, never "carry on with fewer"
 //!

--- a/src/start_gate.rs
+++ b/src/start_gate.rs
@@ -37,9 +37,11 @@
 //! `Condvar`) with a spawn that reports failure instead of panicking
 //! (`thread::Builder::spawn_scoped`, which returns [`io::Result`]).
 //!
-//! Every worker is issued a [`WorkerTicket`] **before** it is spawned, and the
-//! gate only ever waits for *tickets to settle*, never for a number fixed in
-//! advance. A ticket settles in exactly one of three ways:
+//! Every worker is issued a [`WorkerTicket`] **before** it is spawned — by
+//! [`WorkerPool::spawn`] itself, which hands the ticket to the worker closure
+//! so it cannot be omitted or mismatched — and the gate only ever waits for
+//! *tickets to settle*, never for a number fixed in advance. A ticket settles
+//! in exactly one of three ways:
 //!
 //! | outcome | how | effect |
 //! |---|---|---|
@@ -49,9 +51,17 @@
 //!
 //! The `Drop` arm is what makes a panic (or a never-started thread, whose
 //! closure — and therefore ticket — is dropped by the failed `spawn_scoped`)
-//! settle its ticket during unwind. Progress is therefore guaranteed: the
-//! coordinator's wait is satisfied by *any* terminal outcome, so there is no
-//! arrival count left unmet.
+//! settle its ticket during unwind. The coordinator's wait is satisfied by
+//! *any* terminal outcome, so no arrival count is ever left unmet: every way a
+//! worker can *finish* — normally, by failing setup, or by panicking — settles
+//! its ticket.
+//!
+//! **What this does not cover.** A worker that never finishes still blocks the
+//! coordinator: [`StartGate::wait_ready`] has no deadline, so a setup step that
+//! hangs forever (a `connect()` against a blackholed endpoint with no timeout,
+//! say) hangs the run exactly as the barrier did. That is not a regression, and
+//! `--search-timeout` is the intended backstop, but it defaults to `0.0`. A
+//! gate-level deadline is tracked separately.
 //!
 //! # Failure semantics: hard error, never "carry on with fewer"
 //!
@@ -134,6 +144,13 @@ impl StartGate {
 
     /// Issue a ticket for one worker. Call this **before** spawning, so the
     /// ticket exists even if the spawn itself fails.
+    ///
+    /// Every worker counted by [`Self::wait_ready`] must own exactly one
+    /// ticket: a spawned worker without one never settles and hangs the
+    /// coordinator, and a ticket without a worker does the same. Thread-based
+    /// harnesses get that pairing for free from [`WorkerPool::spawn`]; a
+    /// harness calling this directly owns the invariant itself, and must also
+    /// hold an [`AbortGateOnDrop`] across the fan-out.
     pub fn ticket(self: &Arc<Self>) -> WorkerTicket {
         WorkerTicket {
             gate: Arc::clone(self),
@@ -150,7 +167,7 @@ impl StartGate {
     /// Public because not every harness fans out over scoped threads: the
     /// Weaviate gRPC path drives `tokio` tasks and coordinates the same gate by
     /// hand. Thread-based harnesses should use [`WorkerPool`] instead.
-    pub fn wait_ready(&self, expected: usize) -> Result<(), String> {
+    pub fn wait_ready(&self, label: &str, expected: usize) -> Result<(), String> {
         let mut st = self.lock();
         while st.settled < expected && st.phase != Phase::Aborted {
             st = self.cv.wait(st).unwrap_or_else(|e| e.into_inner());
@@ -181,7 +198,7 @@ impl StartGate {
         self.cv.notify_all();
 
         Err(format!(
-            "only {ready} of {expected} search workers reached the start gate — {}. \
+            "only {ready} of {expected} {label} workers reached the start gate — {}. \
              Refusing to report a run at parallel={expected} that measured fewer workers",
             parts.join(", ")
         ))
@@ -227,6 +244,32 @@ enum Outcome {
     Ready,
     Lost,
     Failed(String),
+}
+
+/// Aborts a [`StartGate`] if it is still un-released when this guard drops.
+///
+/// [`WorkerPool`] does this in its own `Drop`. A harness that drives a bare
+/// `StartGate` — currently only the Weaviate gRPC path, which fans out `tokio`
+/// tasks rather than scoped threads — **must** hold one of these across the
+/// whole fan-out, declared *after* whatever owns the workers (the tokio
+/// `Runtime`, say) so that drop order aborts the gate before the workers are
+/// joined. Without it, a coordinator panic between the first `ticket()` and
+/// `wait_ready` leaves the parked workers on a condvar nobody will ever notify.
+///
+/// Aborting after a successful release is a no-op, so the guard needs no
+/// disarm and can simply fall out of scope on the happy path.
+pub struct AbortGateOnDrop(Arc<StartGate>);
+
+impl AbortGateOnDrop {
+    pub fn new(gate: &Arc<StartGate>) -> Self {
+        Self(Arc::clone(gate))
+    }
+}
+
+impl Drop for AbortGateOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 /// One worker's claim on the start gate.
@@ -324,10 +367,9 @@ fn injected_spawn_failure() -> bool {
 ///
 /// ```ignore
 /// let (results, measured_start) = std::thread::scope(|s| {
-///     let mut pool = WorkerPool::new(s, "redis-search");
+///     let mut pool = WorkerPool::new(s, "redis-search", parallel);
 ///     for _ in 0..parallel {
-///         let ticket = pool.ticket();
-///         pool.spawn(move || {
+///         pool.spawn(move |ticket| {
 ///             // ... connect + prime ...
 ///             let Some(start) = ticket.arrive_and_wait() else { return Default::default() };
 ///             // ... measured loop ...
@@ -336,30 +378,35 @@ fn injected_spawn_failure() -> bool {
 ///     pool.start()
 /// })?;
 /// ```
+///
+/// The pool mints each ticket and hands it to the worker closure, so a worker
+/// cannot be spawned without one and a ticket cannot be minted without a
+/// worker. That pairing is the whole deadlock-freedom argument; making it an
+/// API property rather than a convention is why there is no public `ticket()`
+/// here — see [`StartGate::ticket`] for the by-hand variant.
 pub struct WorkerPool<'scope, 'env: 'scope, T: Send + 'scope> {
     scope: &'scope Scope<'scope, 'env>,
     gate: Arc<StartGate>,
     handles: Vec<ScopedJoinHandle<'scope, T>>,
     label: &'static str,
+    /// How many workers the caller intends to run — the `parallel` the result
+    /// will be labelled with. Used for honest diagnostics, and checked against
+    /// the number actually spawned in [`Self::start_with`].
+    planned: usize,
 }
 
 impl<'scope, 'env: 'scope, T: Send + 'scope> WorkerPool<'scope, 'env, T> {
-    pub fn new(scope: &'scope Scope<'scope, 'env>, label: &'static str) -> Self {
+    pub fn new(scope: &'scope Scope<'scope, 'env>, label: &'static str, planned: usize) -> Self {
         Self {
             scope,
             gate: Arc::new(StartGate::new()),
             handles: Vec::new(),
             label,
+            planned,
         }
     }
 
-    /// Issue this worker's ticket. Must be called before [`Self::spawn`] and
-    /// moved into the worker closure.
-    pub fn ticket(&self) -> WorkerTicket {
-        self.gate.ticket()
-    }
-
-    /// Spawn one worker.
+    /// Spawn one worker, handing it its own start-gate ticket.
     ///
     /// Unlike `Scope::spawn`, an OS refusal (`EAGAIN` under `ulimit -u` or
     /// cgroup `pids.max`) is returned as `Err`, not a panic. The gate is
@@ -367,10 +414,16 @@ impl<'scope, 'env: 'scope, T: Send + 'scope> WorkerPool<'scope, 'env, T> {
     /// instead of being stranded when `thread::scope` joins them.
     pub fn spawn<F>(&mut self, f: F) -> Result<(), String>
     where
-        F: FnOnce() -> T + Send + 'scope,
+        F: FnOnce(WorkerTicket) -> T + Send + 'scope,
     {
         let index = self.handles.len();
         let name = format!("{}-{index}", self.label);
+        // Minted here, not by the caller: a spawned worker always has exactly
+        // one ticket, and a minted ticket always has exactly one worker. If the
+        // spawn below fails, the closure — and with it this ticket — is dropped,
+        // which settles it as lost.
+        let ticket = self.gate.ticket();
+        let f = move || f(ticket);
 
         #[cfg(test)]
         let spawned = if injected_spawn_failure() {
@@ -402,7 +455,7 @@ impl<'scope, 'env: 'scope, T: Send + 'scope> WorkerPool<'scope, 'env, T> {
                      limit (ulimit -u, cgroup pids.max)",
                     self.label,
                     index + 1,
-                    index + 1
+                    self.planned
                 ))
             }
         }
@@ -429,7 +482,18 @@ impl<'scope, 'env: 'scope, T: Send + 'scope> WorkerPool<'scope, 'env, T> {
         stamp: impl FnOnce() -> Instant,
     ) -> Result<(Vec<T>, Instant), String> {
         let expected = self.handles.len();
-        if let Err(e) = self.gate.wait_ready(expected) {
+        if expected != self.planned {
+            // Belt and braces on the caller's loop bound: reporting `parallel=N`
+            // for a run that only ever spawned N-1 workers is the same lie as
+            // losing one to the OS.
+            self.gate.abort();
+            self.drain();
+            return Err(format!(
+                "{} spawned {expected} workers but the run is labelled parallel={}",
+                self.label, self.planned
+            ));
+        }
+        if let Err(e) = self.gate.wait_ready(self.label, expected) {
             // `wait_ready` has already aborted the gate, so the parked workers
             // are on their way out. Join them here rather than leaving it to
             // `thread::scope`, which re-panics on an unjoined panicking thread
@@ -592,14 +656,63 @@ mod tests {
         worker: impl Fn(usize, WorkerTicket) -> usize + Sync,
     ) -> Result<(Vec<usize>, Instant), String> {
         std::thread::scope(|s| {
-            let mut pool = WorkerPool::new(s, "test");
+            let mut pool = WorkerPool::new(s, "test", parallel);
             for i in 0..parallel {
-                let ticket = pool.ticket();
                 let worker = &worker;
-                pool.spawn(move || worker(i, ticket))?;
+                pool.spawn(move |ticket| worker(i, ticket))?;
             }
             pool.start()
         })
+    }
+
+    #[test]
+    fn a_pool_that_spawns_fewer_workers_than_it_plans_is_an_error() {
+        // The ticket/worker pairing is an API property — `spawn` mints the
+        // ticket, so a worker cannot exist without one or vice versa. What the
+        // API cannot see is the caller's loop bound: spawning 3 workers for a
+        // point that will be published as `parallel=4` is the same lie as losing
+        // one to the OS, and used to be invisible.
+        let finished = finishes_within(PROMPT, || {
+            let err = std::thread::scope(|s| {
+                let mut pool: WorkerPool<'_, '_, ()> = WorkerPool::new(s, "test", 4);
+                for _ in 0..3 {
+                    pool.spawn(|ticket| {
+                        let _ = ticket.arrive_and_wait();
+                    })?;
+                }
+                pool.start()
+            })
+            .expect_err("spawning fewer workers than planned must be an error");
+            assert!(
+                err.contains("spawned 3 workers but the run is labelled parallel=4"),
+                "{err}"
+            );
+        });
+        assert!(finished, "a short-spawned pool hung instead of erroring");
+    }
+
+    #[test]
+    fn a_worker_that_settles_nothing_is_lost_not_hung() {
+        // The residual hazard the old `pool.ticket()` API allowed was a spawned
+        // worker with no ticket, which never settles. The closure-minted ticket
+        // makes that unrepresentable; the nearest reachable shape is a worker
+        // that simply returns, dropping its ticket. That must settle as lost.
+        let finished = finishes_within(PROMPT, || {
+            let err = run_pool(3, |i, ticket| {
+                if i == 1 {
+                    drop(ticket);
+                    return 0;
+                }
+                let _ = ticket.arrive_and_wait();
+                0
+            })
+            .expect_err("a worker that never reaches the gate must be an error");
+            assert!(
+                err.contains("only 2 of 3 test workers reached the start gate"),
+                "{err}"
+            );
+        });
+        assert!(finished, "a worker that dropped its ticket hung the pool");
     }
 
     #[test]
@@ -646,7 +759,7 @@ mod tests {
             })
             .expect_err("a worker that panics before the gate must be an error");
             assert!(
-                err.contains("only 3 of 4 search workers reached the start gate"),
+                err.contains("only 3 of 4 test workers reached the start gate"),
                 "error should quantify the shortfall: {err}"
             );
             assert!(
@@ -762,11 +875,10 @@ mod tests {
         let (_, start) = {
             let seen = Arc::clone(&seen);
             std::thread::scope(|s| {
-                let mut pool = WorkerPool::new(s, "test");
+                let mut pool = WorkerPool::new(s, "test", 3);
                 for _ in 0..3 {
-                    let ticket = pool.ticket();
                     let seen = Arc::clone(&seen);
-                    pool.spawn(move || {
+                    pool.spawn(move |ticket| {
                         let at = ticket.arrive_and_wait().expect("run must not abort");
                         seen.lock().unwrap().push(at);
                     })?;
@@ -810,12 +922,11 @@ mod tests {
             let gate_reached = Arc::clone(&gate_reached);
             move || {
                 let err = std::thread::scope(|s| {
-                    let mut pool: WorkerPool<'_, '_, ()> = WorkerPool::new(s, "test");
+                    let mut pool: WorkerPool<'_, '_, ()> = WorkerPool::new(s, "test", 3);
                     for _ in 0..2 {
-                        let ticket = pool.ticket();
                         let woke = Arc::clone(&woke);
                         let gate_reached = Arc::clone(&gate_reached);
-                        pool.spawn(move || {
+                        pool.spawn(move |ticket| {
                             gate_reached.wait();
                             assert!(
                                 ticket.arrive_and_wait().is_none(),
@@ -824,10 +935,13 @@ mod tests {
                             woke.fetch_add(1, Ordering::SeqCst);
                         })?;
                     }
-                    // Both workers are now parked at the gate.
-                    gate_reached.wait();
-                    let ticket = pool.ticket();
-                    ticket.fail("simulated late failure");
+                    // The third worker fails only once the first two have parked
+                    // — the ordering that used to strand them.
+                    let gate_reached = Arc::clone(&gate_reached);
+                    pool.spawn(move |ticket| {
+                        gate_reached.wait();
+                        ticket.fail("simulated late failure");
+                    })?;
                     pool.start()
                 })
                 .expect_err("the run must fail");
@@ -851,10 +965,9 @@ mod tests {
         let finished = finishes_within(PROMPT, || {
             let gate_reached = Arc::new(Barrier::new(2));
             let err: Result<(), String> = std::thread::scope(|s| {
-                let mut pool: WorkerPool<'_, '_, ()> = WorkerPool::new(s, "test");
-                let ticket = pool.ticket();
+                let mut pool: WorkerPool<'_, '_, ()> = WorkerPool::new(s, "test", 1);
                 let reached = Arc::clone(&gate_reached);
-                pool.spawn(move || {
+                pool.spawn(move |ticket| {
                     reached.wait();
                     let _ = ticket.arrive_and_wait();
                 })?;

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -11,6 +11,12 @@ services:
 
   pgvector:
     image: pgvector/pgvector:pg18
+    # Every search worker holds one connection for the whole run, and the
+    # shipped `pgvector-single-node.json` has 25 points at `parallel: 100`.
+    # Postgres defaults to max_connections=100 with 3 reserved for superusers,
+    # so a stock server cannot seat them — which is now a hard error rather
+    # than a run labelled `parallel: 100` that 97 workers actually ran (#214).
+    command: ["postgres", "-c", "max_connections=200"]
     environment:
       POSTGRES_PASSWORD: "passwd"
     ports:

--- a/tests/overhead_invariants.rs
+++ b/tests/overhead_invariants.rs
@@ -48,8 +48,228 @@ fn engine_dir() -> PathBuf {
 }
 
 fn read_engine(file: &str) -> String {
+    strip_comments_and_strings(&read_engine_raw(file))
+}
+
+/// The raw file, comments and all — for the few checks that need to see them.
+fn read_engine_raw(file: &str) -> String {
     let path = engine_dir().join(file);
     fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {}", path.display(), e))
+}
+
+/// Blank out comments and string/char literals, preserving line structure.
+///
+/// Every guard in this file is a substring search over source text, and every
+/// one of them was previously blind to the difference between code and prose.
+/// That is not hypothetical: INV-4 bans the `Barrier` type, and all 14 engines
+/// used to carry a comment *describing* the barrier it removed — so the guard
+/// would have forbidden documenting the very bug it exists to prevent.
+/// Newlines are preserved so reported line numbers stay true.
+fn strip_comments_and_strings(src: &str) -> String {
+    #[derive(PartialEq)]
+    enum St {
+        Code,
+        Line,
+        Block,
+        Str,
+        Chr,
+        RawStr,
+    }
+    let b: Vec<char> = src.chars().collect();
+    let mut out = String::with_capacity(src.len());
+    let mut st = St::Code;
+    let mut depth = 0usize;
+    let mut hashes = 0usize;
+    let mut i = 0usize;
+    while i < b.len() {
+        let c = b[i];
+        let next = b.get(i + 1).copied().unwrap_or('\0');
+        match st {
+            St::Code => {
+                if c == '/' && next == '/' {
+                    st = St::Line;
+                    out.push_str("  ");
+                    i += 2;
+                    continue;
+                }
+                if c == '/' && next == '*' {
+                    st = St::Block;
+                    depth = 1;
+                    out.push_str("  ");
+                    i += 2;
+                    continue;
+                }
+                if c == 'r' && (next == '"' || next == '#') {
+                    let prev_ident = i > 0 && (b[i - 1].is_alphanumeric() || b[i - 1] == '_');
+                    if !prev_ident {
+                        let mut j = i + 1;
+                        let mut h = 0;
+                        while j < b.len() && b[j] == '#' {
+                            h += 1;
+                            j += 1;
+                        }
+                        if j < b.len() && b[j] == '"' {
+                            st = St::RawStr;
+                            hashes = h;
+                            out.push_str(&" ".repeat(j - i + 1));
+                            i = j + 1;
+                            continue;
+                        }
+                    }
+                }
+                if c == '"' {
+                    st = St::Str;
+                    out.push(' ');
+                    i += 1;
+                    continue;
+                }
+                if c == '\'' {
+                    // lifetime (`'scope`) vs char literal: a char literal closes
+                    // within four characters.
+                    if let Some(k) = (1..=4).find(|k| b.get(i + k) == Some(&'\'')) {
+                        st = St::Chr;
+                        out.push_str(&" ".repeat(k));
+                        i += k;
+                        continue;
+                    }
+                }
+                out.push(c);
+                i += 1;
+            }
+            St::Line => {
+                if c == '\n' {
+                    st = St::Code;
+                    out.push('\n');
+                } else {
+                    out.push(' ');
+                }
+                i += 1;
+            }
+            St::Block => {
+                if c == '/' && next == '*' {
+                    depth += 1;
+                    out.push_str("  ");
+                    i += 2;
+                    continue;
+                }
+                if c == '*' && next == '/' {
+                    depth -= 1;
+                    out.push_str("  ");
+                    i += 2;
+                    if depth == 0 {
+                        st = St::Code;
+                    }
+                    continue;
+                }
+                out.push(if c == '\n' { '\n' } else { ' ' });
+                i += 1;
+            }
+            St::Str | St::Chr => {
+                if c == '\\' {
+                    out.push_str("  ");
+                    i += 2;
+                    continue;
+                }
+                let closing = if st == St::Str { '"' } else { '\'' };
+                if c == closing {
+                    st = St::Code;
+                }
+                out.push(if c == '\n' { '\n' } else { ' ' });
+                i += 1;
+            }
+            St::RawStr => {
+                if c == '"' {
+                    let mut h = 0;
+                    while b.get(i + 1 + h) == Some(&'#') {
+                        h += 1;
+                    }
+                    if h >= hashes {
+                        st = St::Code;
+                        out.push_str(&" ".repeat(1 + hashes));
+                        i += 1 + hashes;
+                        continue;
+                    }
+                }
+                out.push(if c == '\n' { '\n' } else { ' ' });
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Every `.rs` file under `src/`, as (repo-relative path, comment-stripped source).
+fn all_sources() -> Vec<(String, String)> {
+    fn walk(dir: &PathBuf, out: &mut Vec<PathBuf>) {
+        for entry in fs::read_dir(dir).expect("read dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(path);
+            }
+        }
+    }
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut paths = Vec::new();
+    walk(&root.join("src"), &mut paths);
+    paths.sort();
+    paths
+        .into_iter()
+        .map(|p| {
+            let src = fs::read_to_string(&p).expect("read source");
+            let rel = p
+                .strip_prefix(&root)
+                .unwrap_or(&p)
+                .to_string_lossy()
+                .replace('\\', "/");
+            (rel, strip_comments_and_strings(&src))
+        })
+        .collect()
+}
+
+/// Engines that own a gate-synchronized parallel search, derived from
+/// `engine/mod.rs` rather than hardcoded, so a new engine is opted IN by
+/// default and must be explicitly excused.
+fn gated_engine_files() -> Vec<String> {
+    // Modules with no parallel timed search of their own, or no gate by design.
+    // Each needs a reason; adding a name here is the reviewable act.
+    const EXCUSED: &[(&str, &str)] = &[
+        ("index_naming", "pure helper, no engine"),
+        ("redis_utils", "pure helper, no engine"),
+        ("vertex_grpc", "transport codegen, no engine"),
+        ("weaviate_grpc", "transport codegen, no engine"),
+        ("filter_guard", "pure helper, no engine"),
+        (
+            "turbopuffer",
+            "no warm-up gate by design: its workers start on spawn (tracked separately)",
+        ),
+    ];
+    let mod_rs = read_engine_raw("mod.rs");
+    let mut gated = Vec::new();
+    for line in mod_rs.lines() {
+        let line = line.trim();
+        let Some(rest) = line
+            .strip_prefix("mod ")
+            .or_else(|| line.strip_prefix("pub mod "))
+        else {
+            continue;
+        };
+        let Some(name) = rest.strip_suffix(';') else {
+            continue;
+        };
+        if EXCUSED.iter().any(|(e, _)| *e == name) {
+            continue;
+        }
+        gated.push(format!("{name}.rs"));
+    }
+    assert!(
+        gated.len() >= 14,
+        "expected at least 14 gated engines from engine/mod.rs, found {}: {:?}",
+        gated.len(),
+        gated
+    );
+    gated
 }
 
 /// INV-2 — no per-query metric buffer is pushed through a cross-thread mutex in
@@ -183,7 +403,7 @@ fn inv3_no_nearest_rank_percentile_indexing() {
     );
 }
 
-/// INV-4 — no fixed-count start barrier in a search harness (#214).
+/// INV-4 — no fixed-count start barrier anywhere under `src/` (#214).
 ///
 /// Every engine used to synchronize its measured-window start with
 /// `Barrier::new(parallel + 1)`, a participant count fixed *before* the workers
@@ -194,81 +414,168 @@ fn inv3_no_nearest_rank_percentile_indexing() {
 /// nothing breaks the hang.
 ///
 /// The replacement is `vector_db_benchmark::start_gate`, whose wait is
-/// satisfied by ticket *outcomes* rather than a count. This guard fails the
-/// moment a fixed-count barrier reappears in an engine.
+/// satisfied by ticket *outcomes* rather than a count.
+///
+/// This bans the TYPE, not one spelling of the call, so a type alias, a UFCS
+/// call, `use std::sync::Barrier as B`, and a helper in a different directory
+/// are all caught. It scans comment-stripped source, so documenting the removed
+/// bug is fine. A future *legitimate* barrier (an upload rendezvous, say) opts
+/// out per line with an `INV-4-ALLOW:` marker and a reason — deliberately
+/// noisy, so it surfaces in review.
 #[test]
-fn inv4_no_fixed_count_start_barrier_in_search_harnesses() {
+fn inv4_no_fixed_count_start_barrier() {
+    // `start_gate.rs` owns the `legacy_*` tests that replicate the pre-fix
+    // barrier shape and assert it deadlocks. Banning `Barrier` there would
+    // delete the proof that the module is worth having.
+    const OWNS_THE_PROOF: &str = "src/start_gate.rs";
+
     let mut violations = Vec::new();
-    for entry in fs::read_dir(engine_dir()).expect("read engine dir") {
-        let path = entry.expect("dir entry").path();
-        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+    for (path, src) in all_sources() {
+        if path == OWNS_THE_PROOF {
             continue;
         }
-        let src = fs::read_to_string(&path).expect("read engine source");
-        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        let raw = fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(&path))
+            .expect("read source");
+        let raw_lines: Vec<&str> = raw.lines().collect();
         for (lineno, line) in src.lines().enumerate() {
-            if line.contains("Barrier::new(") {
-                violations.push(format!("  {}:{} {}", name, lineno + 1, line.trim()));
+            let mentions_type = line.contains("Barrier::")
+                || line.contains("sync::Barrier")
+                || line.contains(" Barrier<")
+                || line.contains(": Barrier")
+                || line.contains("Barrier>")
+                || line.contains(", Barrier")
+                || line.contains("{Barrier");
+            if !mentions_type {
+                continue;
             }
-        }
-    }
-
-    assert!(
-        violations.is_empty(),
-        "INV-4 VIOLATED: a fixed-count start barrier reappeared in an engine. Sizing the \
-         wait before the workers exist deadlocks the run when the OS refuses a thread or a \
-         worker panics before arriving (#214) — use `vector_db_benchmark::start_gate::\
-         WorkerPool` / `StartGate`, whose wait is satisfied by ticket outcomes. \
-         Offenders:\n{}",
-        violations.join("\n")
-    );
-}
-
-/// INV-4b — every engine that fans out a timed search actually routes its start
-/// through the gate. Without this, INV-4 could be "satisfied" by an engine that
-/// grew some other fixed-count wait, or by one that silently lost its
-/// synchronized start altogether.
-#[test]
-fn inv4_search_harnesses_route_through_the_start_gate() {
-    // Engines with a parallel, gate-synchronized measured window. Turbopuffer is
-    // absent deliberately: it has no warm-up gate, its workers start on spawn.
-    const GATED: &[&str] = &[
-        "chroma.rs",
-        "dragonfly.rs",
-        "elasticsearch.rs",
-        "kividb.rs",
-        "milvus.rs",
-        "mongodb_engine.rs",
-        "opensearch.rs",
-        "pgvector.rs",
-        "qdrant.rs",
-        "redis.rs",
-        "valkey.rs",
-        "vectorsets.rs",
-        "vertex.rs",
-        "weaviate.rs",
-    ];
-
-    let mut missing = Vec::new();
-    for &file in GATED {
-        let src = read_engine(file);
-        let uses_gate = src.contains("start_gate::WorkerPool")
-            || src.contains("start_gate::{StartGate, WorkerPool}");
-        let arrives = src.contains("ticket.arrive_and_wait()");
-        if !uses_gate || !arrives {
-            missing.push(format!(
-                "  {} (imports gate: {}, parks at gate: {})",
-                file, uses_gate, arrives
+            // The opt-out marker lives in a comment, so read the RAW line —
+            // either trailing the offending line, or on the line above it (a
+            // `use` statement reads better with the reason above it).
+            let marked = |n: usize| raw_lines.get(n).is_some_and(|l| l.contains("INV-4-ALLOW:"));
+            if marked(lineno) || (lineno > 0 && marked(lineno - 1)) {
+                continue;
+            }
+            violations.push(format!(
+                "  {}:{} {}",
+                path,
+                lineno + 1,
+                raw_lines.get(lineno).unwrap_or(&"").trim()
             ));
         }
     }
 
     assert!(
-        missing.is_empty(),
-        "INV-4b VIOLATED: a search harness no longer starts its workers through \
-         `start_gate` (#214). Either it regressed to an ad-hoc synchronization \
-         primitive, or its warm-up gate was dropped and connection setup is back \
-         inside the measured window. Offenders:\n{}",
-        missing.join("\n")
+        violations.is_empty(),
+        "INV-4 VIOLATED: `std::sync::Barrier` reappeared under src/. Sizing a wait before the \
+         workers exist deadlocks the run when the OS refuses a thread or a worker panics before \
+         arriving (#214) — use `vector_db_benchmark::start_gate::WorkerPool` / `StartGate`, whose \
+         wait is satisfied by ticket outcomes. If a barrier here genuinely cannot deadlock, add \
+         `// INV-4-ALLOW: <reason>` on the line. Offenders:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// INV-4b — every engine that fans out a timed search actually routes its start
+/// through the gate, once per harness, in the right place.
+///
+/// Without this, INV-4 could be "satisfied" by an engine that grew some other
+/// fixed-count wait, or by one that dropped its synchronized start altogether.
+/// The engine list is derived from `engine/mod.rs`, so a new engine is opted in
+/// by default.
+#[test]
+fn inv4_search_harnesses_route_through_the_start_gate() {
+    let mut problems = Vec::new();
+
+    for file in gated_engine_files() {
+        let src = read_engine(&file);
+
+        // (a) it uses the gate at all.
+        let pools = src.matches("WorkerPool::new(").count();
+        let bare_gates = src.matches("StartGate::new()").count();
+        let harnesses = pools + bare_gates;
+        if harnesses == 0 {
+            problems.push(format!(
+                "  {file}: no `WorkerPool::new` / `StartGate::new` — the synchronized start is \
+                 gone, so connection setup and the cold first query are back inside the measured \
+                 window"
+            ));
+            continue;
+        }
+
+        // (b) exactly one park per harness. Catches un-gating ONE of the two
+        //     harnesses in weaviate (gRPC/GraphQL) or vertex (search/mixed).
+        let parks = src.matches("ticket.arrive_and_wait()").count();
+        if parks != harnesses {
+            problems.push(format!(
+                "  {file}: {harnesses} harness(es) but {parks} `ticket.arrive_and_wait()` call(s) \
+                 — one of them no longer parks at the gate"
+            ));
+        }
+
+        // (c) the abort verdict is honoured. `let _ = ticket.arrive_and_wait();`
+        //     compiles, satisfies `#[must_use]`, and silently lets every worker
+        //     run on its own clock after an aborted start.
+        if src.contains("let _ = ticket.arrive_and_wait()") {
+            problems.push(format!(
+                "  {file}: discards the `arrive_and_wait` verdict with `let _ =`. `None` means \
+                 the run was aborted; the worker must return, not measure"
+            ));
+        }
+
+        // (d) the park sits BELOW setup. Every gated harness reports at least one
+        //     setup failure through `ticket.fail(...)` before it parks; if the
+        //     first park precedes the first `fail`, the park was hoisted above
+        //     client construction / the prime query, putting connection setup
+        //     back inside the measured window — the regression (a) is meant to
+        //     catch and cannot.
+        let (Some(first_park), Some(first_fail)) = (
+            src.find("ticket.arrive_and_wait()"),
+            src.find("ticket.fail("),
+        ) else {
+            problems.push(format!(
+                "  {file}: no `ticket.fail(...)` — a worker that cannot set itself up is silently \
+                 reducing the run's real concurrency again"
+            ));
+            continue;
+        };
+        if first_park < first_fail {
+            problems.push(format!(
+                "  {file}: parks at the gate before its first setup-failure arm, so client \
+                 construction and the prime query happen AFTER the start stamp — connection setup \
+                 is back inside the measured window"
+            ));
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "INV-4b VIOLATED (#214):\n{}",
+        problems.join("\n")
+    );
+}
+
+/// INV-4c — the bare-`StartGate` harnesses hold an abort guard.
+///
+/// `WorkerPool` aborts its gate in `Drop`, so any early return from the scope
+/// closure releases parked workers. A harness driving `StartGate` by hand has no
+/// such cover: a coordinator panic between the first `ticket()` and `wait_ready`
+/// leaves the workers on a condvar nobody notifies, and whatever owns them (a
+/// tokio `Runtime`) then joins them forever — #214's own shape.
+#[test]
+fn inv4_bare_start_gate_users_hold_an_abort_guard() {
+    let mut problems = Vec::new();
+    for file in gated_engine_files() {
+        let src = read_engine(&file);
+        if src.contains("StartGate::new()") && !src.contains("AbortGateOnDrop::new(") {
+            problems.push(format!(
+                "  {file}: drives a bare `StartGate` without an `AbortGateOnDrop`"
+            ));
+        }
+    }
+    assert!(
+        problems.is_empty(),
+        "INV-4c VIOLATED (#214): a hand-driven start gate can be abandoned without releasing the \
+         workers parked at it:\n{}",
+        problems.join("\n")
     );
 }

--- a/tests/overhead_invariants.rs
+++ b/tests/overhead_invariants.rs
@@ -182,3 +182,93 @@ fn inv3_no_nearest_rank_percentile_indexing() {
         violations.join("\n")
     );
 }
+
+/// INV-4 — no fixed-count start barrier in a search harness (#214).
+///
+/// Every engine used to synchronize its measured-window start with
+/// `Barrier::new(parallel + 1)`, a participant count fixed *before* the workers
+/// exist. Two ordinary failures then hang the run forever with no output: the
+/// OS refusing a thread (`Scope::spawn` panics; the workers already parked at
+/// the barrier are joined by `thread::scope` and never released), and a worker
+/// panicking before it arrives. `--search-timeout` defaults to `0.0`, so
+/// nothing breaks the hang.
+///
+/// The replacement is `vector_db_benchmark::start_gate`, whose wait is
+/// satisfied by ticket *outcomes* rather than a count. This guard fails the
+/// moment a fixed-count barrier reappears in an engine.
+#[test]
+fn inv4_no_fixed_count_start_barrier_in_search_harnesses() {
+    let mut violations = Vec::new();
+    for entry in fs::read_dir(engine_dir()).expect("read engine dir") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let src = fs::read_to_string(&path).expect("read engine source");
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        for (lineno, line) in src.lines().enumerate() {
+            if line.contains("Barrier::new(") {
+                violations.push(format!("  {}:{} {}", name, lineno + 1, line.trim()));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "INV-4 VIOLATED: a fixed-count start barrier reappeared in an engine. Sizing the \
+         wait before the workers exist deadlocks the run when the OS refuses a thread or a \
+         worker panics before arriving (#214) — use `vector_db_benchmark::start_gate::\
+         WorkerPool` / `StartGate`, whose wait is satisfied by ticket outcomes. \
+         Offenders:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// INV-4b — every engine that fans out a timed search actually routes its start
+/// through the gate. Without this, INV-4 could be "satisfied" by an engine that
+/// grew some other fixed-count wait, or by one that silently lost its
+/// synchronized start altogether.
+#[test]
+fn inv4_search_harnesses_route_through_the_start_gate() {
+    // Engines with a parallel, gate-synchronized measured window. Turbopuffer is
+    // absent deliberately: it has no warm-up gate, its workers start on spawn.
+    const GATED: &[&str] = &[
+        "chroma.rs",
+        "dragonfly.rs",
+        "elasticsearch.rs",
+        "kividb.rs",
+        "milvus.rs",
+        "mongodb_engine.rs",
+        "opensearch.rs",
+        "pgvector.rs",
+        "qdrant.rs",
+        "redis.rs",
+        "valkey.rs",
+        "vectorsets.rs",
+        "vertex.rs",
+        "weaviate.rs",
+    ];
+
+    let mut missing = Vec::new();
+    for &file in GATED {
+        let src = read_engine(file);
+        let uses_gate = src.contains("start_gate::WorkerPool")
+            || src.contains("start_gate::{StartGate, WorkerPool}");
+        let arrives = src.contains("ticket.arrive_and_wait()");
+        if !uses_gate || !arrives {
+            missing.push(format!(
+                "  {} (imports gate: {}, parks at gate: {})",
+                file, uses_gate, arrives
+            ));
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "INV-4b VIOLATED: a search harness no longer starts its workers through \
+         `start_gate` (#214). Either it regressed to an ad-hoc synchronization \
+         primitive, or its warm-up gate was dropped and connection setup is back \
+         inside the measured window. Offenders:\n{}",
+        missing.join("\n")
+    );
+}

--- a/tests/overhead_invariants.rs
+++ b/tests/overhead_invariants.rs
@@ -166,7 +166,19 @@ fn strip_comments_and_strings(src: &str) -> String {
             }
             St::Str | St::Chr => {
                 if c == '\\' {
-                    out.push_str("  ");
+                    // An escape consumes two characters — but a `\`-plus-newline
+                    // string continuation's second character IS the newline, and
+                    // swallowing it shifts every line below it up by one. There
+                    // are 219 such continuations under `src/`, so the guards
+                    // would quote the wrong source line and, worse, match an
+                    // `INV-4-ALLOW:` marker against the wrong line: a marker
+                    // three lines above an unrelated barrier would exempt it.
+                    out.push(' ');
+                    match b.get(i + 1) {
+                        Some('\n') => out.push('\n'),
+                        Some(_) => out.push(' '),
+                        None => {}
+                    }
                     i += 2;
                     continue;
                 }
@@ -403,6 +415,17 @@ fn inv3_no_nearest_rank_percentile_indexing() {
     );
 }
 
+/// Does this raw line carry an `INV-4-ALLOW:` opt-out?
+fn line_carries_allow(line: Option<&str>) -> bool {
+    line.is_some_and(|l| l.contains("INV-4-ALLOW:"))
+}
+
+/// Is this raw line a STANDALONE `INV-4-ALLOW:` comment — one that annotates the
+/// line below it rather than the line it trails?
+fn standalone_allow(line: Option<&str>) -> bool {
+    line.is_some_and(|l| l.trim_start().starts_with("//") && l.contains("INV-4-ALLOW:"))
+}
+
 /// INV-4 — no fixed-count start barrier anywhere under `src/` (#214).
 ///
 /// Every engine used to synchronize its measured-window start with
@@ -448,11 +471,15 @@ fn inv4_no_fixed_count_start_barrier() {
             if !mentions_type {
                 continue;
             }
-            // The opt-out marker lives in a comment, so read the RAW line —
-            // either trailing the offending line, or on the line above it (a
-            // `use` statement reads better with the reason above it).
-            let marked = |n: usize| raw_lines.get(n).is_some_and(|l| l.contains("INV-4-ALLOW:"));
-            if marked(lineno) || (lineno > 0 && marked(lineno - 1)) {
+            // The opt-out marker lives in a comment, so read the RAW line. It
+            // may trail the offending line, or sit on the line immediately
+            // above as a STANDALONE comment (a `use` statement reads better
+            // with the reason above it). "Standalone" matters: a marker
+            // trailing line N must not also exempt line N+1, or one annotated
+            // barrier quietly covers its unannotated neighbour.
+            if line_carries_allow(raw_lines.get(lineno).copied())
+                || (lineno > 0 && standalone_allow(raw_lines.get(lineno - 1).copied()))
+            {
                 continue;
             }
             violations.push(format!(
@@ -577,5 +604,136 @@ fn inv4_bare_start_gate_users_hold_an_abort_guard() {
         "INV-4c VIOLATED (#214): a hand-driven start gate can be abandoned without releasing the \
          workers parked at it:\n{}",
         problems.join("\n")
+    );
+}
+
+/// The comment/string stripper must be line-for-line aligned with its input.
+///
+/// Every guard above reports `path:line` from the STRIPPED text and reads the
+/// `INV-4-ALLOW:` opt-out from the RAW line at that index, so the two must agree
+/// exactly. A `\`-plus-newline string continuation used to swallow its newline,
+/// which shifted everything below it up: violations quoted the wrong source
+/// line, a marker on the real line was ignored, and a marker three lines above
+/// an unrelated barrier silently exempted it. There are 219 such continuations
+/// under `src/`, so this was not a corner case — it was latent only because no
+/// `INV-4-ALLOW:` marker exists yet.
+#[test]
+fn stripper_is_line_for_line_aligned_with_its_input() {
+    // A continuation, an escaped quote, a raw string, a lifetime, a char
+    // literal, a block comment and a line comment — each on a known line.
+    let src = concat!(
+        "fn a() {\n",                                // 1
+        "    let s = \"one \\\n",                    // 2  <- `\`-continuation
+        "         two\";\n",                         // 3
+        "    let q = \"he said \\\"hi\\\"\";\n",     // 4
+        "    let r = r#\"raw \" not a close\n",      // 5
+        "       still raw\"#;\n",                    // 6
+        "    /* block\n",                            // 7
+        "       comment */\n",                       // 8
+        "    let c = '\\n';\n",                      // 9
+        "    let g: &'static str = \"x\";\n",        // 10
+        "    // Barrier::new(n + 1) in a comment\n", // 11
+        "    let ready = Barrier::new(n + 1);\n",    // 12
+        "}\n",                                       // 13
+    );
+    let stripped = strip_comments_and_strings(src);
+
+    assert_eq!(
+        stripped.lines().count(),
+        src.lines().count(),
+        "stripper changed the line count:\n--- raw ---\n{src}\n--- stripped ---\n{stripped}"
+    );
+
+    let raw: Vec<&str> = src.lines().collect();
+    let out: Vec<&str> = stripped.lines().collect();
+    for (i, (r, o)) in raw.iter().zip(out.iter()).enumerate() {
+        assert_eq!(
+            r.chars().count(),
+            o.chars().count(),
+            "line {} changed width: {r:?} -> {o:?}",
+            i + 1
+        );
+    }
+
+    // The only surviving `Barrier` must be the code one on line 12, not the
+    // comment on line 11 — and it must be reported as line 12.
+    let hits: Vec<usize> = out
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.contains("Barrier::"))
+        .map(|(i, _)| i + 1)
+        .collect();
+    assert_eq!(hits, vec![12], "stripped text:\n{stripped}");
+}
+
+/// The same alignment property, asserted over every real source file rather
+/// than a fixture — the fixture cannot anticipate the next construct someone
+/// writes.
+#[test]
+fn stripper_preserves_line_count_of_every_source_file() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut checked = 0usize;
+    let mut continuations = 0usize;
+    for (path, stripped) in all_sources() {
+        let raw = fs::read_to_string(root.join(&path)).expect("read source");
+        continuations += raw.matches("\\\n").count();
+        assert_eq!(
+            stripped.lines().count(),
+            raw.lines().count(),
+            "{path}: stripping changed the line count, so every guard below the \
+             first offset line would quote the wrong source line and match \
+             `INV-4-ALLOW:` against the wrong one"
+        );
+        checked += 1;
+    }
+    assert!(
+        checked > 20,
+        "expected to scan the whole tree, saw {checked} files"
+    );
+    assert!(
+        continuations > 100,
+        "expected the tree to still contain `\\`-continuations (the case this pins); \
+         saw {continuations}"
+    );
+}
+
+/// The `INV-4-ALLOW:` opt-out actually exempts the line it is written on, and
+/// only that line — the property the misalignment silently broke.
+#[test]
+fn inv4_allow_marker_exempts_only_its_own_line() {
+    // Reproduces the shape that failed: a `\`-continuation above the barriers.
+    // Line 4 carries a TRAILING marker (exempt, and only itself). Line 5 has
+    // none and must be reported even though line 4's marker is directly above
+    // it. Line 6 is a STANDALONE marker comment, so line 7 is exempt.
+    let src = concat!(
+        "fn a() {\n",
+        "    let msg = \"a long message \\\n",
+        "        continued here\";\n",
+        "    let x = Barrier::new(n + 1); // INV-4-ALLOW: pinned by test\n",
+        "    let y = Barrier::new(n + 1);\n",
+        "    // INV-4-ALLOW: annotates the line below\n",
+        "    let z = Barrier::new(n + 1);\n",
+        "}\n",
+    );
+    let stripped = strip_comments_and_strings(src);
+    let raw: Vec<&str> = src.lines().collect();
+
+    let mut unexempted = Vec::new();
+    for (lineno, line) in stripped.lines().enumerate() {
+        if !line.contains("Barrier::") {
+            continue;
+        }
+        if line_carries_allow(raw.get(lineno).copied())
+            || (lineno > 0 && standalone_allow(raw.get(lineno - 1).copied()))
+        {
+            continue;
+        }
+        unexempted.push(lineno + 1);
+    }
+    assert_eq!(
+        unexempted,
+        vec![5],
+        "line 4 (trailing marker) and line 7 (standalone marker above) must be exempt; \
+         line 5 must NOT be exempted by line 4's trailing marker"
     );
 }


### PR DESCRIPTION
## The bug

Every engine's `search()` synchronized its measured-window start with `Barrier::new(parallel + 1)` — a participant count fixed **before** the workers exist. Two ordinary failures make that count unmeetable, and both produce a **permanent hang with no output** rather than an error:

1. **The OS refuses a thread.** `Scope::spawn` panics on `EAGAIN` (`ulimit -u`, cgroup `pids.max` — i.e. any CI container with a large `parallel`). The panic unwinds into `thread::scope`'s drop, which joins the workers already spawned; they are parked in `ready.wait()` waiting for `parallel + 1` arrivals that can never happen.
2. **A worker panics before the barrier** — e.g. an out-of-bounds index in the "prime" query on a short query set. The coordinator then parks in `ready.wait()` forever.

`--search-timeout` defaults to `0.0` (disabled), so no watchdog breaks it.

## The second half: a published number whose name lies

The barrier deadlock is the headline, but the same code had a quieter defect that needed no fault injection at all. Both cases below are a **shipped config against a stock server**, reproduced during review:

**pgvector `parallel: 100` (25 such points in `pgvector-single-node.json`) against Postgres 17 with `max_connections=64`:**

| | master | this branch |
|---|---|---|
| exit code | **0** | 1 |
| published | `parallel: 100`, `rps: 23.5` | *(nothing)* |
| server log | **36 × `FATAL: sorry, too many clients already`** | same |
| stderr | *(silent)* | `only 64 of 100 pgvector-search workers reached the start gate — 36 failed setup: pgvector-search worker connect failed: FATAL: sorry, too many clients already` |

A 64-wide run labelled 100. The 36 failed workers crossed both barriers, returned empty, and had their errors discarded with no log line.

**Redis `maxclients=24`, `parallel: 64`:** master exits 0 and publishes `parallel: 64, rps: 299.5, failed_queries: 0, mean_recall: 1.0` — measured by 24 workers. This branch exits 1 with `only 24 of 64 redis-search workers reached the start gate — 40 failed setup … Refusing to report a run at parallel=64 that measured fewer workers`.

## Blast radius (independently derived)

The issue named 6 engines; [its own follow-up comment](https://github.com/redis/vector-db-benchmark/issues/214#issuecomment) had already raised that to 13. `grep -rn 'Barrier::new'` over `src/` gives **15 harnesses across 14 engines** — the extra being vertex, whose two harnesses spell it `Barrier::new(workers + 1)`:

| file | harness | shape |
|---|---|---|
| chroma, dragonfly, elasticsearch, kividb, milvus, mongodb, opensearch, pgvector, qdrant, redis, valkey, vectorsets | `search` | `ready` + `go` + `OnceLock` start cell |
| weaviate | `search` gRPC **and** GraphQL | one barrier pair shared by both branches |
| vertex | `search` **and** `mixed` | one barrier + `OnceLock` + spin |

Checked for the same shape in other fixed-count primitives and found none: no `mpsc` channel awaiting N messages (the only channel is `experiment.rs`'s watchdog, which uses `recv_timeout` and is disconnect-safe), no `Condvar`/latch counters, no `WaitGroup`. `src/redisearch/` and `src/vectorsets/` also contain barrier-free scopes but are not declared in `lib.rs` and are not compiled (confirmed against cargo's own dep-info).

23 `s.spawn` sites remain, in the upload / filter-only / mixed / turbopuffer paths. None has a fixed-count wait, so a refused spawn there panics loudly rather than hanging: 8 rely on an explicit `h.join().unwrap()` and 15 on `thread::scope`'s implicit join, and either way the panic reaches the main thread. **One of them — `turbopuffer.rs:586` — is nonetheless inside a *timed* search harness**, so it measures connection setup inside the window; that and seven other timed harnesses are #266.

## The fix

New `vector_db_benchmark::start_gate` replaces both barriers and the `OnceLock` start cell with a gate whose wait is satisfied by ticket **outcomes** rather than a count:

* `WorkerPool::spawn` goes through `thread::Builder::spawn_scoped`, which returns `io::Result` instead of panicking, **and mints the worker's ticket itself**, handing it to the closure. A worker cannot exist without a ticket, or a ticket without a worker — that pairing is the whole deadlock-freedom argument, so it is an API property, not a convention. `WorkerPool::new` also takes the planned worker count, and `start` refuses a pool that spawned fewer than it plans.
* A ticket settles by arriving, by reporting a setup failure, or — via `Drop` — by being lost to a panic or to a thread the OS never started. Any terminal outcome satisfies the coordinator, so no arrival count is ever left unmet.
* `Drop for WorkerPool` aborts the gate, so an early `?` anywhere in the scope closure releases parked workers. Weaviate's gRPC path fans out `tokio` tasks rather than scoped threads and drives a bare `StartGate`, so it holds an `AbortGateOnDrop` declared *after* the runtime — without it, a coordinator-future panic left tasks parked on a condvar and `Runtime::drop` joined them forever, which is #214's own shape. INV-4c now requires that guard.

Vertex's open-loop path keeps its 100 ms scheduling lead via `start_with`. Every other engine's diff is mechanical.

## Failure semantics

Per the settled policy — anything that changes the reported number is a hard error. A worker that never started, died before the gate, failed setup, or panicked mid-run means the run measured fewer workers than the `parallel` it reports, so `WorkerPool::start` returns `Err` naming what happened.

**Scope of the "silent degradation" half.** This closes it for the closed-loop `search()` of 14 engines only. `search_mixed` (4 engines), `search_filter_only` (3) and `turbopuffer::search` still publish a `parallel` from config with no guard — tracked in #266.

**Mid-run panics are a diagnostic improvement, not a correctness fix.** Master does not publish a wrong result here: all 14 engines used `h.join().unwrap()`, so a worker panic re-panics on the main thread and the process exits 101. The gain is a clean exit 1 with `1 of 8 redis-search workers panicked mid-run; discarding the run rather than reporting partial results`, and a named thread (`redis-search-4`) where master prints `thread '<unnamed>'`.

## Reproduction — before / after

**Real `RLIMIT_NPROC`** (`ulimit -u` set 8 above the current task count, `parallel=64`), against the pre-fix shape extracted verbatim into a standalone binary:

* unfixed: panics `failed to spawn thread: Os { code: 11, kind: WouldBlock }`, then **hangs**. SIGKILLed at 30 s in 2 of 3 runs; the third could not start because `timeout` itself could not fork. 30 s is the `timeout` bound — a floor, not a measured hang duration.
* fixed: errors in **~1–2 ms** (1.04 / 1.78 / 2.20 ms over three clean runs) with `could not start redis-search worker 7 of 64: Resource temporarily unavailable (os error 11). The OS refused the thread — lower parallel, or raise the thread/process limit (ulimit -u, cgroup pids.max)`. Single-machine numbers, and the extraction harness is not in this diff; an independent reviewer measured 142 µs–9.3 ms on other boxes, and one noisier box 17–27 ms. The claim reproduces qualitatively, not to the decimal.

**In CI**, deterministically, via a `#[cfg(test)]` thread-local spawn-failure seam (absent from a release build by both `strings` and `nm` — a test seam, not a runtime backdoor), plus real worker panics and real dropped tickets. Reverting the gate to the pre-fix semantics — fixed arrival count, no `Drop` settling, `Scope::spawn`'s panic, failed workers crossing both barriers, no planned-vs-spawned check — turns **6 of the 13** start-gate tests red:

```
running 13 tests
test start_gate::tests::early_return_from_the_scope_closure_does_not_strand_parked_workers ... ok
test start_gate::tests::start_with_hands_every_worker_the_caller_chosen_instant ... ok
test start_gate::tests::worker_panic_after_the_gate_is_reported_not_swallowed ... ok
test start_gate::tests::zero_workers_is_not_a_hang ... ok
test start_gate::tests::all_workers_observe_one_shared_start_after_every_worker_warmed ... ok
test start_gate::tests::legacy_fixed_count_barrier_hangs_when_a_spawn_fails ... ok
test start_gate::tests::legacy_fixed_count_barrier_hangs_when_a_worker_panics ... ok
test start_gate::tests::spawn_failure_is_a_prompt_error_not_a_hang ... FAILED
test start_gate::tests::a_pool_that_spawns_fewer_workers_than_it_plans_is_an_error ... FAILED
test start_gate::tests::a_worker_that_settles_nothing_is_lost_not_hung ... FAILED
test start_gate::tests::abort_releases_workers_already_parked_at_the_gate ... FAILED
test start_gate::tests::worker_setup_failure_is_a_hard_error_not_a_quieter_run ... FAILED
test start_gate::tests::worker_panic_before_the_gate_is_a_prompt_error_not_a_hang ... FAILED

test result: FAILED. 7 passed; 6 failed; 0 ignored; 0 measured; 98 filtered out; finished in 5.01s
```

Those six only *report* rather than hanging forever because each wraps its call in a 5 s watchdog. **With the watchdog raised to an hour, four of them are SIGKILLed at the 30 s `timeout` bound** — `spawn_failure_…`, `worker_panic_before_the_gate_…`, `worker_setup_failure_…`, `a_worker_that_settles_nothing_…`. On this branch all 13 pass; the suite takes 2.00 s, which is the two `legacy_*` hang proofs deliberately watching a known-deadlocked shape for 2 s each. Every other test completes well under the 5 s bound it asserts (per-test timing is nightly-only, so no finer figure is quoted).

## Tests and guards

* `src/start_gate.rs` — 13 unit tests. Two `legacy_*` tests replicate the pre-fix `Barrier` shape under both failure modes and assert it **never** completes, so "the new code returns `Err`" is evidence of something rather than a tautology. Reviewers confirmed they are non-tautological: neutering `Drop for WorkerTicket` alone produces exactly one failure, a full pre-fix revert produces six.
* `tests/overhead_invariants.rs` — **this file had never run in CI.** Every `cargo test` in the workflows is `--lib --bins --release` (which does not build `tests/*.rs`) or a named `--test integration_<engine>`, so INV-2 and INV-3 have been unenforced since they landed, and INV-4 would have been unfailable on day one. This PR adds `cargo test --test overhead_invariants --release` to the unit-test job.
* All guards now scan comment- and string-stripped source. This was a live hazard, not hygiene: INV-4 bans the `Barrier` type, and all 14 engines used to carry a comment *describing* the barrier it removes, so the guard forbade documenting its own subject.
* **INV-4** bans the `Barrier` *type* anywhere under `src/`, not one spelling of the call — closing the alias, type-alias, UFCS and other-directory evasions at once — with a per-line `// INV-4-ALLOW: <reason>` opt-out so a future legitimate barrier is possible but reviewable.
* **INV-4b** derives its engine list from `engine/mod.rs` (new engines opted in by default; each exclusion carries a reason), requires one park *per harness* so ungating one of vertex's or weaviate's two is caught, bans `let _ = ticket.arrive_and_wait()`, and requires the park to sit below the first setup-failure arm — which catches hoisting it above client construction, i.e. connection setup back inside the measured window.
* **INV-4c** requires an `AbortGateOnDrop` wherever a bare `StartGate` is driven.

**Mutation campaign — 10/10 as intended** (8 realistic misses killed, 2 false-positive probes left alone):

| mutant | verdict |
|---|---|
| `let _ = ticket.arrive_and_wait()` (redis) | KILLED |
| park hoisted above client construction (chroma) | KILLED |
| one of vertex's two harnesses un-gated | KILLED |
| `use std::sync::Barrier as Rendezvous` (kividb) | KILLED |
| `type Gate = std::sync::Barrier` + UFCS (milvus) | KILLED |
| `AbortGateOnDrop` removed (weaviate) | KILLED |
| verdict discarded at a second site (pgvector) | KILLED |
| brand-new engine file with `Barrier::new` | KILLED |
| `Barrier::new` in a **comment** | survived *(correct)* |
| legitimate barrier with `INV-4-ALLOW` | survived *(correct)* |

The three API-level mutants reviewers used to break the ticket/spawn pairing are now **unrepresentable**: `pool.spawn(\|\| {})` and `pool.ticket()` fail to compile (`E0593`, `E0599`), and minting N-1 for N planned fails at runtime with `test spawned 3 workers but the run is labelled parallel=4`.

## Other review fixes

* `WorkerPool::spawn`'s error read "worker *k* of *k*" (both operands were `index + 1`); it now names the planned `parallel` — `worker 7 of 64`.
* `StartGate::wait_ready` takes the harness label, so "N never reached the start gate" says which engine.
* pgvector's setup-failure message went through `postgres::Error`'s `Display`, which is literally `"db error"`; it now reads `as_db_error()` and the `source()` chain, so the likeliest real trigger reads `FATAL: sorry, too many clients already`.
* **A failing search point discarded the points that already succeeded.** `experiment.rs` flushed `pending_saves` only after the whole phase, so a `parallel 1, 2, 4` sweep in which only `4` fails wrote **zero** files. That contradicts the policy stated for `--fail-on-dropped-queries` ("results files are still written before the run fails, so the evidence survives"). The hard failure is now recorded and raised *after* the flush.

## Behaviour change to be aware of

The shipped pgvector configs have 25 points at `parallel: 100`, and Postgres defaults to `max_connections = 100` with 3 reserved for superusers — so on a stock server those points are one stray session away from a hard failure that master papered over. Mitigations here, none of which change a published `parallel` value:

* `tests/docker-compose.test.yml` starts pgvector with `max_connections=200`.
* pgvector warns before fanning out when `parallel` exceeds the live budget, with the arithmetic (`max_connections=`, `superuser_reserved=`, in use, available). Advisory only — it is racy by construction and meaningless behind a pooler; the gate stays the authority.
* `--repetitions` (default 3) already absorbs *transient* failures: a run whose rep 1 was refused but whose reps 2–3 succeeded still exits 0 with a valid result. Only deterministic failures go red.

## Follow-ups filed (not fixed here)

* #266 — eight other *timed* fan-out harnesses have no synchronized start (`search_mixed` ×4, `search_filter_only` ×3, `turbopuffer::search`).
* #267 — `wait_ready` has no deadline, so a worker that hangs *inside* setup still hangs the run. Not a regression (the barrier was identical), but the module doc's "progress is therefore guaranteed" overstated it and has been softened.
* #268 — no runtime measurement invariant exists. The review produced the numbers to add one: replacing the barriers cut dead time (stamp → last worker resume) from 5,644 µs to 1,744 µs at N=64 and from 205,527 µs to 26,703 µs at N=1024, because master stamped the start and *then* called `go.wait()` — a second thundering herd inside the window.
* #269 — `--exit-on-error false` publishes a truncated summary and `concurrency_curve` reports a knee computed from it.
* #276 — INV-4c is a per-file existence check, so a *second* bare `StartGate` in `weaviate.rs` would slip through (there is one today, and it is guarded).
* #277 — pgvector's connection-budget warning counts background workers and subtracts superuser-reserved slots from a superuser connection, so it warns spuriously. Advisory only; it cannot fail a run.
* #270 — `WorkerPool::start` merges sample buffers inside `total_time`. Sub-millisecond at 10k queries; also notes that pre-merge results carry a slightly larger dead-time penalty than post-merge ones, which matters because this repo publishes trend charts.

## Note for whoever sequences this with #246

`engine/opensearch.rs` was flagged as off-limits for PR #246, but it is one of the six engines the issue names and leaving it would keep an identical hang alive next door. **The escape hatch is not "drop one hunk"** — it is 7 hunks; dropping only the harness leaves an unused `use …WorkerPool` and fails `clippy -D warnings`, and dropping the file entirely makes *this PR's own tests* fail (INV-4 flags `opensearch.rs:1516/1517`, INV-4b derives it from `engine/mod.rs`). My earlier non-overlap claim also missed my own import hunk at `@@ -16,6`, which falls inside #246's `@@ -8,12`; git merges it because the insertion points differ by two lines — resolved by margin, not by design. `git merge-tree` is clean for `+#251`, `+#246` and all three together; if a conflict ever appears at that import, keep all three `use` lines.

Closes #214

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>