### PR TITLE
fix(skip-flags): --skip-upload must reuse the corpus, not destroy it (#238)

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -52,7 +52,8 @@ docker run --rm --network host \
 | `--engines <PATTERN>` | Engine patterns to run (supports wildcards) | `*` |
 | `--datasets <PATTERN>` | Dataset patterns to run (supports wildcards) | `*` |
 | `--host <HOST>` | Redis / engine host | `localhost` |
-| `--skip-upload` | Skip the upload phase | — |
+| `--skip-upload` | Reuse the corpus already on the server (no configure, no upload); the runner verifies it server-side first | — |
+| `--allow-partial-corpus` | Downgrade the `--skip-upload` reuse check from a hard error to a warning | — |
 | `--skip-search` | Skip the search phase | — |
 | `--skip-if-exists` | Skip if results already exist | — |
 | `--parallels <N,N,...>` | Filter by parallel thread counts | — |

--- a/README.md
+++ b/README.md
@@ -352,11 +352,22 @@ full-size corpus uploaded by a sibling config, or by a different dataset, passes
 The count proves the corpus is the right SIZE, never that it is the right corpus.
 
 **pgvector's count is an estimate on purpose.** The engine never `VACUUM`s and
-forces `STORAGE PLAIN`, so `SELECT count(*) FROM items` plans a Seq Scan: ~2.6s
-and ~1.1GB of I/O on a 1M-row table (~6GB at 1536 dims), pulling the whole corpus
-into the page cache and shared buffers *immediately before the search phase* —
-silently turning a cold-cache run warm and changing the published number. The
-check uses `ANALYZE` + `reltuples` instead and can therefore only warn.
+forces `STORAGE PLAIN`, so `SELECT count(*) FROM items` plans a Seq Scan over the
+whole heap *immediately before the search phase*, silently turning a cold-cache
+run warm and changing the published number. Measured on a cold 1M-row / 768-dim
+table built like this engine's (3906 MB, 500000 relpages):
+
+| | heap blocks touched | cache primed | cold wall clock |
+|---|---|---|---|
+| `SELECT count(*)` | 500,000 | 3906 MB | 1.58 s |
+| `ANALYZE items` | 30,001 | 234 MB | 0.84 s |
+
+The point is not the 16.7x ratio but that ANALYZE's sample is capped at
+`300 * default_statistics_target` = 30,000 rows **regardless of table size**, so
+its footprint is bounded while `count(*)` grows linearly — at 1536 dims (~7.8 GB)
+`count(*)` primes all of it and ANALYZE still touches ~30,000 blocks. Bounded is
+not free (~6% of this heap), so the perturbation is capped, not eliminated. The
+check uses `ANALYZE` + `reltuples` and can therefore only warn, never abort.
 
 Two-phase workflows are unchanged, and now provably non-destructive: upload with
 `--keep-data`, then re-run with `--skip-upload --skip-if-exists false`. A

--- a/README.md
+++ b/README.md
@@ -291,42 +291,76 @@ Options:
 
 ### `--skip-upload`: reuse means reuse (issue #238)
 
-`--skip-upload` asserts *"the server already holds the corpus I want"*. Two rules
-follow, and both are enforced:
+`--skip-upload` asserts *"the server already holds the corpus I want"*. Three
+rules follow, and all three are enforced:
 
-1. **The configure phase never runs.** `configure()` is destructive on 13 of the
-   15 engines — `FT.DROPINDEX … DD` (Redis), `FT.DROPINDEX` + `SCAN`/`UNLINK`
+1. **The configure phase never runs.** `configure()` is destructive on **14 of the
+   15 engines** — `FT.DROPINDEX … DD` (Redis), `FT.DROPINDEX` + `SCAN`/`UNLINK`
    (Valkey / Dragonfly / KiviDB), `collection.drop()` (MongoDB), `DROP TABLE`
    (pgvector), `DELETE /collections/<n>` (Qdrant / Chroma / Weaviate / Milvus /
-   Turbopuffer), `DEL idx` (VectorSets). Until #238 the
+   Turbopuffer), `indices.delete` (Elasticsearch / OpenSearch), `DEL idx`
+   (VectorSets). Only Vertex is non-destructive. Until #238 the
    `--skip-upload --skip-vector-index` combination still called it: the flags that
    mean *"do not upload, do not build an index, just use what is there"* deleted
    the corpus and then benchmarked the empty index — printing a QPS number and
-   exiting 0. Measured live: Redis 400 → 0 docs, Valkey 400 → 0 keys, MongoDB
-   400 → 0 documents.
-2. **The corpus is verified before anything is measured.** The runner reads the
-   row count back off the live server (`FT.INFO num_docs`, `GET /collections/<n>`
-   → `points_count`, `_count`, `countDocuments`, `SELECT count(*)`, `VCARD`) and
-   compares it with the dataset's measured corpus size:
-   - **fewer rows than the dataset declares — including zero, i.e. a missing
-     index — is a hard error.** Recall/precision are scored against ground truth
-     for the FULL corpus, so a short corpus publishes a wrong number under a
-     config name that claims otherwise. Nothing else catches this: a half-deleted
-     Qdrant collection answers every query without error and reports
-     `mean_recall: 1.0`.
-   - more rows than declared → warning (often deliberate: a shared prefix, a
-     superset upload).
-   - an engine that cannot report a count → a printed note that the reuse went
-     unverified. Counting is implemented for Redis, Valkey, Dragonfly, KiviDB,
-     VectorSets, Qdrant, Elasticsearch, OpenSearch, pgvector and MongoDB; Chroma,
-     Milvus, Weaviate, Turbopuffer and Vertex fall back to the note.
+   exiting 0.
+2. **The cleanup phase never runs either.** `--keep-data` defaults to **false**,
+   so `--skip-upload` on its own used to reuse a corpus, measure it, and then
+   `engine.delete()` it. A run that did not create the corpus does not delete it,
+   whatever `--keep-data` says.
+3. **The corpus is verified before anything is measured.** The runner reads the
+   row count back off the live server (`FT.INFO num_docs` / `hnsw_live_count`,
+   `GET /collections/<n>` → `points_count`, `_count`, `countDocuments`,
+   `reltuples`, `VCARD`) and compares it with the corpus **measured on disk**:
+   - **fewer rows than the dataset holds — including zero, i.e. a missing index —
+     is a hard error.** Recall/precision are scored against ground truth for the
+     FULL corpus, so a short corpus publishes a wrong number under a config name
+     that claims otherwise.
+   - more rows → warning (often deliberate: a shared prefix, a superset upload).
+   - an **estimate** that comes up short → warning only. pgvector's count is a
+     planner figure (see below); aborting a run on a number that is allowed to be
+     wrong just trades one silent failure for a noisy one.
+   - a **probe failure** (unreachable server, `NOPERM`, missing `SELECT`, a closed
+     ES index, a shard that did not answer) → a hard error that says *probe
+     failure*. It is never reported as "the corpus is empty": that names the wrong
+     problem and invites a re-upload over a corpus that was fine.
+   - no count implemented for the engine → a printed note that the reuse went
+     unverified. Implemented for Redis, Valkey, Dragonfly, KiviDB, VectorSets,
+     Qdrant, Elasticsearch, OpenSearch, pgvector and MongoDB. Chroma, Milvus and
+     Weaviate all expose a count we have simply not wired up yet; Turbopuffer and
+     Vertex are the only genuinely uncountable ones.
 
-   Pass `--allow-partial-corpus` to downgrade the hard error to a warning (a
-   deliberately partial corpus, or a server whose count cannot be read).
+   **On a sweep, the right remedy for a rejected config is `--exit-on-error false`**
+   (`--exit-on-error` defaults to true, so one stale config otherwise kills the
+   whole run and the *correct* measurements from the other configs are lost too).
+   `--allow-partial-corpus` downgrades the rejection to a warning and measures the
+   partial corpus — it publishes exactly the number the check exists to suppress,
+   so reach for it last, and only deliberately.
+
+The verdict is recorded in every result file it applies to, under
+`params.corpus_reuse` (`status`, `expected_rows`, `actual_rows`,
+`actual_is_estimate`, `waived_by_allow_partial_corpus`), and a rejected
+experiment is listed in the summary under `rejected_experiments` — otherwise a
+sweep that lost most of its configs produces a summary and a chart
+indistinguishable from a complete one.
+
+**What the check cannot do: cardinality is not identity.** Only the four
+Redis-wire engines address a per-config index and keyspace (#151-4). MongoDB,
+pgvector, Elasticsearch/OpenSearch, Qdrant, Milvus and VectorSets each have ONE
+corpus object per server, shared by every config *and every dataset* — so a
+full-size corpus uploaded by a sibling config, or by a different dataset, passes.
+The count proves the corpus is the right SIZE, never that it is the right corpus.
+
+**pgvector's count is an estimate on purpose.** The engine never `VACUUM`s and
+forces `STORAGE PLAIN`, so `SELECT count(*) FROM items` plans a Seq Scan: ~2.6s
+and ~1.1GB of I/O on a 1M-row table (~6GB at 1536 dims), pulling the whole corpus
+into the page cache and shared buffers *immediately before the search phase* —
+silently turning a cold-cache run warm and changing the published number. The
+check uses `ANALYZE` + `reltuples` instead and can therefore only warn.
 
 Two-phase workflows are unchanged, and now provably non-destructive: upload with
-`--keep-data`, then re-run with `--skip-upload --keep-data --skip-if-exists false`.
-A filter-only two-phase run must pass `--skip-vector-index` in **both** phases —
+`--keep-data`, then re-run with `--skip-upload --skip-if-exists false`. A
+filter-only two-phase run must pass `--skip-vector-index` in **both** phases —
 the flag renames the config to `<engine>-no-vector`, so phase 1 writes exactly the
 schema-only index phase 2 reuses.
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ Options:
     --host <HOST>              Redis/engine host [default: localhost]
     --parallels <N,N,...>      Filter by parallel thread counts
     --ef-runtime <N,N,...>     Filter by ef runtime values
-    --skip-upload              Skip the upload phase
+    --skip-upload              Reuse the corpus already on the server (no configure,
+                               no upload); verified against the live server first
+    --allow-partial-corpus     Downgrade that verification from a hard error to a warning
     --skip-search              Skip the search phase
     --skip-if-exists           Skip if results already exist
     --exit-on-error            Stop on first error
@@ -250,6 +252,47 @@ Options:
     --plot <OUTPUT.svg>        Render a QPS-vs-precision trade-off chart from results/
     -h, --help                 Print help
 ```
+
+### `--skip-upload`: reuse means reuse (issue #238)
+
+`--skip-upload` asserts *"the server already holds the corpus I want"*. Two rules
+follow, and both are enforced:
+
+1. **The configure phase never runs.** `configure()` is destructive on 13 of the
+   15 engines — `FT.DROPINDEX … DD` (Redis), `FT.DROPINDEX` + `SCAN`/`UNLINK`
+   (Valkey / Dragonfly / KiviDB), `collection.drop()` (MongoDB), `DROP TABLE`
+   (pgvector), `DELETE /collections/<n>` (Qdrant / Chroma / Weaviate / Milvus /
+   Turbopuffer), `DEL idx` (VectorSets). Until #238 the
+   `--skip-upload --skip-vector-index` combination still called it: the flags that
+   mean *"do not upload, do not build an index, just use what is there"* deleted
+   the corpus and then benchmarked the empty index — printing a QPS number and
+   exiting 0. Measured live: Redis 400 → 0 docs, Valkey 400 → 0 keys, MongoDB
+   400 → 0 documents.
+2. **The corpus is verified before anything is measured.** The runner reads the
+   row count back off the live server (`FT.INFO num_docs`, `GET /collections/<n>`
+   → `points_count`, `_count`, `countDocuments`, `SELECT count(*)`, `VCARD`) and
+   compares it with the dataset's measured corpus size:
+   - **fewer rows than the dataset declares — including zero, i.e. a missing
+     index — is a hard error.** Recall/precision are scored against ground truth
+     for the FULL corpus, so a short corpus publishes a wrong number under a
+     config name that claims otherwise. Nothing else catches this: a half-deleted
+     Qdrant collection answers every query without error and reports
+     `mean_recall: 1.0`.
+   - more rows than declared → warning (often deliberate: a shared prefix, a
+     superset upload).
+   - an engine that cannot report a count → a printed note that the reuse went
+     unverified. Counting is implemented for Redis, Valkey, Dragonfly, KiviDB,
+     VectorSets, Qdrant, Elasticsearch, OpenSearch, pgvector and MongoDB; Chroma,
+     Milvus, Weaviate, Turbopuffer and Vertex fall back to the note.
+
+   Pass `--allow-partial-corpus` to downgrade the hard error to a warning (a
+   deliberately partial corpus, or a server whose count cannot be read).
+
+Two-phase workflows are unchanged, and now provably non-destructive: upload with
+`--keep-data`, then re-run with `--skip-upload --keep-data --skip-if-exists false`.
+A filter-only two-phase run must pass `--skip-vector-index` in **both** phases —
+the flag renames the config to `<engine>-no-vector`, so phase 1 writes exactly the
+schema-only index phase 2 reuses.
 
 ### Per-config index isolation (Redis / Valkey / Dragonfly / KiviDB)
 
@@ -296,11 +339,12 @@ VSIM coerces a non-numeric attribute to `0` in a numeric comparison — so a
 (a two-sided range matches nothing → recall 0; a one-sided `lt`/`lte` matches
 everything). **Re-upload before searching.**
 
-Unlike Redis/Valkey — where `--skip-upload` against a missing or mismatched index
-hard-errors (`redis_utils::ensure_index_exists`) — VectorSets has **no such
-guard**: it uses a single hardcoded key (`idx`), so there is not even a name
-change for the tool to detect. The stale corpus is found, the run succeeds, and
-only the recall number is wrong.
+`--skip-upload` does check that the corpus is **present and complete** on
+VectorSets too (`VCARD idx`, see above), but it cannot check that the corpus is
+*current*: a pre-#230 corpus is the right size and the wrong encoding. And because
+the engine uses a single hardcoded key (`idx`, issue #236), there is not even a
+name change for the tool to detect. A stale corpus of the right size is found, the
+run succeeds, and only the recall number is wrong.
 
 ### Charts
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,9 @@ Options:
     --host <HOST>              Redis/engine host [default: localhost]
     --parallels <N,N,...>      Filter by parallel thread counts
     --ef-runtime <N,N,...>     Filter by ef runtime values
-    --skip-upload              Skip the upload phase
+    --skip-upload              Reuse the corpus already on the server (no configure,
+                               no upload); verified against the live server first
+    --allow-partial-corpus     Downgrade that verification from a hard error to a warning
     --skip-search              Skip the search phase
     --skip-if-exists           Skip if results already exist
     --exit-on-error            Stop on first error
@@ -286,6 +288,47 @@ Options:
     --plot <OUTPUT.svg>        Render a QPS-vs-precision trade-off chart from results/
     -h, --help                 Print help
 ```
+
+### `--skip-upload`: reuse means reuse (issue #238)
+
+`--skip-upload` asserts *"the server already holds the corpus I want"*. Two rules
+follow, and both are enforced:
+
+1. **The configure phase never runs.** `configure()` is destructive on 13 of the
+   15 engines — `FT.DROPINDEX … DD` (Redis), `FT.DROPINDEX` + `SCAN`/`UNLINK`
+   (Valkey / Dragonfly / KiviDB), `collection.drop()` (MongoDB), `DROP TABLE`
+   (pgvector), `DELETE /collections/<n>` (Qdrant / Chroma / Weaviate / Milvus /
+   Turbopuffer), `DEL idx` (VectorSets). Until #238 the
+   `--skip-upload --skip-vector-index` combination still called it: the flags that
+   mean *"do not upload, do not build an index, just use what is there"* deleted
+   the corpus and then benchmarked the empty index — printing a QPS number and
+   exiting 0. Measured live: Redis 400 → 0 docs, Valkey 400 → 0 keys, MongoDB
+   400 → 0 documents.
+2. **The corpus is verified before anything is measured.** The runner reads the
+   row count back off the live server (`FT.INFO num_docs`, `GET /collections/<n>`
+   → `points_count`, `_count`, `countDocuments`, `SELECT count(*)`, `VCARD`) and
+   compares it with the dataset's measured corpus size:
+   - **fewer rows than the dataset declares — including zero, i.e. a missing
+     index — is a hard error.** Recall/precision are scored against ground truth
+     for the FULL corpus, so a short corpus publishes a wrong number under a
+     config name that claims otherwise. Nothing else catches this: a half-deleted
+     Qdrant collection answers every query without error and reports
+     `mean_recall: 1.0`.
+   - more rows than declared → warning (often deliberate: a shared prefix, a
+     superset upload).
+   - an engine that cannot report a count → a printed note that the reuse went
+     unverified. Counting is implemented for Redis, Valkey, Dragonfly, KiviDB,
+     VectorSets, Qdrant, Elasticsearch, OpenSearch, pgvector and MongoDB; Chroma,
+     Milvus, Weaviate, Turbopuffer and Vertex fall back to the note.
+
+   Pass `--allow-partial-corpus` to downgrade the hard error to a warning (a
+   deliberately partial corpus, or a server whose count cannot be read).
+
+Two-phase workflows are unchanged, and now provably non-destructive: upload with
+`--keep-data`, then re-run with `--skip-upload --keep-data --skip-if-exists false`.
+A filter-only two-phase run must pass `--skip-vector-index` in **both** phases —
+the flag renames the config to `<engine>-no-vector`, so phase 1 writes exactly the
+schema-only index phase 2 reuses.
 
 ### Per-config index isolation (Redis / Valkey / Dragonfly / KiviDB)
 
@@ -332,11 +375,12 @@ VSIM coerces a non-numeric attribute to `0` in a numeric comparison — so a
 (a two-sided range matches nothing → recall 0; a one-sided `lt`/`lte` matches
 everything). **Re-upload before searching.**
 
-Unlike Redis/Valkey — where `--skip-upload` against a missing or mismatched index
-hard-errors (`redis_utils::ensure_index_exists`) — VectorSets has **no such
-guard**: it uses a single hardcoded key (`idx`), so there is not even a name
-change for the tool to detect. The stale corpus is found, the run succeeds, and
-only the recall number is wrong.
+`--skip-upload` does check that the corpus is **present and complete** on
+VectorSets too (`VCARD idx`, see above), but it cannot check that the corpus is
+*current*: a pre-#230 corpus is the right size and the wrong encoding. And because
+the engine uses a single hardcoded key (`idx`, issue #236), there is not even a
+name change for the tool to detect. A stale corpus of the right size is found, the
+run succeeds, and only the recall number is wrong.
 
 ### Charts
 

--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -39,9 +39,26 @@ pub struct Args {
     #[arg(long, default_value = "localhost")]
     pub host: String,
 
-    /// Skip upload phase
+    /// Skip upload phase.
+    ///
+    /// Means "the server already holds the corpus I want": the configure phase
+    /// is NOT run (it is destructive on almost every engine — see #238) and the
+    /// runner instead verifies, against the live server, that the corpus is
+    /// present and complete before measuring anything.
     #[arg(long, default_value = "false")]
     pub skip_upload: bool,
+
+    /// Downgrade the `--skip-upload` reuse precondition from a hard error to a
+    /// warning (issue #238).
+    ///
+    /// By default a `--skip-upload` run aborts when the engine holds fewer rows
+    /// than the dataset declares — including zero, i.e. a missing index — because
+    /// recall is scored against ground truth for the FULL corpus and a short
+    /// corpus therefore publishes a wrong number under a config name that claims
+    /// otherwise. Set this to measure a deliberately partial corpus, or when the
+    /// server-side count cannot be read at all (restrictive ACLs).
+    #[arg(long, default_value = "false")]
+    pub allow_partial_corpus: bool,
 
     /// Skip search phase
     #[arg(long, default_value = "false")]

--- a/src/bin/vector_db_benchmark/engine/chroma.rs
+++ b/src/bin/vector_db_benchmark/engine/chroma.rs
@@ -131,6 +131,41 @@ impl ChromaEngine {
         Ok(())
     }
 
+    /// Look the collection's id up by name.
+    ///
+    /// `collection_id` is the one piece of engine state that is NOT a function of
+    /// the dataset — it comes back from the create-collection response — so the
+    /// `--skip-upload` path, which never calls configure() (#238), would otherwise
+    /// query `.../collections//query` and fail every request after a green reuse
+    /// check. Resolving by name recovers it without touching the corpus.
+    fn resolve_collection_id(&mut self, client: &reqwest::blocking::Client) -> Result<(), String> {
+        if !self.collection_id.is_empty() {
+            return Ok(());
+        }
+        let url = format!("{}/collections/{}", self.api_base, self.collection_name);
+        let resp = client
+            .get(&url)
+            .send()
+            .map_err(|e| format!("resolve collection id request failed: {}", e))?;
+        if !resp.status().is_success() {
+            return Err(format!(
+                "collection '{}' not found on the server (status {}) — --skip-upload needs a \
+                 collection created by a previous run with --keep-data",
+                self.collection_name,
+                resp.status()
+            ));
+        }
+        let v: serde_json::Value = resp
+            .json()
+            .map_err(|e| format!("resolve collection id response parse: {}", e))?;
+        self.collection_id = v
+            .get("id")
+            .and_then(|x| x.as_str())
+            .ok_or("resolve collection id: no id in response")?
+            .to_string();
+        Ok(())
+    }
+
     /// Create the collection and remember its id.
     fn create_collection(&mut self, client: &reqwest::blocking::Client) -> Result<(), String> {
         let url = format!("{}/collections", self.api_base);
@@ -624,6 +659,14 @@ impl Engine for ChromaEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // On the --skip-upload path configure() never runs (#238), so the
+        // collection id — the only piece of state here that is not derivable from
+        // the dataset — has to be recovered from the server by name.
+        {
+            let client = self.create_client()?;
+            self.resolve_collection_id(&client)?;
+        }
+
         let parallel = params.parallel.unwrap_or(1) as usize;
         let (queries, neighbors, conditions) = dataset.read_queries()?;
 

--- a/src/bin/vector_db_benchmark/engine/dragonfly.rs
+++ b/src/bin/vector_db_benchmark/engine/dragonfly.rs
@@ -833,6 +833,14 @@ fn redis_value_to_json(val: &redis::Value) -> serde_json::Value {
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for DragonflyEngine {
+    /// Server-side corpus size for this config's index, for the `--skip-upload`
+    /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
+    /// index counts as 0 (the corpus to reuse is not there).
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.get_connection()?;
+        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/dragonfly.rs
+++ b/src/bin/vector_db_benchmark/engine/dragonfly.rs
@@ -48,7 +48,7 @@ use super::redis_utils;
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::index_naming::{derive_index_name, derive_key_prefix};
-use crate::engine::{Engine, SearchResults, UploadStats};
+use crate::engine::{CorpusCount, Engine, SearchResults, UploadStats};
 use crate::metrics::compute_metrics;
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, doc_key_to_id, doc_key_to_id_opt};
 use vector_db_benchmark::query_filter::QueryFilter;
@@ -79,6 +79,16 @@ pub struct DragonflyEngine {
     config: DragonflyEngineConfig,
     search_params: Vec<SearchParams>,
     commandstats_baseline: Option<redis_utils::CommandStatsBaseline>,
+    /// Whether `commandstats_baseline` was established by this process.
+    ///
+    /// `None` is ambiguous on its own: it means BOTH "CONFIG RESETSTAT succeeded,
+    /// so the server counters start at zero" and "configure() never ran, so
+    /// nothing was reset". On the `--skip-upload` path (#238) configure() is
+    /// skipped, and `check_commandstats` would then compare this run's failure
+    /// count against zero while the counters still hold every failure since the
+    /// server started — failing a search in which nothing actually failed. This
+    /// flag disambiguates so `search()` can prime the baseline exactly once.
+    commandstats_primed: bool,
 }
 
 impl DragonflyEngine {
@@ -152,6 +162,7 @@ impl DragonflyEngine {
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             commandstats_baseline: None,
+            commandstats_primed: false,
         })
     }
 
@@ -832,13 +843,32 @@ fn redis_value_to_json(val: &redis::Value) -> serde_json::Value {
 
 // ── Engine trait implementation ──────────────────────────────────────────
 
+/// Establish the commandstats baseline if configure() did not (issue #238).
+impl DragonflyEngine {
+    /// Idempotent and a no-op on the normal configure -> upload -> search path,
+    /// so the existing accounting is unchanged; it only rescues the
+    /// `--skip-upload` path, where nothing had reset the counters.
+    fn prime_commandstats_if_needed(&mut self) -> Result<(), String> {
+        if self.commandstats_primed {
+            return Ok(());
+        }
+        let mut conn = self.get_connection()?;
+        self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
+        self.commandstats_primed = true;
+        Ok(())
+    }
+}
+
 impl Engine for DragonflyEngine {
     /// Server-side corpus size for this config's index, for the `--skip-upload`
     /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
     /// index counts as 0 (the corpus to reuse is not there).
-    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+    fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let mut conn = self.get_connection()?;
-        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+        Ok(
+            redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)?
+                .map(CorpusCount::exact),
+        )
     }
 
     fn name(&self) -> &str {
@@ -866,6 +896,7 @@ impl Engine for DragonflyEngine {
         // surfaces an `Err` on failure. The baseline is still reset for parity
         // (and would activate automatically if Dragonfly ever adds failed_calls).
         self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
+        self.commandstats_primed = true;
         Ok(())
     }
 
@@ -961,6 +992,14 @@ impl Engine for DragonflyEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // configure() normally resets the server's command counters and
+        // establishes the commandstats baseline; on the `--skip-upload` path it
+        // never runs (#238), so check_commandstats below would compare this run's
+        // failure count against zero while the counters still hold every failure
+        // since the server started — failing a run in which nothing failed.
+        // Idempotent no-op once primed; outside every timed window.
+        self.prime_commandstats_if_needed()?;
+
         // Index-existence guard (#151-4): on the --skip-upload path a missing or
         // mismatched index would otherwise write a silent recall-0.0 result file.
         {

--- a/src/bin/vector_db_benchmark/engine/dragonfly.rs
+++ b/src/bin/vector_db_benchmark/engine/dragonfly.rs
@@ -832,6 +832,14 @@ fn redis_value_to_json(val: &redis::Value) -> serde_json::Value {
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for DragonflyEngine {
+    /// Server-side corpus size for this config's index, for the `--skip-upload`
+    /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
+    /// index counts as 0 (the corpus to reuse is not there).
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.get_connection()?;
+        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -12,7 +12,7 @@ use elasticsearch::indices::{
     IndicesCreateParts, IndicesDeleteParts, IndicesForcemergeParts, IndicesRefreshParts,
 };
 use elasticsearch::params::WaitForStatus;
-use elasticsearch::{BulkParts, Elasticsearch, SearchParts};
+use elasticsearch::{BulkParts, CountParts, Elasticsearch, SearchParts};
 use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 use uuid::Uuid;
 
@@ -889,6 +889,29 @@ fn extract_knn_hits(resp_body: &serde_json::Value) -> Result<Vec<(i64, f64)>, St
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for ElasticsearchEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `GET /<index>/_count`; a missing index (404) answers 0.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let resp = self
+            .rt
+            .block_on(
+                self.client
+                    .count(CountParts::Index(&[&self.index_name]))
+                    .send(),
+            )
+            .map_err(|e| format!("_count on index '{}' failed: {}", self.index_name, e))?;
+        if resp.status_code().as_u16() == 404 {
+            return Ok(Some(0));
+        }
+        let body: serde_json::Value = self.rt.block_on(resp.json()).map_err(|e| {
+            format!(
+                "_count on index '{}' returned no JSON: {}",
+                self.index_name, e
+            )
+        })?;
+        Ok(body.get("count").and_then(|v| v.as_u64()))
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{Engine, SearchResults, UploadStats};
+use crate::engine::{CorpusCount, Engine, SearchResults, UploadStats};
 use vector_db_benchmark::query_filter::QueryFilter;
 use vector_db_benchmark::readers::metadata::MetadataItem;
 
@@ -892,7 +892,7 @@ fn extract_knn_hits(resp_body: &serde_json::Value) -> Result<Vec<(i64, f64)>, St
 impl Engine for ElasticsearchEngine {
     /// Server-side corpus size, for the `--skip-upload` reuse precondition
     /// (issue #238). `GET /<index>/_count`; a missing index (404) answers 0.
-    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+    fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let resp = self
             .rt
             .block_on(
@@ -901,8 +901,19 @@ impl Engine for ElasticsearchEngine {
                     .send(),
             )
             .map_err(|e| format!("_count on index '{}' failed: {}", self.index_name, e))?;
-        if resp.status_code().as_u16() == 404 {
-            return Ok(Some(0));
+        // 404 = the index is not there, which for this check is the same as an
+        // empty one. Any other non-2xx (403, or 400 on a CLOSED index whose
+        // corpus is perfectly intact) is a probe failure, not a corpus of zero.
+        let status = resp.status_code().as_u16();
+        if status == 404 {
+            return Ok(Some(CorpusCount::exact(0)));
+        }
+        if !(200..300).contains(&status) {
+            return Err(format!(
+                "_count on index '{}' returned HTTP {} (the index may be closed or \
+                 unreadable; the corpus itself may be intact)",
+                self.index_name, status
+            ));
         }
         let body: serde_json::Value = self.rt.block_on(resp.json()).map_err(|e| {
             format!(
@@ -910,7 +921,24 @@ impl Engine for ElasticsearchEngine {
                 self.index_name, e
             )
         })?;
-        Ok(body.get("count").and_then(|v| v.as_u64()))
+        // A shard that failed to answer makes the count a floor, not a total —
+        // reporting it as the corpus size would invent a shortfall on a degraded
+        // but intact cluster.
+        let failed_shards = body
+            .pointer("/_shards/failed")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        if failed_shards > 0 {
+            return Err(format!(
+                "_count on index '{}' had {} failed shard(s); the count is a floor, \
+                 not the corpus size",
+                self.index_name, failed_shards
+            ));
+        }
+        Ok(body
+            .get("count")
+            .and_then(|v| v.as_u64())
+            .map(CorpusCount::exact))
     }
 
     fn name(&self) -> &str {

--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -12,7 +12,7 @@ use elasticsearch::indices::{
     IndicesCreateParts, IndicesDeleteParts, IndicesForcemergeParts, IndicesRefreshParts,
 };
 use elasticsearch::params::WaitForStatus;
-use elasticsearch::{BulkParts, Elasticsearch, SearchParts};
+use elasticsearch::{BulkParts, CountParts, Elasticsearch, SearchParts};
 use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 use uuid::Uuid;
 
@@ -890,6 +890,29 @@ fn extract_knn_hits(resp_body: &serde_json::Value) -> Result<Vec<(i64, f64)>, St
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for ElasticsearchEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `GET /<index>/_count`; a missing index (404) answers 0.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let resp = self
+            .rt
+            .block_on(
+                self.client
+                    .count(CountParts::Index(&[&self.index_name]))
+                    .send(),
+            )
+            .map_err(|e| format!("_count on index '{}' failed: {}", self.index_name, e))?;
+        if resp.status_code().as_u16() == 404 {
+            return Ok(Some(0));
+        }
+        let body: serde_json::Value = self.rt.block_on(resp.json()).map_err(|e| {
+            format!(
+                "_count on index '{}' returned no JSON: {}",
+                self.index_name, e
+            )
+        })?;
+        Ok(body.get("count").and_then(|v| v.as_u64()))
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/kividb.rs
+++ b/src/bin/vector_db_benchmark/engine/kividb.rs
@@ -1975,6 +1975,14 @@ fn redis_value_to_json(val: &redis::Value) -> serde_json::Value {
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for KividbEngine {
+    /// Server-side corpus size for this config's index, for the `--skip-upload`
+    /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
+    /// index counts as 0 (the corpus to reuse is not there).
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.get_connection()?;
+        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/kividb.rs
+++ b/src/bin/vector_db_benchmark/engine/kividb.rs
@@ -69,7 +69,7 @@ use super::redis_utils;
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::index_naming::{derive_index_name, derive_key_prefix};
-use crate::engine::{Engine, SearchResults, UploadStats};
+use crate::engine::{CorpusCount, Engine, SearchResults, UploadStats};
 use crate::metrics::compute_metrics;
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, doc_key_to_id, doc_key_to_id_opt};
 use vector_db_benchmark::readers::metadata::{is_multivalued_keyword_field, MetadataItem};
@@ -100,6 +100,16 @@ pub struct KividbEngine {
     config: KividbEngineConfig,
     search_params: Vec<SearchParams>,
     commandstats_baseline: Option<redis_utils::CommandStatsBaseline>,
+    /// Whether `commandstats_baseline` was established by this process.
+    ///
+    /// `None` is ambiguous on its own: it means BOTH "CONFIG RESETSTAT succeeded,
+    /// so the server counters start at zero" and "configure() never ran, so
+    /// nothing was reset". On the `--skip-upload` path (#238) configure() is
+    /// skipped, and `check_commandstats` would then compare this run's failure
+    /// count against zero while the counters still hold every failure since the
+    /// server started — failing a search in which nothing actually failed. This
+    /// flag disambiguates so `search()` can prime the baseline exactly once.
+    commandstats_primed: bool,
 }
 
 impl KividbEngine {
@@ -175,6 +185,7 @@ impl KividbEngine {
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             commandstats_baseline: None,
+            commandstats_primed: false,
         })
     }
 
@@ -1982,13 +1993,32 @@ fn redis_value_to_json(val: &redis::Value) -> serde_json::Value {
 
 // ── Engine trait implementation ──────────────────────────────────────────
 
+/// Establish the commandstats baseline if configure() did not (issue #238).
+impl KividbEngine {
+    /// Idempotent and a no-op on the normal configure -> upload -> search path,
+    /// so the existing accounting is unchanged; it only rescues the
+    /// `--skip-upload` path, where nothing had reset the counters.
+    fn prime_commandstats_if_needed(&mut self) -> Result<(), String> {
+        if self.commandstats_primed {
+            return Ok(());
+        }
+        let mut conn = self.get_connection()?;
+        self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
+        self.commandstats_primed = true;
+        Ok(())
+    }
+}
+
 impl Engine for KividbEngine {
     /// Server-side corpus size for this config's index, for the `--skip-upload`
     /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
     /// index counts as 0 (the corpus to reuse is not there).
-    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+    fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let mut conn = self.get_connection()?;
-        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+        Ok(
+            redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)?
+                .map(CorpusCount::exact),
+        )
     }
 
     fn name(&self) -> &str {
@@ -2016,6 +2046,7 @@ impl Engine for KividbEngine {
         self.create_index(&mut conn, dataset)?;
         // Best-effort; see check_commandstats note in upload()/search() below.
         self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
+        self.commandstats_primed = true;
         Ok(())
     }
 
@@ -2109,6 +2140,14 @@ impl Engine for KividbEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // configure() normally resets the server's command counters and
+        // establishes the commandstats baseline; on the `--skip-upload` path it
+        // never runs (#238), so check_commandstats below would compare this run's
+        // failure count against zero while the counters still hold every failure
+        // since the server started — failing a run in which nothing failed.
+        // Idempotent no-op once primed; outside every timed window.
+        self.prime_commandstats_if_needed()?;
+
         // Repeated for the `--skip-upload` path, which reaches `search()`
         // without ever calling `configure()`. Schema-only, so it costs nothing.
         validate_dataset_support(dataset)?;

--- a/src/bin/vector_db_benchmark/engine/kividb.rs
+++ b/src/bin/vector_db_benchmark/engine/kividb.rs
@@ -1983,6 +1983,14 @@ fn redis_value_to_json(val: &redis::Value) -> serde_json::Value {
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for KividbEngine {
+    /// Server-side corpus size for this config's index, for the `--skip-upload`
+    /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
+    /// index counts as 0 (the corpus to reuse is not there).
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.get_connection()?;
+        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -1448,6 +1448,12 @@ impl Engine for MilvusEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // Re-derive the metric type here as well as in configure(): on the
+        // `--skip-upload` path configure() never runs (#238) and this field would
+        // still be the `new()` default of "" — an empty metric_type in the search
+        // body. Pure function of the dataset, so recomputing is idempotent.
+        self.metric_type = map_milvus_metric_type(&dataset.distance().to_lowercase())?.to_string();
+
         let parallel = params.parallel.unwrap_or(1) as usize;
 
         // Extract ef from search params. The typed `ef` field first, then the

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -442,6 +442,29 @@ pub trait Engine {
         None
     }
 
+    /// Number of corpus rows this config would search, **read back off the live
+    /// server** (issue #238).
+    ///
+    /// This is the reuse precondition for `--skip-upload`: the flag asserts "the
+    /// corpus is already loaded", and the runner has to be able to check that
+    /// assertion against reality rather than trust it. A missing index/collection
+    /// answers `Ok(Some(0))` — indistinguishable from an empty one for this
+    /// purpose, and both are equally fatal to the reported recall.
+    ///
+    /// The count must cover exactly the keyspace/collection **this config**
+    /// searches (per-config prefix included), so a sibling config's corpus can
+    /// never be mistaken for this one's.
+    ///
+    /// Default `Ok(None)`: "this engine cannot report one". The runner then says
+    /// so and proceeds — an unverifiable engine must not become an unusable one.
+    /// `Err` means the probe itself failed (unreachable server, refused command);
+    /// the runner treats that as fatal unless `--allow-partial-corpus` is set,
+    /// because an unverified reuse is exactly how a partial index gets published
+    /// as a full one.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        Ok(None)
+    }
+
     /// Snapshot server reproducibility metadata (version, loaded modules +
     /// versions, full INFO/CONFIG). Default `None` (non-Redis engines are
     /// unaffected). Redis-wire engines override this to return

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -444,6 +444,29 @@ pub trait Engine {
         None
     }
 
+    /// Number of corpus rows this config would search, **read back off the live
+    /// server** (issue #238).
+    ///
+    /// This is the reuse precondition for `--skip-upload`: the flag asserts "the
+    /// corpus is already loaded", and the runner has to be able to check that
+    /// assertion against reality rather than trust it. A missing index/collection
+    /// answers `Ok(Some(0))` — indistinguishable from an empty one for this
+    /// purpose, and both are equally fatal to the reported recall.
+    ///
+    /// The count must cover exactly the keyspace/collection **this config**
+    /// searches (per-config prefix included), so a sibling config's corpus can
+    /// never be mistaken for this one's.
+    ///
+    /// Default `Ok(None)`: "this engine cannot report one". The runner then says
+    /// so and proceeds — an unverifiable engine must not become an unusable one.
+    /// `Err` means the probe itself failed (unreachable server, refused command);
+    /// the runner treats that as fatal unless `--allow-partial-corpus` is set,
+    /// because an unverified reuse is exactly how a partial index gets published
+    /// as a full one.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        Ok(None)
+    }
+
     /// Snapshot server reproducibility metadata (version, loaded modules +
     /// versions, full INFO/CONFIG). Default `None` (non-Redis engines are
     /// unaffected). Redis-wire engines override this to return

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -397,6 +397,39 @@ pub fn zero_search_results(
     }
 }
 
+/// A corpus size read back off a live server (issue #238), and how much the
+/// runner may conclude from it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CorpusCount {
+    pub rows: u64,
+    /// True when `rows` is a planner/metadata **estimate** rather than a count of
+    /// rows. An estimate may only ever produce a warning, never a hard error:
+    /// aborting a run on a number that is allowed to be wrong trades one silent
+    /// failure for a noisy one.
+    pub approximate: bool,
+}
+
+impl CorpusCount {
+    /// A count the server actually performed.
+    pub fn exact(rows: u64) -> Self {
+        Self {
+            rows,
+            approximate: false,
+        }
+    }
+
+    /// An estimate — cheap, but never grounds to abort. Used where an exact count
+    /// would cost more than it is worth, or would perturb the measurement (see
+    /// pgvector: `count(*)` seq-scans the whole heap into the page cache
+    /// immediately before the search phase, turning a cold run warm).
+    pub fn estimated(rows: u64) -> Self {
+        Self {
+            rows,
+            approximate: true,
+        }
+    }
+}
+
 /// Engine trait - equivalent to Python BaseClient
 ///
 /// Each engine implementation provides:
@@ -449,21 +482,29 @@ pub trait Engine {
     ///
     /// This is the reuse precondition for `--skip-upload`: the flag asserts "the
     /// corpus is already loaded", and the runner has to be able to check that
-    /// assertion against reality rather than trust it. A missing index/collection
-    /// answers `Ok(Some(0))` — indistinguishable from an empty one for this
-    /// purpose, and both are equally fatal to the reported recall.
+    /// assertion against reality rather than trust it.
     ///
-    /// The count must cover exactly the keyspace/collection **this config**
-    /// searches (per-config prefix included), so a sibling config's corpus can
-    /// never be mistaken for this one's.
+    /// Contract:
+    /// - index/collection **missing** → `Ok(Some(CorpusCount::exact(0)))`. For
+    ///   this check "gone" and "empty" are the same fact.
+    /// - **probe failed** (unreachable server, `NOPERM`, missing privilege) →
+    ///   `Err`. It must NEVER be reported as a corpus of zero: that names the
+    ///   wrong problem and invites a re-upload over a corpus that was fine.
+    /// - engine has no implementation yet → `Ok(None)`. The runner then says the
+    ///   reuse went unverified and proceeds; an unimplemented probe must not make
+    ///   the engine unusable.
     ///
-    /// Default `Ok(None)`: "this engine cannot report one". The runner then says
-    /// so and proceeds — an unverifiable engine must not become an unusable one.
-    /// `Err` means the probe itself failed (unreachable server, refused command);
-    /// the runner treats that as fatal unless `--allow-partial-corpus` is set,
-    /// because an unverified reuse is exactly how a partial index gets published
-    /// as a full one.
-    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+    /// Scope, and its limits. Only the four Redis-wire engines address a
+    /// per-config object (each config owns `idx:<config>` and a `<config>:`
+    /// keyspace, #151-4). MongoDB (`bench.vectors`), pgvector (`items`),
+    /// Elasticsearch/OpenSearch (`bench`), Qdrant (`benchmark`), Milvus and
+    /// VectorSets (`idx`, #236) each have exactly ONE such object per server,
+    /// shared by every config and every dataset. On those, a full-size corpus
+    /// uploaded by a SIBLING config — or by a different dataset entirely —
+    /// certifies as this config's. The count therefore proves the corpus is the
+    /// right SIZE; it never proves it is the right corpus. Cardinality is not
+    /// identity.
+    fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         Ok(None)
     }
 

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -16,7 +16,7 @@ use rand::{seq::SliceRandom, SeedableRng};
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{Engine, SearchResults, UpdateSearchRatio, UploadStats};
+use crate::engine::{CorpusCount, Engine, SearchResults, UpdateSearchRatio, UploadStats};
 use vector_db_benchmark::query_filter::QueryFilter;
 use vector_db_benchmark::readers::metadata::MetadataItem;
 
@@ -1196,15 +1196,24 @@ impl Engine for MongoDBEngine {
     /// (issue #238). `countDocuments({})` on the benchmark collection — an exact
     /// count, not the metadata estimate, because the estimate can lag a drop and
     /// report a corpus that is no longer there. A missing collection answers 0.
-    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+    fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let coll = self
             .client
             .database(&self.db_name)
             .collection::<Document>(&self.collection_name);
-        match coll.count_documents(doc! {}).run() {
-            Ok(n) => Ok(Some(n)),
-            Err(_) => Ok(Some(0)),
-        }
+        // A missing collection is not an error in MongoDB — countDocuments
+        // answers 0 — so any Err here is a real probe failure (unreachable node,
+        // auth). Reporting that as a corpus of zero would send the user to
+        // re-upload a corpus that is still intact.
+        coll.count_documents(doc! {})
+            .run()
+            .map(|n| Some(CorpusCount::exact(n)))
+            .map_err(|e| {
+                format!(
+                    "countDocuments on {}.{} failed: {}",
+                    self.db_name, self.collection_name, e
+                )
+            })
     }
 
     fn name(&self) -> &str {
@@ -1327,9 +1336,17 @@ impl Engine for MongoDBEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
-        // `--skip-upload` never runs configure() (issue #238), so the schema type
-        // cache must be primed here too — without it a numeric filter would be
-        // built against string literals and quietly match nothing.
+        // Defensive, matching what Redis and Valkey already do at the top of
+        // their own `search()`: `--skip-upload` never runs configure() (#238),
+        // which is where this cache is otherwise primed. It is the identical
+        // call with the identical argument, so no divergence is possible.
+        //
+        // It is NOT load-bearing for a pure search on shipped data — the filter
+        // builders (`parse_mongo_conditions` -> `json_to_bson`) type literals off
+        // the JSON value itself and never consult the cache; the cache only feeds
+        // `metadata_value_to_bson`, which coerces `MetadataValue::String` on the
+        // WRITE path (upload, and the update half of `search_mixed`). Kept so the
+        // engine's state does not depend on which phases happened to run.
         self.load_schema_types(dataset);
         if self.config.skip_vector_index {
             return self.search_filter_only(dataset, params, num_queries);

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -1193,6 +1193,21 @@ fn json_to_bson(value: &serde_json::Value) -> mongodb::bson::Bson {
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for MongoDBEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `countDocuments({})` on the benchmark collection — an exact
+    /// count, not the metadata estimate, because the estimate can lag a drop and
+    /// report a corpus that is no longer there. A missing collection answers 0.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let coll = self
+            .client
+            .database(&self.db_name)
+            .collection::<Document>(&self.collection_name);
+        match coll.count_documents(doc! {}).run() {
+            Ok(n) => Ok(Some(n)),
+            Err(_) => Ok(Some(0)),
+        }
+    }
+
     fn name(&self) -> &str {
         &self.name
     }
@@ -1313,6 +1328,10 @@ impl Engine for MongoDBEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // `--skip-upload` never runs configure() (issue #238), so the schema type
+        // cache must be primed here too — without it a numeric filter would be
+        // built against string literals and quietly match nothing.
+        self.load_schema_types(dataset);
         if self.config.skip_vector_index {
             return self.search_filter_only(dataset, params, num_queries);
         }

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -1192,6 +1192,21 @@ fn json_to_bson(value: &serde_json::Value) -> mongodb::bson::Bson {
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for MongoDBEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `countDocuments({})` on the benchmark collection — an exact
+    /// count, not the metadata estimate, because the estimate can lag a drop and
+    /// report a corpus that is no longer there. A missing collection answers 0.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let coll = self
+            .client
+            .database(&self.db_name)
+            .collection::<Document>(&self.collection_name);
+        match coll.count_documents(doc! {}).run() {
+            Ok(n) => Ok(Some(n)),
+            Err(_) => Ok(Some(0)),
+        }
+    }
+
     fn name(&self) -> &str {
         &self.name
     }
@@ -1312,6 +1327,10 @@ impl Engine for MongoDBEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // `--skip-upload` never runs configure() (issue #238), so the schema type
+        // cache must be primed here too — without it a numeric filter would be
+        // built against string literals and quietly match nothing.
+        self.load_schema_types(dataset);
         if self.config.skip_vector_index {
             return self.search_filter_only(dataset, params, num_queries);
         }

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -16,7 +16,7 @@ use opensearch::indices::{
     IndicesRefreshParts,
 };
 use opensearch::params::WaitForStatus;
-use opensearch::{BulkParts, OpenSearch, SearchParts};
+use opensearch::{BulkParts, CountParts, OpenSearch, SearchParts};
 use uuid::Uuid;
 
 use crate::config::{EngineConfig, SearchParams};
@@ -1774,6 +1774,29 @@ fn extract_knn_hits(resp_body: &serde_json::Value) -> Result<Vec<(i64, f64)>, St
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for OpenSearchEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `GET /<index>/_count`; a missing index (404) answers 0.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let resp = self
+            .rt
+            .block_on(
+                self.client
+                    .count(CountParts::Index(&[&self.index_name]))
+                    .send(),
+            )
+            .map_err(|e| format!("_count on index '{}' failed: {}", self.index_name, e))?;
+        if resp.status_code().as_u16() == 404 {
+            return Ok(Some(0));
+        }
+        let body: serde_json::Value = self.rt.block_on(resp.json()).map_err(|e| {
+            format!(
+                "_count on index '{}' returned no JSON: {}",
+                self.index_name, e
+            )
+        })?;
+        Ok(body.get("count").and_then(|v| v.as_u64()))
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -14,7 +14,7 @@ use opensearch::indices::{
     IndicesCreateParts, IndicesDeleteParts, IndicesForcemergeParts, IndicesPutSettingsParts,
     IndicesRefreshParts,
 };
-use opensearch::{BulkParts, OpenSearch, SearchParts};
+use opensearch::{BulkParts, CountParts, OpenSearch, SearchParts};
 use uuid::Uuid;
 
 use crate::config::{EngineConfig, SearchParams};
@@ -1350,6 +1350,29 @@ fn extract_knn_hits(resp_body: &serde_json::Value) -> Result<Vec<(i64, f64)>, St
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for OpenSearchEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `GET /<index>/_count`; a missing index (404) answers 0.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let resp = self
+            .rt
+            .block_on(
+                self.client
+                    .count(CountParts::Index(&[&self.index_name]))
+                    .send(),
+            )
+            .map_err(|e| format!("_count on index '{}' failed: {}", self.index_name, e))?;
+        if resp.status_code().as_u16() == 404 {
+            return Ok(Some(0));
+        }
+        let body: serde_json::Value = self.rt.block_on(resp.json()).map_err(|e| {
+            format!(
+                "_count on index '{}' returned no JSON: {}",
+                self.index_name, e
+            )
+        })?;
+        Ok(body.get("count").and_then(|v| v.as_u64()))
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -21,7 +21,7 @@ use uuid::Uuid;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{Engine, SearchResults, UploadStats};
+use crate::engine::{CorpusCount, Engine, SearchResults, UploadStats};
 use vector_db_benchmark::query_filter::QueryFilter;
 use vector_db_benchmark::readers::metadata::MetadataItem;
 
@@ -1776,7 +1776,7 @@ fn extract_knn_hits(resp_body: &serde_json::Value) -> Result<Vec<(i64, f64)>, St
 impl Engine for OpenSearchEngine {
     /// Server-side corpus size, for the `--skip-upload` reuse precondition
     /// (issue #238). `GET /<index>/_count`; a missing index (404) answers 0.
-    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+    fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let resp = self
             .rt
             .block_on(
@@ -1785,8 +1785,19 @@ impl Engine for OpenSearchEngine {
                     .send(),
             )
             .map_err(|e| format!("_count on index '{}' failed: {}", self.index_name, e))?;
-        if resp.status_code().as_u16() == 404 {
-            return Ok(Some(0));
+        // 404 = the index is not there, which for this check is the same as an
+        // empty one. Any other non-2xx (403, or 400 on a CLOSED index whose
+        // corpus is perfectly intact) is a probe failure, not a corpus of zero.
+        let status = resp.status_code().as_u16();
+        if status == 404 {
+            return Ok(Some(CorpusCount::exact(0)));
+        }
+        if !(200..300).contains(&status) {
+            return Err(format!(
+                "_count on index '{}' returned HTTP {} (the index may be closed or \
+                 unreadable; the corpus itself may be intact)",
+                self.index_name, status
+            ));
         }
         let body: serde_json::Value = self.rt.block_on(resp.json()).map_err(|e| {
             format!(
@@ -1794,7 +1805,24 @@ impl Engine for OpenSearchEngine {
                 self.index_name, e
             )
         })?;
-        Ok(body.get("count").and_then(|v| v.as_u64()))
+        // A shard that failed to answer makes the count a floor, not a total —
+        // reporting it as the corpus size would invent a shortfall on a degraded
+        // but intact cluster.
+        let failed_shards = body
+            .pointer("/_shards/failed")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        if failed_shards > 0 {
+            return Err(format!(
+                "_count on index '{}' had {} failed shard(s); the count is a floor, \
+                 not the corpus size",
+                self.index_name, failed_shards
+            ));
+        }
+        Ok(body
+            .get("count")
+            .and_then(|v| v.as_u64())
+            .map(CorpusCount::exact))
     }
 
     fn name(&self) -> &str {

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -166,6 +166,20 @@ impl PgVectorEngine {
 }
 
 impl Engine for PgVectorEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `SELECT count(*) FROM items`; a missing table answers 0.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.connect()?;
+        match conn.query_one("SELECT count(*) FROM items", &[]) {
+            Ok(row) => {
+                let n: i64 = row.get(0);
+                Ok(Some(n.max(0) as u64))
+            }
+            // relation "items" does not exist → nothing to reuse.
+            Err(_) => Ok(Some(0)),
+        }
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -233,14 +233,31 @@ impl Engine for PgVectorEngine {
     ///
     /// It is deliberately not `SELECT count(*) FROM items`. This engine never
     /// VACUUMs and forces `STORAGE PLAIN`, so an exact count plans a Seq Scan
-    /// over the whole heap — 2.6s and ~1.1GB of I/O on a 1M-row table, ~6GB at
-    /// 1536 dims — pulling the entire corpus into the OS page cache and shared
-    /// buffers **immediately before the search phase**. That silently converts a
-    /// cold-cache pgvector run into a warm one and changes the published number,
-    /// which is a worse failure than the one the guard prevents.
+    /// over the whole heap, pulling the entire corpus into shared buffers and the
+    /// OS page cache **immediately before the search phase** — silently turning a
+    /// cold-cache run warm and changing the published number, a worse failure
+    /// than the one this guard prevents.
     ///
-    /// So: `ANALYZE` (a bounded sample) then read the planner's `reltuples`.
-    /// Being approximate, it can only ever warn — never abort a run.
+    /// Measured on a cold 1M-row / 768-dim table built exactly like this engine's
+    /// (3906 MB, 500000 relpages, never VACUUMed, `STORAGE PLAIN`):
+    ///
+    /// ```text
+    ///                      heap blocks touched   cache primed   cold wall clock
+    ///   SELECT count(*)          500 000           3906 MB          1.58 s
+    ///   ANALYZE items             30 001            234 MB          0.84 s
+    /// ```
+    ///
+    /// `EXPLAIN (ANALYZE, BUFFERS)` confirms the plan: `Parallel Seq Scan on
+    /// items … Buffers: shared hit=96 read=499904`.
+    ///
+    /// The decisive property is not the 16.7x ratio but that ANALYZE's sample is
+    /// capped at `300 * default_statistics_target` = 30 000 rows **regardless of
+    /// table size**, so its footprint is BOUNDED while `count(*)` grows linearly:
+    /// at 1536 dims (~7.8 GB) `count(*)` primes the whole 7.8 GB and ANALYZE
+    /// still touches ~30 000 blocks. It is bounded, not free — ~234 MB, ~6% of
+    /// this heap — so the perturbation is capped rather than eliminated.
+    ///
+    /// Being approximate, the result can only ever warn — never abort a run.
     fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let mut conn = self.connect()?;
         // A missing table is "nothing to reuse", not a probe failure.

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -13,7 +13,7 @@ use postgres::types::ToSql;
 
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{Engine, SearchResults, UploadStats};
+use crate::engine::{CorpusCount, Engine, SearchResults, UploadStats};
 use vector_db_benchmark::query_filter::QueryFilter;
 use vector_db_benchmark::readers::metadata::{
     is_multivalued_keyword_field, MetadataItem, MetadataValue,
@@ -168,17 +168,42 @@ impl PgVectorEngine {
 
 impl Engine for PgVectorEngine {
     /// Server-side corpus size, for the `--skip-upload` reuse precondition
-    /// (issue #238). `SELECT count(*) FROM items`; a missing table answers 0.
-    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+    /// (issue #238), as an **estimate**.
+    ///
+    /// It is deliberately not `SELECT count(*) FROM items`. This engine never
+    /// VACUUMs and forces `STORAGE PLAIN`, so an exact count plans a Seq Scan
+    /// over the whole heap — 2.6s and ~1.1GB of I/O on a 1M-row table, ~6GB at
+    /// 1536 dims — pulling the entire corpus into the OS page cache and shared
+    /// buffers **immediately before the search phase**. That silently converts a
+    /// cold-cache pgvector run into a warm one and changes the published number,
+    /// which is a worse failure than the one the guard prevents.
+    ///
+    /// So: `ANALYZE` (a bounded sample) then read the planner's `reltuples`.
+    /// Being approximate, it can only ever warn — never abort a run.
+    fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let mut conn = self.connect()?;
-        match conn.query_one("SELECT count(*) FROM items", &[]) {
-            Ok(row) => {
-                let n: i64 = row.get(0);
-                Ok(Some(n.max(0) as u64))
-            }
-            // relation "items" does not exist → nothing to reuse.
-            Err(_) => Ok(Some(0)),
+        // A missing table is "nothing to reuse", not a probe failure.
+        let exists: bool = conn
+            .query_one("SELECT to_regclass('public.items') IS NOT NULL", &[])
+            .map_err(|e| format!("probing for the items table failed: {e}"))?
+            .get(0);
+        if !exists {
+            return Ok(Some(CorpusCount::exact(0)));
         }
+        conn.execute("ANALYZE items", &[])
+            .map_err(|e| format!("ANALYZE items failed: {e}"))?;
+        let reltuples: f32 = conn
+            .query_one(
+                "SELECT reltuples FROM pg_class WHERE oid = 'public.items'::regclass",
+                &[],
+            )
+            .map_err(|e| format!("reading reltuples for items failed: {e}"))?
+            .get(0);
+        // -1 is "never analyzed"; treat it as "cannot tell" rather than as zero.
+        if reltuples < 0.0 {
+            return Ok(None);
+        }
+        Ok(Some(CorpusCount::estimated(reltuples as u64)))
     }
 
     fn name(&self) -> &str {
@@ -416,6 +441,18 @@ impl Engine for PgVectorEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // Re-derive the distance operator here as well as in configure(): on the
+        // `--skip-upload` path configure() never runs (#238), and `distance_op`
+        // would still be its `new()` default of "" — which splices into the query
+        // as `embedding  $1` and fails EVERY search with a bare SQL syntax error
+        // after a green reuse check. It is a pure function of the dataset, so
+        // recomputing is idempotent; it also restores the unsupported-metric hard
+        // error that the skip-upload path otherwise loses.
+        let (distance_op, hnsw_ops_class) =
+            map_pg_distance_ops(&dataset.distance().to_lowercase())?;
+        self.distance_op = distance_op.to_string();
+        self.hnsw_ops_class = hnsw_ops_class.to_string();
+
         let parallel = params.parallel.unwrap_or(1) as usize;
 
         // Extract hnsw_ef from search params: the typed `ef` field first, then

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -167,6 +167,20 @@ impl PgVectorEngine {
 }
 
 impl Engine for PgVectorEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `SELECT count(*) FROM items`; a missing table answers 0.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.connect()?;
+        match conn.query_one("SELECT count(*) FROM items", &[]) {
+            Ok(row) => {
+                let n: i64 = row.get(0);
+                Ok(Some(n.max(0) as u64))
+            }
+            // relation "items" does not exist → nothing to reuse.
+            Err(_) => Ok(Some(0)),
+        }
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -1712,6 +1712,21 @@ fn build_qdrant_filter(
 }
 
 impl Engine for QdrantEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `points_count` from the collection info — the same figure
+    /// `GET /collections/<name>` reports. A missing collection answers 0.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        match self
+            .rt
+            .block_on(self.client.collection_info(&self.collection_name))
+        {
+            Ok(info) => Ok(Some(info.result.and_then(|r| r.points_count).unwrap_or(0))),
+            // "collection doesn't exist" is a normal error reply here, and for
+            // this check it means the same thing as an empty collection.
+            Err(_) => Ok(Some(0)),
+        }
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -27,7 +27,7 @@ use qdrant_client::{Payload, Qdrant};
 
 use crate::config::{EngineConfig, HnswConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{Engine, SearchResults, UploadStats};
+use crate::engine::{CorpusCount, Engine, SearchResults, UploadStats};
 use vector_db_benchmark::query_filter::QueryFilter;
 use vector_db_benchmark::readers::metadata::MetadataItem;
 
@@ -1711,19 +1711,42 @@ fn build_qdrant_filter(
     }
 }
 
+/// Whether a Qdrant client error means "no such collection" rather than "the
+/// probe failed" (issue #238 — a probe failure must never be reported as a
+/// corpus size of zero).
+fn collection_missing(e: &qdrant_client::QdrantError) -> bool {
+    let msg = e.to_string().to_lowercase();
+    msg.contains("doesn't exist") || msg.contains("does not exist") || msg.contains("not found")
+}
+
 impl Engine for QdrantEngine {
     /// Server-side corpus size, for the `--skip-upload` reuse precondition
     /// (issue #238). `points_count` from the collection info — the same figure
     /// `GET /collections/<name>` reports. A missing collection answers 0.
-    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+    fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         match self
             .rt
             .block_on(self.client.collection_info(&self.collection_name))
         {
-            Ok(info) => Ok(Some(info.result.and_then(|r| r.points_count).unwrap_or(0))),
-            // "collection doesn't exist" is a normal error reply here, and for
-            // this check it means the same thing as an empty collection.
-            Err(_) => Ok(Some(0)),
+            // Pass the Option THROUGH: a reply with no `points_count` means
+            // "cannot tell", and `unwrap_or(0)` would turn that into "the corpus
+            // is gone" — the exact fabrication `ft_info_num_docs` is careful to
+            // avoid (see its `missing_field_is_none_not_zero` test). None here
+            // lands in `Unverifiable`, which says so out loud.
+            Ok(info) => Ok(info
+                .result
+                .and_then(|r| r.points_count)
+                .map(CorpusCount::exact)),
+            // "collection doesn't exist" is a normal error reply, and for this
+            // check it means the same thing as an empty collection. Anything else
+            // (unreachable node, refused gRPC port) says nothing about the corpus
+            // and must NOT be reported as a corpus of zero — that sends the user
+            // to re-upload data that is still there.
+            Err(e) if collection_missing(&e) => Ok(Some(CorpusCount::exact(0))),
+            Err(e) => Err(format!(
+                "collection_info('{}') failed: {}",
+                self.collection_name, e
+            )),
         }
     }
 

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -1743,6 +1743,21 @@ fn build_qdrant_filter(
 }
 
 impl Engine for QdrantEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `points_count` from the collection info — the same figure
+    /// `GET /collections/<name>` reports. A missing collection answers 0.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        match self
+            .rt
+            .block_on(self.client.collection_info(&self.collection_name))
+        {
+            Ok(info) => Ok(Some(info.result.and_then(|r| r.points_count).unwrap_or(0))),
+            // "collection doesn't exist" is a normal error reply here, and for
+            // this check it means the same thing as an empty collection.
+            Err(_) => Ok(Some(0)),
+        }
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -1874,6 +1874,14 @@ fn prime_datetime_fields(schema: Option<&serde_json::Value>) -> HashSet<String> 
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for RedisEngine {
+    /// Server-side corpus size for this config's index, for the `--skip-upload`
+    /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
+    /// index counts as 0 (the corpus to reuse is not there).
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.get_connection()?;
+        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -19,8 +19,8 @@ use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::index_naming::{derive_index_name, derive_key_prefix};
 use crate::engine::{
-    attach_open_loop_metrics, closed_loop_duration, zero_search_results, Engine, OpenLoopPlan,
-    SearchResults, UpdateSearchRatio, UploadStats,
+    attach_open_loop_metrics, closed_loop_duration, zero_search_results, CorpusCount, Engine,
+    OpenLoopPlan, SearchResults, UpdateSearchRatio, UploadStats,
 };
 use crate::metrics::compute_metrics;
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, parse_ft_search_response};
@@ -134,6 +134,16 @@ pub struct RedisEngine {
     config: RedisEngineConfig,
     search_params: Vec<SearchParams>,
     commandstats_baseline: Option<redis_utils::CommandStatsBaseline>,
+    /// Whether `commandstats_baseline` was established by this process.
+    ///
+    /// `None` is ambiguous on its own: it means BOTH "CONFIG RESETSTAT succeeded,
+    /// so the server counters start at zero" and "configure() never ran, so
+    /// nothing was reset". On the `--skip-upload` path (#238) configure() is
+    /// skipped, and `check_commandstats` would then compare this run's failure
+    /// count against zero while the counters still hold every failure since the
+    /// server started — failing a search in which nothing actually failed. This
+    /// flag disambiguates so `search()` can prime the baseline exactly once.
+    commandstats_primed: bool,
 }
 
 impl RedisEngine {
@@ -263,6 +273,7 @@ impl RedisEngine {
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             commandstats_baseline: None,
+            commandstats_primed: false,
         })
     }
 
@@ -1873,13 +1884,32 @@ fn prime_datetime_fields(schema: Option<&serde_json::Value>) -> HashSet<String> 
 
 // ── Engine trait implementation ──────────────────────────────────────────
 
+/// Establish the commandstats baseline if configure() did not (issue #238).
+impl RedisEngine {
+    /// Idempotent and a no-op on the normal configure -> upload -> search path,
+    /// so the existing accounting is unchanged; it only rescues the
+    /// `--skip-upload` path, where nothing had reset the counters.
+    fn prime_commandstats_if_needed(&mut self) -> Result<(), String> {
+        if self.commandstats_primed {
+            return Ok(());
+        }
+        let mut conn = self.get_connection()?;
+        self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
+        self.commandstats_primed = true;
+        Ok(())
+    }
+}
+
 impl Engine for RedisEngine {
     /// Server-side corpus size for this config's index, for the `--skip-upload`
     /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
     /// index counts as 0 (the corpus to reuse is not there).
-    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+    fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let mut conn = self.get_connection()?;
-        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+        Ok(
+            redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)?
+                .map(CorpusCount::exact),
+        )
     }
 
     fn name(&self) -> &str {
@@ -1908,6 +1938,7 @@ impl Engine for RedisEngine {
 
         self.create_index(&mut conn, dataset)?;
         self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
+        self.commandstats_primed = true;
         Ok(())
     }
 
@@ -2043,6 +2074,14 @@ impl Engine for RedisEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // configure() normally resets the server's command counters and
+        // establishes the commandstats baseline; on the `--skip-upload` path it
+        // never runs (#238), so check_commandstats below would compare this run's
+        // failure count against zero while the counters still hold every failure
+        // since the server started — failing a run in which nothing failed.
+        // Idempotent no-op once primed; outside every timed window.
+        self.prime_commandstats_if_needed()?;
+
         // Prime the datetime field-type map from the schema so datetime range
         // filters are built with the correct field type even on the
         // `--skip-upload` path, where configure() (which normally primes it) is
@@ -2462,6 +2501,14 @@ impl Engine for RedisEngine {
         num_queries: i64,
         ratio: &UpdateSearchRatio,
     ) -> Result<SearchResults, String> {
+        // configure() normally resets the server's command counters and
+        // establishes the commandstats baseline; on the `--skip-upload` path it
+        // never runs (#238), so check_commandstats below would compare this run's
+        // failure count against zero while the counters still hold every failure
+        // since the server started — failing a run in which nothing failed.
+        // Idempotent no-op once primed; outside every timed window.
+        self.prime_commandstats_if_needed()?;
+
         // Prime the datetime field-type map from the schema so the update half of
         // the mixed workload encodes datetime payloads as epoch seconds even on
         // the `--skip-upload` path (configure() does not run there). Idempotent.

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -1875,6 +1875,14 @@ fn prime_datetime_fields(schema: Option<&serde_json::Value>) -> HashSet<String> 
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for RedisEngine {
+    /// Server-side corpus size for this config's index, for the `--skip-upload`
+    /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
+    /// index counts as 0 (the corpus to reuse is not there).
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.get_connection()?;
+        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/redis_utils.rs
+++ b/src/bin/vector_db_benchmark/engine/redis_utils.rs
@@ -381,6 +381,14 @@ pub fn ensure_index_exists(conn: &mut Connection, index_name: &str) -> Result<()
 /// This is the count the search actually sees — keys that exist but are not (yet)
 /// in the index cannot answer a query, so a raw keyspace count would overstate
 /// the corpus. Returns `None` when the reply carries no `num_docs` field.
+/// `FT.INFO` fields that carry the live document count, in preference order.
+///
+/// RediSearch (Redis / Valkey / Dragonfly) reports `num_docs`. **KiviDB does
+/// not** — its `FT.INFO` has no `num_docs` at all and reports `hnsw_live_count`
+/// instead, so reading only `num_docs` silently degraded the #238 reuse guard to
+/// "this engine cannot count" on KiviDB while the docs claimed otherwise.
+const FT_INFO_COUNT_FIELDS: [&str; 2] = ["num_docs", "hnsw_live_count"];
+
 pub fn ft_info_num_docs(v: &redis::Value) -> Option<u64> {
     let pairs: Vec<(String, &redis::Value)> = match v {
         redis::Value::Map(m) => m.iter().map(|(k, val)| (value_to_string(k), val)).collect(),
@@ -390,30 +398,51 @@ pub fn ft_info_num_docs(v: &redis::Value) -> Option<u64> {
             .collect(),
         _ => return None,
     };
-    pairs
-        .into_iter()
-        .find(|(k, _)| k == "num_docs")
-        .and_then(|(_, val)| match val {
-            redis::Value::Int(n) => u64::try_from(*n).ok(),
-            other => value_to_string(other).parse::<u64>().ok(),
-        })
+    FT_INFO_COUNT_FIELDS.iter().find_map(|field| {
+        pairs
+            .iter()
+            .find(|(k, _)| k == field)
+            .and_then(|(_, val)| match val {
+                redis::Value::Int(n) => u64::try_from(*n).ok(),
+                other => value_to_string(other).parse::<u64>().ok(),
+            })
+    })
+}
+
+/// Whether a `FT.INFO` error means "that index does not exist" as opposed to
+/// "the probe failed".
+///
+/// The distinction decides whether the #238 reuse guard may report a corpus size
+/// of 0. Only a server reply that names the index as unknown is a real zero;
+/// `NOPERM`, a dropped connection or a timeout say nothing about the corpus, and
+/// reporting them as 0 sends the user to re-upload a corpus that was fine.
+///
+/// Wordings differ per engine: RediSearch/KiviDB say "no such index", Valkey
+/// Search says "Index with name '<n>' not found".
+fn is_missing_index_error(e: &redis::RedisError) -> bool {
+    let msg = format!("{} {}", e.detail().unwrap_or_default(), e).to_lowercase();
+    msg.contains("no such index")
+        || msg.contains("unknown index")
+        || (msg.contains("index") && msg.contains("not found"))
 }
 
 /// Server-side corpus size for a RediSearch-family index, for the `--skip-upload`
 /// reuse precondition (issue #238).
 ///
-/// A **missing** index answers `Ok(Some(0))` rather than an error: for this check
-/// "the index is gone" and "the index is empty" are the same fact — the corpus the
-/// user promised to reuse is not there. An index that exists but reports no
-/// `num_docs` answers `Ok(None)` ("cannot tell"), never a fabricated zero.
+/// - index missing → `Ok(Some(0))`: "the index is gone" and "the index is empty"
+///   are the same fact here — the corpus to reuse is not there.
+/// - index present but the reply carries no count field → `Ok(None)`
+///   ("cannot tell"), never a fabricated zero.
+/// - the probe itself failed (`NOPERM`, connection dropped) → `Err`, so the
+///   caller reports a probe failure rather than an imaginary empty corpus.
 pub fn ft_index_num_docs(conn: &mut Connection, index_name: &str) -> Result<Option<u64>, String> {
     match redis::cmd("FT.INFO")
         .arg(index_name)
         .query::<redis::Value>(conn)
     {
         Ok(v) => Ok(ft_info_num_docs(&v)),
-        // FT.INFO on an absent index is an error reply, not a transport failure.
-        Err(_) => Ok(Some(0)),
+        Err(e) if is_missing_index_error(&e) => Ok(Some(0)),
+        Err(e) => Err(format!("FT.INFO {index_name} failed: {e}")),
     }
 }
 

--- a/src/bin/vector_db_benchmark/engine/redis_utils.rs
+++ b/src/bin/vector_db_benchmark/engine/redis_utils.rs
@@ -376,6 +376,47 @@ pub fn ensure_index_exists(conn: &mut Connection, index_name: &str) -> Result<()
         })
 }
 
+/// `num_docs` from an `FT.INFO` reply (RESP2 flat array or RESP3 map).
+///
+/// This is the count the search actually sees — keys that exist but are not (yet)
+/// in the index cannot answer a query, so a raw keyspace count would overstate
+/// the corpus. Returns `None` when the reply carries no `num_docs` field.
+pub fn ft_info_num_docs(v: &redis::Value) -> Option<u64> {
+    let pairs: Vec<(String, &redis::Value)> = match v {
+        redis::Value::Map(m) => m.iter().map(|(k, val)| (value_to_string(k), val)).collect(),
+        redis::Value::Array(items) => items
+            .chunks_exact(2)
+            .map(|c| (value_to_string(&c[0]), &c[1]))
+            .collect(),
+        _ => return None,
+    };
+    pairs
+        .into_iter()
+        .find(|(k, _)| k == "num_docs")
+        .and_then(|(_, val)| match val {
+            redis::Value::Int(n) => u64::try_from(*n).ok(),
+            other => value_to_string(other).parse::<u64>().ok(),
+        })
+}
+
+/// Server-side corpus size for a RediSearch-family index, for the `--skip-upload`
+/// reuse precondition (issue #238).
+///
+/// A **missing** index answers `Ok(Some(0))` rather than an error: for this check
+/// "the index is gone" and "the index is empty" are the same fact — the corpus the
+/// user promised to reuse is not there. An index that exists but reports no
+/// `num_docs` answers `Ok(None)` ("cannot tell"), never a fabricated zero.
+pub fn ft_index_num_docs(conn: &mut Connection, index_name: &str) -> Result<Option<u64>, String> {
+    match redis::cmd("FT.INFO")
+        .arg(index_name)
+        .query::<redis::Value>(conn)
+    {
+        Ok(v) => Ok(ft_info_num_docs(&v)),
+        // FT.INFO on an absent index is an error reply, not a transport failure.
+        Err(_) => Ok(Some(0)),
+    }
+}
+
 /// Per-index memory footprint in bytes, summed from every `*_mb` size field of
 /// an `FT.INFO` reply (RESP2 flat array or RESP3 map). Under issue #151-4's
 /// coexistence mode the server-wide `used_memory` is the SUM of all resident
@@ -739,5 +780,68 @@ mod metadata_tests {
         let cfg = parse_kv_map(&reply);
         assert_eq!(cfg["maxmemory"], "0");
         assert_eq!(cfg["save"], "3600 1");
+    }
+}
+
+#[cfg(test)]
+mod num_docs_tests {
+    use super::ft_info_num_docs;
+    use redis::Value;
+
+    fn bulk(s: &str) -> Value {
+        Value::BulkString(s.as_bytes().to_vec())
+    }
+
+    // RESP2: FT.INFO is a flat alternating array; num_docs arrives as a string.
+    #[test]
+    fn reads_num_docs_from_resp2_array() {
+        let v = Value::Array(vec![
+            bulk("index_name"),
+            bulk("idx:cfg"),
+            bulk("num_docs"),
+            bulk("400"),
+            bulk("indexing"),
+            Value::Int(0),
+        ]);
+        assert_eq!(ft_info_num_docs(&v), Some(400));
+    }
+
+    // RESP3: a map, and num_docs may be a native integer.
+    #[test]
+    fn reads_num_docs_from_resp3_map() {
+        let v = Value::Map(vec![
+            (bulk("index_name"), bulk("idx:cfg")),
+            (bulk("num_docs"), Value::Int(400)),
+        ]);
+        assert_eq!(ft_info_num_docs(&v), Some(400));
+    }
+
+    // No num_docs field → "cannot tell", never a fabricated 0: a 0 would be read
+    // as "the corpus is gone" and abort a legitimate --skip-upload run (#238).
+    #[test]
+    fn missing_field_is_none_not_zero() {
+        let v = Value::Array(vec![bulk("index_name"), bulk("idx:cfg")]);
+        assert_eq!(ft_info_num_docs(&v), None);
+        assert_eq!(ft_info_num_docs(&Value::Nil), None);
+    }
+
+    // An empty index legitimately reports 0.
+    #[test]
+    fn empty_index_reports_zero() {
+        let v = Value::Array(vec![bulk("num_docs"), bulk("0")]);
+        assert_eq!(ft_info_num_docs(&v), Some(0));
+    }
+
+    // A negative or unparseable value must not wrap into a huge u64.
+    #[test]
+    fn nonsense_values_are_none() {
+        assert_eq!(
+            ft_info_num_docs(&Value::Array(vec![bulk("num_docs"), Value::Int(-1)])),
+            None
+        );
+        assert_eq!(
+            ft_info_num_docs(&Value::Array(vec![bulk("num_docs"), bulk("many")])),
+            None
+        );
     }
 }

--- a/src/bin/vector_db_benchmark/engine/turbopuffer.rs
+++ b/src/bin/vector_db_benchmark/engine/turbopuffer.rs
@@ -499,6 +499,16 @@ impl Engine for TurbopufferEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // Re-derive the distance metric here as well as in configure(): on the
+        // `--skip-upload` path configure() never runs (#238) and this field would
+        // keep its `new()` default of "cosine_distance" — which does not fail, it
+        // just measures an l2 or dot dataset under the WRONG metric and writes a
+        // plausible file. Pure function of the dataset, so recomputing is
+        // idempotent.
+        self.distance_metric =
+            to_turbopuffer_metric(dataset.config.distance.as_deref().unwrap_or("cosine"))
+                .to_string();
+
         // Clamp to >=1: `parallel` is Option<i64> from config, so 0 would spawn
         // no workers (AtomicUsize never drained → spurious "no searches" error)
         // and a negative value would wrap to usize::MAX via `as usize` and spawn

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -34,7 +34,7 @@ use redis::Connection;
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
 use crate::engine::index_naming::{derive_index_name, derive_key_prefix};
-use crate::engine::{Engine, SearchResults, UpdateSearchRatio, UploadStats};
+use crate::engine::{CorpusCount, Engine, SearchResults, UpdateSearchRatio, UploadStats};
 use vector_db_benchmark::parsers::{datetime_to_epoch_secs, doc_key_to_id, doc_key_to_id_opt};
 use vector_db_benchmark::query_filter::QueryFilter;
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
@@ -76,6 +76,16 @@ pub struct ValkeyEngine {
     config: ValkeyEngineConfig,
     search_params: Vec<SearchParams>,
     commandstats_baseline: Option<redis_utils::CommandStatsBaseline>,
+    /// Whether `commandstats_baseline` was established by this process.
+    ///
+    /// `None` is ambiguous on its own: it means BOTH "CONFIG RESETSTAT succeeded,
+    /// so the server counters start at zero" and "configure() never ran, so
+    /// nothing was reset". On the `--skip-upload` path (#238) configure() is
+    /// skipped, and `check_commandstats` would then compare this run's failure
+    /// count against zero while the counters still hold every failure since the
+    /// server started — failing a search in which nothing actually failed. This
+    /// flag disambiguates so `search()` can prime the baseline exactly once.
+    commandstats_primed: bool,
 }
 
 impl ValkeyEngine {
@@ -139,6 +149,7 @@ impl ValkeyEngine {
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             commandstats_baseline: None,
+            commandstats_primed: false,
         })
     }
 
@@ -1632,13 +1643,32 @@ fn prime_field_types(schema: Option<&serde_json::Value>) -> (HashSet<String>, Ha
 
 // ── Engine trait implementation ──────────────────────────────────────────
 
+/// Establish the commandstats baseline if configure() did not (issue #238).
+impl ValkeyEngine {
+    /// Idempotent and a no-op on the normal configure -> upload -> search path,
+    /// so the existing accounting is unchanged; it only rescues the
+    /// `--skip-upload` path, where nothing had reset the counters.
+    fn prime_commandstats_if_needed(&mut self) -> Result<(), String> {
+        if self.commandstats_primed {
+            return Ok(());
+        }
+        let mut conn = self.get_connection()?;
+        self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
+        self.commandstats_primed = true;
+        Ok(())
+    }
+}
+
 impl Engine for ValkeyEngine {
     /// Server-side corpus size for this config's index, for the `--skip-upload`
     /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
     /// index counts as 0 (the corpus to reuse is not there).
-    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+    fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let mut conn = self.get_connection()?;
-        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+        Ok(
+            redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)?
+                .map(CorpusCount::exact),
+        )
     }
 
     fn name(&self) -> &str {
@@ -1669,6 +1699,7 @@ impl Engine for ValkeyEngine {
 
         self.create_index(&mut conn, dataset)?;
         self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
+        self.commandstats_primed = true;
         Ok(())
     }
 
@@ -1747,6 +1778,14 @@ impl Engine for ValkeyEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // configure() normally resets the server's command counters and
+        // establishes the commandstats baseline; on the `--skip-upload` path it
+        // never runs (#238), so check_commandstats below would compare this run's
+        // failure count against zero while the counters still hold every failure
+        // since the server started — failing a run in which nothing failed.
+        // Idempotent no-op once primed; outside every timed window.
+        self.prime_commandstats_if_needed()?;
+
         // Prime the datetime/text field-type maps from the schema so range and
         // text/tag filters are built with the correct field type even on the
         // `--skip-upload` path, where configure() (which normally primes them) is
@@ -2032,6 +2071,14 @@ impl Engine for ValkeyEngine {
         num_queries: i64,
         ratio: &UpdateSearchRatio,
     ) -> Result<SearchResults, String> {
+        // configure() normally resets the server's command counters and
+        // establishes the commandstats baseline; on the `--skip-upload` path it
+        // never runs (#238), so check_commandstats below would compare this run's
+        // failure count against zero while the counters still hold every failure
+        // since the server started — failing a run in which nothing failed.
+        // Idempotent no-op once primed; outside every timed window.
+        self.prime_commandstats_if_needed()?;
+
         // Prime the datetime/text field-type maps from the schema so the update
         // half of the mixed workload encodes datetime payloads as epoch seconds
         // and text payloads as tokenised TAGs even on the `--skip-upload` path

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -1634,6 +1634,14 @@ fn prime_field_types(schema: Option<&serde_json::Value>) -> (HashSet<String>, Ha
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for ValkeyEngine {
+    /// Server-side corpus size for this config's index, for the `--skip-upload`
+    /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
+    /// index counts as 0 (the corpus to reuse is not there).
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.get_connection()?;
+        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -1633,6 +1633,14 @@ fn prime_field_types(schema: Option<&serde_json::Value>) -> (HashSet<String>, Ha
 // ── Engine trait implementation ──────────────────────────────────────────
 
 impl Engine for ValkeyEngine {
+    /// Server-side corpus size for this config's index, for the `--skip-upload`
+    /// reuse precondition (issue #238). `FT.INFO <index>` → `num_docs`; a missing
+    /// index counts as 0 (the corpus to reuse is not there).
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.get_connection()?;
+        redis_utils::ft_index_num_docs(&mut conn, &self.config.index_name)
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -447,6 +447,22 @@ fn vadd_single(
 }
 
 impl Engine for VectorSetsEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `VCARD idx` — the cardinality of the vector set this engine
+    /// searches. A missing key answers 0 (VCARD returns 0 for a non-existent key),
+    /// which is exactly the "nothing to reuse" verdict we want.
+    ///
+    /// The key is the hardcoded `idx` (issue #236): this count therefore cannot
+    /// distinguish two configs sharing one server, and neither can the search.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.get_connection()?;
+        let n: u64 = redis::cmd("VCARD")
+            .arg("idx")
+            .query(&mut conn)
+            .map_err(|e| format!("VCARD idx failed: {e}"))?;
+        Ok(Some(n))
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -448,6 +448,22 @@ fn vadd_single(
 }
 
 impl Engine for VectorSetsEngine {
+    /// Server-side corpus size, for the `--skip-upload` reuse precondition
+    /// (issue #238). `VCARD idx` — the cardinality of the vector set this engine
+    /// searches. A missing key answers 0 (VCARD returns 0 for a non-existent key),
+    /// which is exactly the "nothing to reuse" verdict we want.
+    ///
+    /// The key is the hardcoded `idx` (issue #236): this count therefore cannot
+    /// distinguish two configs sharing one server, and neither can the search.
+    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+        let mut conn = self.get_connection()?;
+        let n: u64 = redis::cmd("VCARD")
+            .arg("idx")
+            .query(&mut conn)
+            .map_err(|e| format!("VCARD idx failed: {e}"))?;
+        Ok(Some(n))
+    }
+
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -15,7 +15,7 @@ use redis::Connection;
 use super::redis_utils;
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{Engine, SearchResults, UpdateSearchRatio, UploadStats};
+use crate::engine::{CorpusCount, Engine, SearchResults, UpdateSearchRatio, UploadStats};
 use vector_db_benchmark::parsers::datetime_to_epoch_secs;
 use vector_db_benchmark::query_filter::QueryFilter;
 use vector_db_benchmark::readers::metadata::{MetadataItem, MetadataValue};
@@ -37,6 +37,16 @@ pub struct VectorSetsEngine {
     config: VectorSetsConfig,
     search_params: Vec<SearchParams>,
     commandstats_baseline: Option<redis_utils::CommandStatsBaseline>,
+    /// Whether `commandstats_baseline` was established by this process.
+    ///
+    /// `None` is ambiguous on its own: it means BOTH "CONFIG RESETSTAT succeeded,
+    /// so the server counters start at zero" and "configure() never ran, so
+    /// nothing was reset". On the `--skip-upload` path (#238) configure() is
+    /// skipped, and `check_commandstats` would then compare this run's failure
+    /// count against zero while the counters still hold every failure since the
+    /// server started — failing a search in which nothing actually failed. This
+    /// flag disambiguates so `search()` can prime the baseline exactly once.
+    commandstats_primed: bool,
 }
 
 impl VectorSetsEngine {
@@ -99,6 +109,7 @@ impl VectorSetsEngine {
             },
             search_params: engine_config.search_params.clone().unwrap_or_default(),
             commandstats_baseline: None,
+            commandstats_primed: false,
         })
     }
 
@@ -447,6 +458,22 @@ fn vadd_single(
         .map_err(|e| format!("VADD update error: {}", e))
 }
 
+/// Establish the commandstats baseline if configure() did not (issue #238).
+impl VectorSetsEngine {
+    /// Idempotent and a no-op on the normal configure -> upload -> search path,
+    /// so the existing accounting is unchanged; it only rescues the
+    /// `--skip-upload` path, where nothing had reset the counters.
+    fn prime_commandstats_if_needed(&mut self) -> Result<(), String> {
+        if self.commandstats_primed {
+            return Ok(());
+        }
+        let mut conn = self.get_connection()?;
+        self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
+        self.commandstats_primed = true;
+        Ok(())
+    }
+}
+
 impl Engine for VectorSetsEngine {
     /// Server-side corpus size, for the `--skip-upload` reuse precondition
     /// (issue #238). `VCARD idx` — the cardinality of the vector set this engine
@@ -455,13 +482,16 @@ impl Engine for VectorSetsEngine {
     ///
     /// The key is the hardcoded `idx` (issue #236): this count therefore cannot
     /// distinguish two configs sharing one server, and neither can the search.
-    fn corpus_row_count(&mut self) -> Result<Option<u64>, String> {
+    fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let mut conn = self.get_connection()?;
+        // VCARD answers 0 for a key that does not exist, so a missing corpus and
+        // an empty one are the same reply — which is the verdict we want. Any
+        // Err is a genuine probe failure and is propagated, never reported as 0.
         let n: u64 = redis::cmd("VCARD")
             .arg("idx")
             .query(&mut conn)
             .map_err(|e| format!("VCARD idx failed: {e}"))?;
-        Ok(Some(n))
+        Ok(Some(CorpusCount::exact(n)))
     }
 
     fn name(&self) -> &str {
@@ -488,6 +518,7 @@ impl Engine for VectorSetsEngine {
         let _ = redis::cmd("DEL").arg("idx").query::<()>(&mut conn);
 
         self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
+        self.commandstats_primed = true;
         Ok(())
     }
 
@@ -555,6 +586,14 @@ impl Engine for VectorSetsEngine {
         params: &SearchParams,
         num_queries: i64,
     ) -> Result<SearchResults, String> {
+        // configure() normally resets the server's command counters and
+        // establishes the commandstats baseline; on the `--skip-upload` path it
+        // never runs (#238), so check_commandstats below would compare this run's
+        // failure count against zero while the counters still hold every failure
+        // since the server started — failing a run in which nothing failed.
+        // Idempotent no-op once primed; outside every timed window.
+        self.prime_commandstats_if_needed()?;
+
         let ef = params
             .search_params
             .as_ref()
@@ -788,6 +827,14 @@ impl Engine for VectorSetsEngine {
         num_queries: i64,
         ratio: &UpdateSearchRatio,
     ) -> Result<SearchResults, String> {
+        // configure() normally resets the server's command counters and
+        // establishes the commandstats baseline; on the `--skip-upload` path it
+        // never runs (#238), so check_commandstats below would compare this run's
+        // failure count against zero while the counters still hold every failure
+        // since the server started — failing a run in which nothing failed.
+        // Idempotent no-op once primed; outside every timed window.
+        self.prime_commandstats_if_needed()?;
+
         let ef = params
             .search_params
             .as_ref()

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -410,6 +410,158 @@ fn parse_update_search_ratio(s: &str) -> Result<UpdateSearchRatio, String> {
     Ok(UpdateSearchRatio { updates, searches })
 }
 
+/// Outcome of the `--skip-upload` reuse precondition check, split out so it can
+/// be unit-tested without a server (issue #238).
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReusePrecondition {
+    /// Server-side count matches (or exceeds, see `Surplus`) what the dataset declares.
+    Ok { actual: u64, expected: u64 },
+    /// Nothing to check against: the dataset has no measurable corpus size, or
+    /// the engine cannot report a server-side count. Proceed with a note.
+    Unverifiable(String),
+    /// The server holds MORE rows than the dataset declares. Warn and continue:
+    /// leftovers from a bigger corpus change the reported recall, but so does
+    /// refusing to run, and unlike a short corpus this is often deliberate
+    /// (a shared prefix, a superset upload).
+    Surplus { actual: u64, expected: u64 },
+    /// The server holds FEWER rows than the dataset declares — including zero,
+    /// i.e. a missing index/collection. Fatal: every reported recall/precision
+    /// figure is computed against ground truth for the FULL corpus, so a short
+    /// corpus silently publishes the wrong number.
+    Short { actual: u64, expected: u64 },
+}
+
+/// Classify a server-side corpus count against what the dataset declares.
+pub fn classify_reuse_precondition(
+    expected: Option<u64>,
+    actual: Option<u64>,
+    engine_name: &str,
+) -> ReusePrecondition {
+    match (expected, actual) {
+        (None, _) => ReusePrecondition::Unverifiable(
+            "dataset does not declare (and cannot measure) a corpus size".to_string(),
+        ),
+        (Some(_), None) => ReusePrecondition::Unverifiable(format!(
+            "engine '{}' cannot report a server-side row count",
+            engine_name
+        )),
+        (Some(e), Some(a)) if a < e => ReusePrecondition::Short {
+            actual: a,
+            expected: e,
+        },
+        (Some(e), Some(a)) if a > e => ReusePrecondition::Surplus {
+            actual: a,
+            expected: e,
+        },
+        (Some(e), Some(a)) => ReusePrecondition::Ok {
+            actual: a,
+            expected: e,
+        },
+    }
+}
+
+/// Verify the promise `--skip-upload` makes: that the corpus it is told to reuse
+/// is actually there, and whole (issue #238).
+///
+/// The check reads state back off the live server (`FT.INFO`/`SCAN`,
+/// `GET /collections/<n>`, `_count`, `countDocuments`, `SELECT count(*)`, ...) —
+/// "search returned no error" is not evidence, and neither is recall: a run
+/// against a half-deleted Qdrant collection reports `mean_recall: 1.0`.
+///
+/// Repo policy on what is fatal: a short corpus changes the reported number, so
+/// it is a hard error; everything softer is a warning.
+fn check_corpus_reuse_precondition(
+    engine: &mut dyn Engine,
+    dataset: &Dataset,
+    args: &Args,
+) -> Result<(), String> {
+    // Nothing is measured, so nothing can be misreported.
+    if args.skip_search {
+        return Ok(());
+    }
+
+    // The expected count MEASURES the corpus on disk where it can, rather than
+    // trusting a declared `vector_count` that may be smaller than the real
+    // corpus (#224).
+    let expected = match dataset.corpus_completeness_target() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("\tNote: could not determine the dataset's corpus size ({e}); --skip-upload reuse left unverified");
+            None
+        }
+    };
+
+    let actual = match engine.corpus_row_count() {
+        Ok(v) => v,
+        Err(e) => {
+            let msg = format!(
+                "--skip-upload: could not read the server-side corpus size for engine '{}' ({}). \
+                 The flag promises to reuse an already-loaded corpus, and that promise is now \
+                 unverified — a missing or partial index would be measured and reported as if it \
+                 were complete. Fix the connection, or pass --allow-partial-corpus to run anyway.",
+                engine.name(),
+                e
+            );
+            if args.allow_partial_corpus {
+                eprintln!("WARNING: {msg}");
+                return Ok(());
+            }
+            return Err(msg);
+        }
+    };
+
+    match classify_reuse_precondition(expected, actual, engine.name()) {
+        ReusePrecondition::Ok { actual, expected } => {
+            println!(
+                "Experiment stage: Reuse check — server holds {actual} of {expected} expected rows"
+            );
+            Ok(())
+        }
+        ReusePrecondition::Unverifiable(why) => {
+            println!(
+                "Experiment stage: Reuse check — SKIPPED ({why}); \
+                 --skip-upload is running against an unverified corpus"
+            );
+            Ok(())
+        }
+        ReusePrecondition::Surplus { actual, expected } => {
+            eprintln!(
+                "WARNING: --skip-upload: engine '{}' holds {} rows but dataset '{}' declares {} — \
+                 the extra rows are searchable and can displace true neighbours, so recall may be \
+                 understated.",
+                engine.name(),
+                actual,
+                dataset.config.name,
+                expected
+            );
+            Ok(())
+        }
+        ReusePrecondition::Short { actual, expected } => {
+            let what = if actual == 0 {
+                "is empty or missing"
+            } else {
+                "is incomplete"
+            };
+            let msg = format!(
+                "--skip-upload: the corpus you asked to reuse {what} — engine '{}' holds {} of the \
+                 {} rows dataset '{}' declares. Recall/precision are scored against ground truth \
+                 for the FULL corpus, so continuing would publish a wrong number under a config \
+                 name that claims otherwise. Re-upload (drop --skip-upload, add --keep-data), or \
+                 pass --allow-partial-corpus to measure the partial corpus deliberately.",
+                engine.name(),
+                actual,
+                expected,
+                dataset.config.name
+            );
+            if args.allow_partial_corpus {
+                eprintln!("WARNING: {msg}");
+                return Ok(());
+            }
+            Err(msg)
+        }
+    }
+}
+
 /// Run a single experiment (configure, upload, search)
 fn run_single_experiment(
     engine: &mut dyn Engine,
@@ -477,11 +629,23 @@ fn run_single_experiment(
             &upload_stats,
             number_of_shards,
         )?;
-    } else if args.skip_vector_index {
-        // --skip-upload + --skip-vector-index: data already uploaded, but we need
-        // a schema-only index (previous run's index was dropped by delete()).
-        println!("Experiment stage: Configure (creating schema-only index for filter-only search)");
-        engine.configure(dataset)?;
+    } else {
+        // `--skip-upload` means: the server already holds the corpus I want —
+        // do not create, drop, recreate or otherwise modify it. `configure()` is
+        // destructive on 13 of the 15 engines (FT.DROPINDEX ... DD, SCAN+UNLINK,
+        // collection.drop(), DROP TABLE, DELETE /collections/<n>, ...), so it must
+        // NOT run here under any flag combination.
+        //
+        // This used to have an `else if args.skip_vector_index` arm that called
+        // `configure()` "to create a schema-only index". It destroyed the corpus
+        // the flags had just promised to reuse and then measured the empty index
+        // without a word (issue #238) — verified live: Redis 400 -> 0 docs,
+        // Valkey 400 -> 0 keys, MongoDB 400 -> 0 documents, each still printing a
+        // QPS number and exiting 0. The arm is also unnecessary: the prior
+        // `--skip-vector-index --keep-data` upload runs under the SAME rewritten
+        // config name (`<engine>-no-vector`), so it left exactly the schema-only
+        // index this run needs.
+        check_corpus_reuse_precondition(engine, dataset, args)?;
     }
 
     // Build ordered search phases: pure search first, then mixed ratios ascending
@@ -1939,5 +2103,90 @@ mod tests {
                 note
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod reuse_precondition_tests {
+    use super::{classify_reuse_precondition, ReusePrecondition};
+
+    // A corpus shorter than the dataset declares is the case that publishes a
+    // wrong recall under a config name claiming otherwise (issue #238).
+    #[test]
+    fn short_corpus_is_short() {
+        assert_eq!(
+            classify_reuse_precondition(Some(400), Some(200), "redis-x"),
+            ReusePrecondition::Short {
+                actual: 200,
+                expected: 400
+            }
+        );
+    }
+
+    // A missing index/collection reports 0 rows. Same verdict as a truncated
+    // one: the corpus the flags promised to reuse is not there.
+    #[test]
+    fn missing_corpus_is_short_not_ok() {
+        assert_eq!(
+            classify_reuse_precondition(Some(400), Some(0), "redis-x"),
+            ReusePrecondition::Short {
+                actual: 0,
+                expected: 400
+            }
+        );
+    }
+
+    #[test]
+    fn exact_match_is_ok() {
+        assert_eq!(
+            classify_reuse_precondition(Some(400), Some(400), "redis-x"),
+            ReusePrecondition::Ok {
+                actual: 400,
+                expected: 400
+            }
+        );
+    }
+
+    // Extra rows affect the number too, but unlike a shortfall they are often
+    // deliberate (a shared prefix, a superset upload) — warn, do not abort.
+    #[test]
+    fn surplus_is_a_warning_not_an_error() {
+        assert_eq!(
+            classify_reuse_precondition(Some(400), Some(401), "redis-x"),
+            ReusePrecondition::Surplus {
+                actual: 401,
+                expected: 400
+            }
+        );
+    }
+
+    // Nothing to compare against must never be silently reported as "Ok" — the
+    // runner has to say the reuse went unverified.
+    #[test]
+    fn unknown_expected_or_actual_is_unverifiable() {
+        assert!(matches!(
+            classify_reuse_precondition(None, Some(400), "redis-x"),
+            ReusePrecondition::Unverifiable(_)
+        ));
+        let why = match classify_reuse_precondition(Some(400), None, "chroma-y") {
+            ReusePrecondition::Unverifiable(w) => w,
+            other => panic!("expected Unverifiable, got {other:?}"),
+        };
+        assert!(
+            why.contains("chroma-y"),
+            "the note must name the engine that cannot count: {why}"
+        );
+    }
+
+    // Zero expected rows cannot make a zero-row server look short.
+    #[test]
+    fn zero_expected_never_fires() {
+        assert_eq!(
+            classify_reuse_precondition(Some(0), Some(0), "redis-x"),
+            ReusePrecondition::Ok {
+                actual: 0,
+                expected: 0
+            }
+        );
     }
 }

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -402,6 +402,158 @@ fn parse_update_search_ratio(s: &str) -> Result<UpdateSearchRatio, String> {
     Ok(UpdateSearchRatio { updates, searches })
 }
 
+/// Outcome of the `--skip-upload` reuse precondition check, split out so it can
+/// be unit-tested without a server (issue #238).
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReusePrecondition {
+    /// Server-side count matches (or exceeds, see `Surplus`) what the dataset declares.
+    Ok { actual: u64, expected: u64 },
+    /// Nothing to check against: the dataset has no measurable corpus size, or
+    /// the engine cannot report a server-side count. Proceed with a note.
+    Unverifiable(String),
+    /// The server holds MORE rows than the dataset declares. Warn and continue:
+    /// leftovers from a bigger corpus change the reported recall, but so does
+    /// refusing to run, and unlike a short corpus this is often deliberate
+    /// (a shared prefix, a superset upload).
+    Surplus { actual: u64, expected: u64 },
+    /// The server holds FEWER rows than the dataset declares — including zero,
+    /// i.e. a missing index/collection. Fatal: every reported recall/precision
+    /// figure is computed against ground truth for the FULL corpus, so a short
+    /// corpus silently publishes the wrong number.
+    Short { actual: u64, expected: u64 },
+}
+
+/// Classify a server-side corpus count against what the dataset declares.
+pub fn classify_reuse_precondition(
+    expected: Option<u64>,
+    actual: Option<u64>,
+    engine_name: &str,
+) -> ReusePrecondition {
+    match (expected, actual) {
+        (None, _) => ReusePrecondition::Unverifiable(
+            "dataset does not declare (and cannot measure) a corpus size".to_string(),
+        ),
+        (Some(_), None) => ReusePrecondition::Unverifiable(format!(
+            "engine '{}' cannot report a server-side row count",
+            engine_name
+        )),
+        (Some(e), Some(a)) if a < e => ReusePrecondition::Short {
+            actual: a,
+            expected: e,
+        },
+        (Some(e), Some(a)) if a > e => ReusePrecondition::Surplus {
+            actual: a,
+            expected: e,
+        },
+        (Some(e), Some(a)) => ReusePrecondition::Ok {
+            actual: a,
+            expected: e,
+        },
+    }
+}
+
+/// Verify the promise `--skip-upload` makes: that the corpus it is told to reuse
+/// is actually there, and whole (issue #238).
+///
+/// The check reads state back off the live server (`FT.INFO`/`SCAN`,
+/// `GET /collections/<n>`, `_count`, `countDocuments`, `SELECT count(*)`, ...) —
+/// "search returned no error" is not evidence, and neither is recall: a run
+/// against a half-deleted Qdrant collection reports `mean_recall: 1.0`.
+///
+/// Repo policy on what is fatal: a short corpus changes the reported number, so
+/// it is a hard error; everything softer is a warning.
+fn check_corpus_reuse_precondition(
+    engine: &mut dyn Engine,
+    dataset: &Dataset,
+    args: &Args,
+) -> Result<(), String> {
+    // Nothing is measured, so nothing can be misreported.
+    if args.skip_search {
+        return Ok(());
+    }
+
+    // The expected count MEASURES the corpus on disk where it can, rather than
+    // trusting a declared `vector_count` that may be smaller than the real
+    // corpus (#224).
+    let expected = match dataset.corpus_completeness_target() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("\tNote: could not determine the dataset's corpus size ({e}); --skip-upload reuse left unverified");
+            None
+        }
+    };
+
+    let actual = match engine.corpus_row_count() {
+        Ok(v) => v,
+        Err(e) => {
+            let msg = format!(
+                "--skip-upload: could not read the server-side corpus size for engine '{}' ({}). \
+                 The flag promises to reuse an already-loaded corpus, and that promise is now \
+                 unverified — a missing or partial index would be measured and reported as if it \
+                 were complete. Fix the connection, or pass --allow-partial-corpus to run anyway.",
+                engine.name(),
+                e
+            );
+            if args.allow_partial_corpus {
+                eprintln!("WARNING: {msg}");
+                return Ok(());
+            }
+            return Err(msg);
+        }
+    };
+
+    match classify_reuse_precondition(expected, actual, engine.name()) {
+        ReusePrecondition::Ok { actual, expected } => {
+            println!(
+                "Experiment stage: Reuse check — server holds {actual} of {expected} expected rows"
+            );
+            Ok(())
+        }
+        ReusePrecondition::Unverifiable(why) => {
+            println!(
+                "Experiment stage: Reuse check — SKIPPED ({why}); \
+                 --skip-upload is running against an unverified corpus"
+            );
+            Ok(())
+        }
+        ReusePrecondition::Surplus { actual, expected } => {
+            eprintln!(
+                "WARNING: --skip-upload: engine '{}' holds {} rows but dataset '{}' declares {} — \
+                 the extra rows are searchable and can displace true neighbours, so recall may be \
+                 understated.",
+                engine.name(),
+                actual,
+                dataset.config.name,
+                expected
+            );
+            Ok(())
+        }
+        ReusePrecondition::Short { actual, expected } => {
+            let what = if actual == 0 {
+                "is empty or missing"
+            } else {
+                "is incomplete"
+            };
+            let msg = format!(
+                "--skip-upload: the corpus you asked to reuse {what} — engine '{}' holds {} of the \
+                 {} rows dataset '{}' declares. Recall/precision are scored against ground truth \
+                 for the FULL corpus, so continuing would publish a wrong number under a config \
+                 name that claims otherwise. Re-upload (drop --skip-upload, add --keep-data), or \
+                 pass --allow-partial-corpus to measure the partial corpus deliberately.",
+                engine.name(),
+                actual,
+                expected,
+                dataset.config.name
+            );
+            if args.allow_partial_corpus {
+                eprintln!("WARNING: {msg}");
+                return Ok(());
+            }
+            Err(msg)
+        }
+    }
+}
+
 /// Run a single experiment (configure, upload, search)
 fn run_single_experiment(
     engine: &mut dyn Engine,
@@ -469,11 +621,23 @@ fn run_single_experiment(
             &upload_stats,
             number_of_shards,
         )?;
-    } else if args.skip_vector_index {
-        // --skip-upload + --skip-vector-index: data already uploaded, but we need
-        // a schema-only index (previous run's index was dropped by delete()).
-        println!("Experiment stage: Configure (creating schema-only index for filter-only search)");
-        engine.configure(dataset)?;
+    } else {
+        // `--skip-upload` means: the server already holds the corpus I want —
+        // do not create, drop, recreate or otherwise modify it. `configure()` is
+        // destructive on 13 of the 15 engines (FT.DROPINDEX ... DD, SCAN+UNLINK,
+        // collection.drop(), DROP TABLE, DELETE /collections/<n>, ...), so it must
+        // NOT run here under any flag combination.
+        //
+        // This used to have an `else if args.skip_vector_index` arm that called
+        // `configure()` "to create a schema-only index". It destroyed the corpus
+        // the flags had just promised to reuse and then measured the empty index
+        // without a word (issue #238) — verified live: Redis 400 -> 0 docs,
+        // Valkey 400 -> 0 keys, MongoDB 400 -> 0 documents, each still printing a
+        // QPS number and exiting 0. The arm is also unnecessary: the prior
+        // `--skip-vector-index --keep-data` upload runs under the SAME rewritten
+        // config name (`<engine>-no-vector`), so it left exactly the schema-only
+        // index this run needs.
+        check_corpus_reuse_precondition(engine, dataset, args)?;
     }
 
     // Build ordered search phases: pure search first, then mixed ratios ascending
@@ -1931,5 +2095,90 @@ mod tests {
                 note
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod reuse_precondition_tests {
+    use super::{classify_reuse_precondition, ReusePrecondition};
+
+    // A corpus shorter than the dataset declares is the case that publishes a
+    // wrong recall under a config name claiming otherwise (issue #238).
+    #[test]
+    fn short_corpus_is_short() {
+        assert_eq!(
+            classify_reuse_precondition(Some(400), Some(200), "redis-x"),
+            ReusePrecondition::Short {
+                actual: 200,
+                expected: 400
+            }
+        );
+    }
+
+    // A missing index/collection reports 0 rows. Same verdict as a truncated
+    // one: the corpus the flags promised to reuse is not there.
+    #[test]
+    fn missing_corpus_is_short_not_ok() {
+        assert_eq!(
+            classify_reuse_precondition(Some(400), Some(0), "redis-x"),
+            ReusePrecondition::Short {
+                actual: 0,
+                expected: 400
+            }
+        );
+    }
+
+    #[test]
+    fn exact_match_is_ok() {
+        assert_eq!(
+            classify_reuse_precondition(Some(400), Some(400), "redis-x"),
+            ReusePrecondition::Ok {
+                actual: 400,
+                expected: 400
+            }
+        );
+    }
+
+    // Extra rows affect the number too, but unlike a shortfall they are often
+    // deliberate (a shared prefix, a superset upload) — warn, do not abort.
+    #[test]
+    fn surplus_is_a_warning_not_an_error() {
+        assert_eq!(
+            classify_reuse_precondition(Some(400), Some(401), "redis-x"),
+            ReusePrecondition::Surplus {
+                actual: 401,
+                expected: 400
+            }
+        );
+    }
+
+    // Nothing to compare against must never be silently reported as "Ok" — the
+    // runner has to say the reuse went unverified.
+    #[test]
+    fn unknown_expected_or_actual_is_unverifiable() {
+        assert!(matches!(
+            classify_reuse_precondition(None, Some(400), "redis-x"),
+            ReusePrecondition::Unverifiable(_)
+        ));
+        let why = match classify_reuse_precondition(Some(400), None, "chroma-y") {
+            ReusePrecondition::Unverifiable(w) => w,
+            other => panic!("expected Unverifiable, got {other:?}"),
+        };
+        assert!(
+            why.contains("chroma-y"),
+            "the note must name the engine that cannot count: {why}"
+        );
+    }
+
+    // Zero expected rows cannot make a zero-row server look short.
+    #[test]
+    fn zero_expected_never_fires() {
+        assert_eq!(
+            classify_reuse_precondition(Some(0), Some(0), "redis-x"),
+            ReusePrecondition::Ok {
+                actual: 0,
+                expected: 0
+            }
+        );
     }
 }

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -15,7 +15,7 @@ use crate::config::{
     self, matches_pattern, project_root, read_dataset_configs, InnerSearchParams, SearchParams,
 };
 use crate::dataset::Dataset;
-use crate::engine::{create_engine, Engine, UpdateSearchRatio};
+use crate::engine::{create_engine, CorpusCount, Engine, UpdateSearchRatio};
 use crate::summary::{self, SearchEntry};
 
 /// Results directory
@@ -414,79 +414,165 @@ fn parse_update_search_ratio(s: &str) -> Result<UpdateSearchRatio, String> {
 /// be unit-tested without a server (issue #238).
 #[derive(Debug, PartialEq, Eq)]
 pub enum ReusePrecondition {
-    /// Server-side count matches (or exceeds, see `Surplus`) what the dataset declares.
-    Ok { actual: u64, expected: u64 },
-    /// Nothing to check against: the dataset has no measurable corpus size, or
-    /// the engine cannot report a server-side count. Proceed with a note.
+    /// Server-side count matches what the dataset declares.
+    Ok {
+        actual: u64,
+        expected: u64,
+        approximate: bool,
+    },
+    /// Nothing to check against: the dataset's corpus size cannot be determined,
+    /// or no server-side count is implemented for this engine. Proceed with a note.
     Unverifiable(String),
     /// The server holds MORE rows than the dataset declares. Warn and continue:
     /// leftovers from a bigger corpus change the reported recall, but so does
     /// refusing to run, and unlike a short corpus this is often deliberate
     /// (a shared prefix, a superset upload).
-    Surplus { actual: u64, expected: u64 },
+    Surplus {
+        actual: u64,
+        expected: u64,
+        approximate: bool,
+    },
     /// The server holds FEWER rows than the dataset declares — including zero,
-    /// i.e. a missing index/collection. Fatal: every reported recall/precision
-    /// figure is computed against ground truth for the FULL corpus, so a short
-    /// corpus silently publishes the wrong number.
-    Short { actual: u64, expected: u64 },
+    /// i.e. a missing index/collection. Fatal when the count is exact: every
+    /// reported recall/precision figure is computed against ground truth for the
+    /// FULL corpus, so a short corpus silently publishes the wrong number.
+    /// `approximate` counts only ever warn — aborting on a number that is allowed
+    /// to be wrong trades one silent failure for a noisy one.
+    Short {
+        actual: u64,
+        expected: u64,
+        approximate: bool,
+    },
+}
+
+impl ReusePrecondition {
+    /// Short machine-readable tag for the results JSON.
+    fn status(&self) -> &'static str {
+        match self {
+            ReusePrecondition::Ok { .. } => "verified",
+            ReusePrecondition::Unverifiable(_) => "unverified",
+            ReusePrecondition::Surplus { .. } => "surplus",
+            ReusePrecondition::Short { .. } => "short",
+        }
+    }
 }
 
 /// Classify a server-side corpus count against what the dataset declares.
 pub fn classify_reuse_precondition(
     expected: Option<u64>,
-    actual: Option<u64>,
+    actual: Option<CorpusCount>,
     engine_name: &str,
 ) -> ReusePrecondition {
-    match (expected, actual) {
-        (None, _) => ReusePrecondition::Unverifiable(
-            "dataset does not declare (and cannot measure) a corpus size".to_string(),
-        ),
-        (Some(_), None) => ReusePrecondition::Unverifiable(format!(
-            "engine '{}' cannot report a server-side row count",
-            engine_name
-        )),
-        (Some(e), Some(a)) if a < e => ReusePrecondition::Short {
+    let Some(expected) = expected else {
+        return ReusePrecondition::Unverifiable(
+            "the dataset's corpus size could not be determined".to_string(),
+        );
+    };
+    let Some(actual) = actual else {
+        // Deliberately phrased as a gap in this tool, not a limitation of the
+        // database: Chroma, Milvus and Weaviate all expose a count, we simply
+        // have not wired one up yet.
+        return ReusePrecondition::Unverifiable(format!(
+            "no server-side row count is implemented here for the engine behind config \
+             '{engine_name}' yet"
+        ));
+    };
+    let (a, e, approximate) = (actual.rows, expected, actual.approximate);
+    if a < e {
+        ReusePrecondition::Short {
             actual: a,
             expected: e,
-        },
-        (Some(e), Some(a)) if a > e => ReusePrecondition::Surplus {
+            approximate,
+        }
+    } else if a > e {
+        ReusePrecondition::Surplus {
             actual: a,
             expected: e,
-        },
-        (Some(e), Some(a)) => ReusePrecondition::Ok {
+            approximate,
+        }
+    } else {
+        ReusePrecondition::Ok {
             actual: a,
             expected: e,
-        },
+            approximate,
+        }
     }
+}
+
+/// How many rows the reused corpus should hold, for the `--skip-upload` check.
+///
+/// Cost: this runs once per experiment and only on the `--skip-upload` path. For
+/// npy/hdf5 corpora it is a header read. For the two `jsonl` datasets in
+/// `datasets.json` it is a full-file line count that the search path did not
+/// previously perform — cheap at their size, but not free, and worth knowing
+/// before pointing `jsonl` at a very large corpus.
+///
+/// MEASURES the corpus on disk in preference to trusting `vector_count` in
+/// `datasets.json`. `corpus_completeness_target()` is deliberately not used here:
+/// it turns a declared-vs-measured DISAGREEMENT into an `Err`, and on this path an
+/// `Err` degrades to "cannot verify" — so an under-declared `vector_count`
+/// switched the guard off entirely, waving through exactly the half-empty corpus
+/// it exists to catch (a `Recall: 0.0000` run, exit 0). The measurement is the
+/// fact; a conflicting declaration is a `datasets.json` bug worth warning about,
+/// not a reason to stop checking.
+fn reuse_expected_rows(dataset: &Dataset) -> Result<Option<u64>, String> {
+    if let Some(measured) = dataset.measured_vector_count()? {
+        if let Some(declared) = dataset
+            .config
+            .vector_count
+            .filter(|&n| n > 0)
+            .map(|n| n as u64)
+        {
+            if declared != measured {
+                eprintln!(
+                    "WARNING: dataset '{}' declares vector_count {} but its corpus on disk holds \
+                     {}. The --skip-upload reuse check uses the MEASURED {}; fix vector_count in \
+                     datasets/datasets.json.",
+                    dataset.config.name, declared, measured, measured
+                );
+            }
+        }
+        return Ok(Some(measured));
+    }
+    // Layouts with no cheap row count (sparse CSR, h5-multi) fall back to the
+    // declared count, but only when their files are actually present.
+    dataset.corpus_completeness_target()
 }
 
 /// Verify the promise `--skip-upload` makes: that the corpus it is told to reuse
 /// is actually there, and whole (issue #238).
 ///
-/// The check reads state back off the live server (`FT.INFO`/`SCAN`,
-/// `GET /collections/<n>`, `_count`, `countDocuments`, `SELECT count(*)`, ...) —
-/// "search returned no error" is not evidence, and neither is recall: a run
-/// against a half-deleted Qdrant collection reports `mean_recall: 1.0`.
+/// The check reads state back off the live server (`FT.INFO`, `GET
+/// /collections/<n>`, `_count`, `countDocuments`, `reltuples`, `VCARD`) — "search
+/// returned no error" is not evidence. Neither, in general, is recall: whether a
+/// truncated corpus shows up in recall depends entirely on which rows went. On
+/// `random-100` (9 queries, one ground-truth neighbour each, ids 0-8) deleting
+/// the UPPER half of the collection leaves `mean_recall: 1.0` and deleting the
+/// LOWER half gives `mean_recall: 0.0`. A metric that is a coin flip on the
+/// deletion pattern cannot be the guard.
 ///
 /// Repo policy on what is fatal: a short corpus changes the reported number, so
-/// it is a hard error; everything softer is a warning.
+/// an exact count that comes up short is a hard error; everything softer warns.
+///
+/// Returns the verdict so it can be stamped into every result file this
+/// experiment writes.
 fn check_corpus_reuse_precondition(
     engine: &mut dyn Engine,
     dataset: &Dataset,
     args: &Args,
-) -> Result<(), String> {
+) -> Result<Option<serde_json::Value>, String> {
     // Nothing is measured, so nothing can be misreported.
     if args.skip_search {
-        return Ok(());
+        return Ok(None);
     }
 
-    // The expected count MEASURES the corpus on disk where it can, rather than
-    // trusting a declared `vector_count` that may be smaller than the real
-    // corpus (#224).
-    let expected = match dataset.corpus_completeness_target() {
+    let expected = match reuse_expected_rows(dataset) {
         Ok(v) => v,
         Err(e) => {
-            eprintln!("\tNote: could not determine the dataset's corpus size ({e}); --skip-upload reuse left unverified");
+            eprintln!(
+                "\tNote: could not determine the dataset's corpus size ({e}); \
+                 --skip-upload reuse left unverified"
+            );
             None
         }
     };
@@ -495,70 +581,130 @@ fn check_corpus_reuse_precondition(
         Ok(v) => v,
         Err(e) => {
             let msg = format!(
-                "--skip-upload: could not read the server-side corpus size for engine '{}' ({}). \
-                 The flag promises to reuse an already-loaded corpus, and that promise is now \
-                 unverified — a missing or partial index would be measured and reported as if it \
-                 were complete. Fix the connection, or pass --allow-partial-corpus to run anyway.",
+                "--skip-upload: could not read the server-side corpus size for config '{}' ({}). \
+                 This is a PROBE failure, not a verdict on the corpus — the data may well be \
+                 intact. The flag promises to reuse an already-loaded corpus and that promise is \
+                 now unverified. Fix the connection or the privilege, or pass \
+                 --allow-partial-corpus to run anyway.",
                 engine.name(),
                 e
             );
             if args.allow_partial_corpus {
                 eprintln!("WARNING: {msg}");
-                return Ok(());
+                return Ok(Some(json!({
+                    "status": "probe_failed",
+                    "detail": e,
+                    "waived_by_allow_partial_corpus": true,
+                })));
             }
             return Err(msg);
         }
     };
 
-    match classify_reuse_precondition(expected, actual, engine.name()) {
-        ReusePrecondition::Ok { actual, expected } => {
+    let verdict = classify_reuse_precondition(expected, actual, engine.name());
+    let approx_note = |approximate: bool| if approximate { "≈" } else { "" };
+    let record = |waived: bool| {
+        json!({
+            "status": verdict.status(),
+            "expected_rows": expected,
+            "actual_rows": actual.map(|c| c.rows),
+            "actual_is_estimate": actual.map(|c| c.approximate).unwrap_or(false),
+            "waived_by_allow_partial_corpus": waived,
+        })
+    };
+
+    match &verdict {
+        ReusePrecondition::Ok {
+            actual,
+            expected,
+            approximate,
+        } => {
             println!(
-                "Experiment stage: Reuse check — server holds {actual} of {expected} expected rows"
+                "Experiment stage: Reuse check — server holds {}{} of {} expected rows",
+                approx_note(*approximate),
+                actual,
+                expected
             );
-            Ok(())
+            Ok(Some(record(false)))
         }
         ReusePrecondition::Unverifiable(why) => {
             println!(
                 "Experiment stage: Reuse check — SKIPPED ({why}); \
                  --skip-upload is running against an unverified corpus"
             );
-            Ok(())
+            Ok(Some(record(false)))
         }
-        ReusePrecondition::Surplus { actual, expected } => {
+        ReusePrecondition::Surplus {
+            actual,
+            expected,
+            approximate,
+        } => {
             eprintln!(
-                "WARNING: --skip-upload: engine '{}' holds {} rows but dataset '{}' declares {} — \
-                 the extra rows are searchable and can displace true neighbours, so recall may be \
-                 understated.",
+                "WARNING: --skip-upload: config '{}' holds {}{} rows but dataset '{}' declares {} \
+                 — the extra rows are searchable and can displace true neighbours, so recall may \
+                 be understated.",
                 engine.name(),
+                approx_note(*approximate),
                 actual,
                 dataset.config.name,
                 expected
             );
-            Ok(())
+            Ok(Some(record(false)))
         }
-        ReusePrecondition::Short { actual, expected } => {
-            let what = if actual == 0 {
+        ReusePrecondition::Short {
+            actual,
+            expected,
+            approximate,
+        } => {
+            let what = if *actual == 0 {
                 "is empty or missing"
             } else {
                 "is incomplete"
             };
             let msg = format!(
-                "--skip-upload: the corpus you asked to reuse {what} — engine '{}' holds {} of the \
-                 {} rows dataset '{}' declares. Recall/precision are scored against ground truth \
-                 for the FULL corpus, so continuing would publish a wrong number under a config \
-                 name that claims otherwise. Re-upload (drop --skip-upload, add --keep-data), or \
-                 pass --allow-partial-corpus to measure the partial corpus deliberately.",
+                "--skip-upload: the corpus you asked to reuse {what} — config '{}' holds {}{} of \
+                 the {} rows dataset '{}' declares. Recall/precision are scored against ground \
+                 truth for the FULL corpus, so continuing would publish a wrong number under a \
+                 config name that claims otherwise. Re-upload this config (drop --skip-upload, \
+                 add --keep-data). On a sweep, add --exit-on-error false so the configs whose \
+                 corpus IS intact still publish their (correct) numbers while this one is \
+                 skipped. --allow-partial-corpus measures the partial corpus deliberately — it \
+                 publishes exactly the number this check exists to suppress, so reach for it \
+                 last.",
                 engine.name(),
+                approx_note(*approximate),
                 actual,
                 expected,
                 dataset.config.name
             );
+            // An ESTIMATE may not abort a run: pgvector's count is a planner
+            // figure, and a false hard error would be its own silent-wrong-result.
+            if *approximate {
+                eprintln!(
+                    "WARNING: {msg}\n\t(the count above is an ESTIMATE, so this is a warning, \
+                     not a rejection — verify it before quoting the run)"
+                );
+                return Ok(Some(record(false)));
+            }
             if args.allow_partial_corpus {
                 eprintln!("WARNING: {msg}");
-                return Ok(());
+                return Ok(Some(record(true)));
             }
+            crate::summary::record_rejected_experiment(engine.name(), &dataset.config.name, &msg);
             Err(msg)
         }
+    }
+}
+
+/// Why a run is not tearing its corpus down, for the "Keep data" line.
+///
+/// `--skip-upload` gets its own wording because it is not a user preference but
+/// an invariant (#238): a run that did not upload the corpus never deletes it.
+fn keep_data_reason(args: &Args) -> &'static str {
+    if args.skip_upload {
+        "--skip-upload did not create this corpus, so it does not delete it"
+    } else {
+        "cleanup skipped"
     }
 }
 
@@ -575,7 +721,16 @@ fn run_single_experiment(
     // copy doesn't accumulate and OOM the server (#184). Without the flag,
     // `--keep-data` keeps every config's data (the default coexistence behaviour,
     // needed for --skip-upload reuse). A single-config run is always the last.
-    let keep_data = args.keep_data && (is_last_config || !args.reset_between_configs);
+    //
+    // `--skip-upload` overrides all of that (#238). `configure()` is not the only
+    // destructive call in an experiment: cleanup runs `engine.delete()`, and
+    // `--keep-data` defaults to FALSE — so the plainest form of the flag
+    // (`--skip-upload` alone) used to reuse a corpus, benchmark it, and then
+    // delete it. Measured: qdrant 400 points -> collection MISSING, vectorsets
+    // `VCARD idx` 400 -> 0, redis `DBSIZE` 400 -> 0, all exit 0. A run that did
+    // not create the corpus must not tear it down, whatever `--keep-data` says.
+    let keep_data =
+        args.skip_upload || (args.keep_data && (is_last_config || !args.reset_between_configs));
 
     // Skip an incompatible (engine, dataset) pair BEFORE `get_path()`, which would
     // otherwise download the archive — hundreds of MB for the msmarco-sparse sets
@@ -611,6 +766,7 @@ fn run_single_experiment(
     let server_metadata_before = engine.server_metadata();
 
     // Configure phase
+    let mut corpus_reuse: Option<serde_json::Value> = None;
     if !args.skip_upload {
         println!("Experiment stage: Configure");
         engine.configure(dataset)?;
@@ -632,9 +788,10 @@ fn run_single_experiment(
     } else {
         // `--skip-upload` means: the server already holds the corpus I want —
         // do not create, drop, recreate or otherwise modify it. `configure()` is
-        // destructive on 13 of the 15 engines (FT.DROPINDEX ... DD, SCAN+UNLINK,
-        // collection.drop(), DROP TABLE, DELETE /collections/<n>, ...), so it must
-        // NOT run here under any flag combination.
+        // destructive on 14 of the 15 engines (FT.DROPINDEX ... DD, SCAN+UNLINK,
+        // collection.drop(), DROP TABLE, DELETE /collections/<n>, indices.delete,
+        // DEL idx — only Vertex is not), so it must NOT run here under any flag
+        // combination.
         //
         // This used to have an `else if args.skip_vector_index` arm that called
         // `configure()` "to create a schema-only index". It destroyed the corpus
@@ -645,7 +802,12 @@ fn run_single_experiment(
         // `--skip-vector-index --keep-data` upload runs under the SAME rewritten
         // config name (`<engine>-no-vector`), so it left exactly the schema-only
         // index this run needs.
-        check_corpus_reuse_precondition(engine, dataset, args)?;
+        //
+        // A related shape survives the fix and the guard below is what catches
+        // it: if phase 1 was a NORMAL upload, phase 2 does not destroy anything —
+        // it publishes a QPS number from an empty `<engine>-no-vector` index while
+        // the real corpus sits untouched under the original config name.
+        corpus_reuse = check_corpus_reuse_precondition(engine, dataset, args)?;
     }
 
     // Build ordered search phases: pure search first, then mixed ratios ascending
@@ -740,7 +902,7 @@ fn run_single_experiment(
                     dataset.config.name
                 );
                 if keep_data {
-                    println!("Experiment stage: Keep data (cleanup skipped)");
+                    println!("Experiment stage: Keep data ({})", keep_data_reason(args));
                 } else {
                     if args.keep_data {
                         println!(
@@ -1173,6 +1335,7 @@ fn run_single_experiment(
             number_of_shards,
             ground_truth.as_ref(),
             calibration.as_ref(),
+            corpus_reuse.as_ref(),
         )?;
     }
 
@@ -1249,7 +1412,7 @@ fn run_single_experiment(
     // multi-config sweep `--keep-data` keeps only the LAST config's data; earlier
     // configs tear down here so their corpus copy doesn't accumulate (#184).
     if keep_data {
-        println!("Experiment stage: Keep data (cleanup skipped)");
+        println!("Experiment stage: Keep data ({})", keep_data_reason(args));
     } else {
         if args.keep_data {
             println!(
@@ -1552,6 +1715,7 @@ fn save_search_results(
     number_of_shards: Option<&serde_json::Value>,
     ground_truth: Option<&crate::ground_truth::GroundTruthProfile>,
     calibration: Option<&serde_json::Value>,
+    corpus_reuse: Option<&serde_json::Value>,
 ) -> Result<(), String> {
     let timestamp = Local::now().format("%Y-%m-%d-%H-%M-%S");
     let pid = std::process::id();
@@ -1576,6 +1740,7 @@ fn save_search_results(
         number_of_shards,
         ground_truth,
         calibration,
+        corpus_reuse,
     );
 
     let path = results_dir().join(&filename);
@@ -1603,6 +1768,7 @@ fn build_search_result_json(
     number_of_shards: Option<&serde_json::Value>,
     ground_truth: Option<&crate::ground_truth::GroundTruthProfile>,
     calibration: Option<&serde_json::Value>,
+    corpus_reuse: Option<&serde_json::Value>,
 ) -> serde_json::Value {
     let mut result = json!({
         "params": {
@@ -1689,6 +1855,14 @@ fn build_search_result_json(
     // without reaching its target is not a calibration.
     if let Some(cal) = calibration {
         result["params"]["calibration"] = cal.clone();
+    }
+
+    // Whether this run's corpus was the one it claims to have measured (#238).
+    // A verified run, an unverified-note run and an --allow-partial-corpus run
+    // over a half-deleted corpus used to produce structurally identical
+    // artifacts; the verdict travels with the numbers so it cannot be lost.
+    if let Some(reuse) = corpus_reuse {
+        result["params"]["corpus_reuse"] = reuse.clone();
     }
 
     // Shard count the index was built with. Recall and QPS both move with it, so
@@ -2028,6 +2202,7 @@ mod tests {
                 None,
                 Some(&gt),
                 None,
+                None,
             );
 
             let res = doc["results"].as_object().unwrap();
@@ -2082,6 +2257,7 @@ mod tests {
                 None,
                 None,
                 Some(&outcome.to_json()),
+                None,
             );
             let cal = &doc["params"]["calibration"];
             assert_eq!(cal["reached_target"], false);
@@ -2109,16 +2285,18 @@ mod tests {
 #[cfg(test)]
 mod reuse_precondition_tests {
     use super::{classify_reuse_precondition, ReusePrecondition};
+    use crate::engine::CorpusCount;
 
     // A corpus shorter than the dataset declares is the case that publishes a
     // wrong recall under a config name claiming otherwise (issue #238).
     #[test]
     fn short_corpus_is_short() {
         assert_eq!(
-            classify_reuse_precondition(Some(400), Some(200), "redis-x"),
+            classify_reuse_precondition(Some(400), Some(CorpusCount::exact(200)), "redis-x"),
             ReusePrecondition::Short {
                 actual: 200,
-                expected: 400
+                expected: 400,
+                approximate: false
             }
         );
     }
@@ -2128,10 +2306,11 @@ mod reuse_precondition_tests {
     #[test]
     fn missing_corpus_is_short_not_ok() {
         assert_eq!(
-            classify_reuse_precondition(Some(400), Some(0), "redis-x"),
+            classify_reuse_precondition(Some(400), Some(CorpusCount::exact(0)), "redis-x"),
             ReusePrecondition::Short {
                 actual: 0,
-                expected: 400
+                expected: 400,
+                approximate: false
             }
         );
     }
@@ -2139,10 +2318,11 @@ mod reuse_precondition_tests {
     #[test]
     fn exact_match_is_ok() {
         assert_eq!(
-            classify_reuse_precondition(Some(400), Some(400), "redis-x"),
+            classify_reuse_precondition(Some(400), Some(CorpusCount::exact(400)), "redis-x"),
             ReusePrecondition::Ok {
                 actual: 400,
-                expected: 400
+                expected: 400,
+                approximate: false
             }
         );
     }
@@ -2150,12 +2330,36 @@ mod reuse_precondition_tests {
     // Extra rows affect the number too, but unlike a shortfall they are often
     // deliberate (a shared prefix, a superset upload) — warn, do not abort.
     #[test]
-    fn surplus_is_a_warning_not_an_error() {
+    fn surplus_is_classified_as_surplus() {
         assert_eq!(
-            classify_reuse_precondition(Some(400), Some(401), "redis-x"),
+            classify_reuse_precondition(Some(400), Some(CorpusCount::exact(401)), "redis-x"),
             ReusePrecondition::Surplus {
                 actual: 401,
-                expected: 400
+                expected: 400,
+                approximate: false
+            }
+        );
+    }
+
+    // An ESTIMATE carries through to the verdict, which is what lets the handler
+    // downgrade a short estimate to a warning instead of aborting on a number
+    // that is allowed to be wrong.
+    #[test]
+    fn approximate_flag_survives_classification() {
+        assert_eq!(
+            classify_reuse_precondition(Some(400), Some(CorpusCount::estimated(200)), "pg-x"),
+            ReusePrecondition::Short {
+                actual: 200,
+                expected: 400,
+                approximate: true
+            }
+        );
+        assert_eq!(
+            classify_reuse_precondition(Some(400), Some(CorpusCount::estimated(400)), "pg-x"),
+            ReusePrecondition::Ok {
+                actual: 400,
+                expected: 400,
+                approximate: true
             }
         );
     }
@@ -2165,7 +2369,7 @@ mod reuse_precondition_tests {
     #[test]
     fn unknown_expected_or_actual_is_unverifiable() {
         assert!(matches!(
-            classify_reuse_precondition(None, Some(400), "redis-x"),
+            classify_reuse_precondition(None, Some(CorpusCount::exact(400)), "redis-x"),
             ReusePrecondition::Unverifiable(_)
         ));
         let why = match classify_reuse_precondition(Some(400), None, "chroma-y") {
@@ -2174,7 +2378,13 @@ mod reuse_precondition_tests {
         };
         assert!(
             why.contains("chroma-y"),
-            "the note must name the engine that cannot count: {why}"
+            "the note must name the config it could not count: {why}"
+        );
+        // The wording must blame this tool, not the database: Chroma, Milvus and
+        // Weaviate all expose a count, we simply have not wired one up.
+        assert!(
+            why.contains("implemented"),
+            "the note must read as a gap in this tool, not a database limitation: {why}"
         );
     }
 
@@ -2182,10 +2392,11 @@ mod reuse_precondition_tests {
     #[test]
     fn zero_expected_never_fires() {
         assert_eq!(
-            classify_reuse_precondition(Some(0), Some(0), "redis-x"),
+            classify_reuse_precondition(Some(0), Some(CorpusCount::exact(0)), "redis-x"),
             ReusePrecondition::Ok {
                 actual: 0,
-                expected: 0
+                expected: 0,
+                approximate: false
             }
         );
     }

--- a/src/bin/vector_db_benchmark/summary.rs
+++ b/src/bin/vector_db_benchmark/summary.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
+use std::sync::Mutex;
 
 use serde_json::json;
 
@@ -466,6 +467,32 @@ fn ratio_sort_key(key: &str) -> f64 {
     0.0
 }
 
+/// Experiments this run REFUSED to measure, and why (issue #238).
+///
+/// A `--skip-upload` run that finds a short corpus aborts that experiment. With
+/// `--exit-on-error false` a five-config sweep can lose four of them, exit 0, and
+/// write one summary — which then charts as a clean sweep with nothing saying the
+/// other four never ran. Same reasoning as `skipped_config_files` (#239): the
+/// stderr message has scrolled away by the time anyone reads the artifact, so the
+/// artifact has to say it itself.
+static REJECTED_EXPERIMENTS: Mutex<Vec<serde_json::Value>> = Mutex::new(Vec::new());
+
+/// Record an experiment that was refused before it could be measured.
+pub fn record_rejected_experiment(engine: &str, dataset: &str, reason: &str) {
+    REJECTED_EXPERIMENTS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .push(json!({ "engine": engine, "dataset": dataset, "reason": reason }));
+}
+
+/// Every experiment this run refused, for stamping into the summary artifact.
+pub fn rejected_experiments() -> Vec<serde_json::Value> {
+    REJECTED_EXPERIMENTS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
+
 /// Save summary JSON matching Python v0 format.
 pub fn save_summary(
     engine_name: &str,
@@ -599,6 +626,11 @@ pub fn save_summary(
         // above: the stderr warning has long scrolled away by the time anyone
         // reads the artifact, so a truncated sweep has to say so itself (#239).
         "skipped_config_files": crate::config::skipped_config_files(),
+        // Experiments this run REFUSED to measure — currently the --skip-upload
+        // reuse precondition (#238). Without it a sweep that lost most of its
+        // configs to a missing corpus produces a summary and a chart that look
+        // exactly like a complete one.
+        "rejected_experiments": rejected_experiments(),
     });
 
     if let Some(upload) = upload_json {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1460,6 +1460,32 @@ pub fn run_binary_extra(
 /// update_* metrics, the mean_precision_at_returned sentinel, …). `engine` is the result
 /// filename prefix — note `--skip-vector-index` renames the engine to
 /// `<engine_type>-no-vector`, so pass that prefix for filter-only runs.
+/// Read the `params` block from the engine's search result JSON.
+///
+/// Used to assert on `params.corpus_reuse` — the recorded `--skip-upload`
+/// verdict (#238), which is the only thing distinguishing a verified run from a
+/// waived one in the artifact.
+pub fn read_params_obj(root: &Path, engine: &str) -> serde_json::Value {
+    read_result_doc(root, engine)["params"].clone()
+}
+
+/// The whole search-result document for `engine`.
+pub fn read_result_doc(root: &Path, engine: &str) -> serde_json::Value {
+    let pattern = format!("{}-*-search-*.json", engine);
+    let dir = root.join("results");
+    let path = fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            glob::Pattern::new(&pattern)
+                .unwrap()
+                .matches(&p.file_name().unwrap().to_string_lossy())
+        })
+        .unwrap_or_else(|| panic!("no search result for {}", engine));
+    serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+}
+
 pub fn read_results_obj(root: &Path, engine: &str) -> serde_json::Value {
     let pattern = format!("{}-*-search-*.json", engine);
     let dir = root.join("results");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -57,7 +57,7 @@ fn matches_labels_filter(id: usize) -> bool {
     MATCH_ANY_LABELS.iter().any(|q| l.contains(q))
 }
 
-const N_DOCS: usize = 400;
+pub const N_DOCS: usize = 400;
 const N_QUERIES: usize = 10;
 const TOP: usize = 10;
 

--- a/tests/integration_kividb.rs
+++ b/tests/integration_kividb.rs
@@ -1143,3 +1143,187 @@ fn test_kividb_skip_upload_without_prior_upload_errors() {
 
     fs::remove_dir_all(&root).ok();
 }
+
+// ---------------------------------------------------------------------------
+// Issue #238 — KiviDB's server-side corpus count
+// ---------------------------------------------------------------------------
+
+/// KiviDB's `FT.INFO` has NO `num_docs` field — it reports `hnsw_live_count`.
+/// Reading only `num_docs` made `corpus_row_count()` answer `Ok(None)`, silently
+/// downgrading the `--skip-upload` guard to "this engine cannot count" while the
+/// docs claimed KiviDB was covered. This asserts the field is actually there, so
+/// a future image that renames it fails loudly instead of degrading.
+#[test]
+fn test_kividb_ft_info_exposes_a_live_count_field() {
+    wait_for_kividb();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let _: () = redis::cmd("FT.CREATE")
+        .arg("idx:cfg238kvprobe")
+        .arg("ON")
+        .arg("HASH")
+        .arg("PREFIX")
+        .arg(1)
+        .arg("cfg238kvprobe:")
+        .arg("SCHEMA")
+        .arg("vector")
+        .arg("VECTOR")
+        .arg("HNSW")
+        .arg(6)
+        .arg("TYPE")
+        .arg("FLOAT32")
+        .arg("DIM")
+        .arg(4)
+        .arg("DISTANCE_METRIC")
+        .arg("COSINE")
+        .query(&mut conn)
+        .expect("FT.CREATE");
+
+    let info: redis::Value = redis::cmd("FT.INFO")
+        .arg("idx:cfg238kvprobe")
+        .query(&mut conn)
+        .expect("FT.INFO");
+    let keys = ft_info_field_names(&info);
+    assert!(
+        keys.iter().any(|k| k == "hnsw_live_count") || keys.iter().any(|k| k == "num_docs"),
+        "FT.INFO exposes no count field this tool can read — the #238 reuse guard \
+         would silently degrade to 'cannot count'. Fields seen: {keys:?}"
+    );
+
+    flush_db(&mut conn);
+}
+
+/// Field names of an `FT.INFO` reply (RESP2 array or RESP3 map).
+fn ft_info_field_names(v: &redis::Value) -> Vec<String> {
+    fn as_str(v: &redis::Value) -> String {
+        match v {
+            redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+            redis::Value::SimpleString(s) => s.clone(),
+            other => format!("{other:?}"),
+        }
+    }
+    match v {
+        redis::Value::Map(m) => m.iter().map(|(k, _)| as_str(k)).collect(),
+        redis::Value::Array(items) => items.chunks_exact(2).map(|c| as_str(&c[0])).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// End-to-end: KiviDB reports a real server-side count, and a corpus that is
+/// gone is fatal rather than waved through (#238 item B).
+///
+/// RED before the `hnsw_live_count` fix: `ft_info_num_docs` looked only for
+/// `num_docs`, which KiviDB's `FT.INFO` does not have, so `corpus_row_count()`
+/// returned `Ok(None)`, the run printed
+/// "Reuse check — SKIPPED (... cannot report a server-side row count)",
+/// benchmarked whatever was there and exited 0.
+///
+/// The amputation here is `FT.DROPINDEX`, not a key deletion. KiviDB's HNSW
+/// graph is independent of the hashes: UNLINKing 45 of 100 documents leaves
+/// `hnsw_live_count` at 100 AND leaves recall at 1.0000 (measured), because the
+/// vectors are still in the graph. So the count is right and there is nothing to
+/// catch — dropping the index is what actually removes the searchable corpus.
+#[test]
+fn test_binary_kividb_skip_upload_missing_corpus_is_fatal() {
+    wait_for_kividb();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "cfg238kv", "engine": "kividb",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_cosine_project(
+        "cfg238kv-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let port = test_port().to_string();
+
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg238kv",
+            "cfg238kv-test",
+            "localhost",
+            &[("KIVIDB_PORT", port.as_str())],
+            &["--keep-data", "--skip-search"],
+        ),
+        "phase 1 (upload) failed"
+    );
+
+    // The count must be a real read of the populated index, not a note.
+    let out_ok = std::process::Command::new(common::binary_path())
+        .args([
+            "--engines",
+            "cfg238kv",
+            "--datasets",
+            "cfg238kv-test",
+            "--host",
+            "localhost",
+            "--skip-if-exists",
+            "false",
+            "--skip-upload",
+            "--keep-data",
+        ])
+        .env("KIVIDB_PORT", &port)
+        .current_dir(&proj.root)
+        .output()
+        .expect("run vector-db-benchmark");
+    let ok_combined = String::from_utf8_lossy(&out_ok.stdout).to_string();
+    assert!(
+        !ok_combined.contains("cannot report a server-side row count"),
+        "KiviDB must report a count (hnsw_live_count), not degrade to a note.\n{ok_combined}"
+    );
+    assert!(
+        ok_combined.contains(&format!(
+            "server holds {} of {} expected rows",
+            common::N_DOCS,
+            common::N_DOCS
+        )),
+        "the reuse check must report the real corpus size.\n{ok_combined}"
+    );
+
+    // Now remove the searchable corpus behind the tool's back.
+    let _: () = redis::cmd("FT.DROPINDEX")
+        .arg("idx:cfg238kv")
+        .query(&mut conn)
+        .expect("FT.DROPINDEX");
+
+    let out = std::process::Command::new(common::binary_path())
+        .args([
+            "--engines",
+            "cfg238kv",
+            "--datasets",
+            "cfg238kv-test",
+            "--host",
+            "localhost",
+            "--skip-if-exists",
+            "false",
+            "--skip-upload",
+            "--keep-data",
+        ])
+        .env("KIVIDB_PORT", &port)
+        .current_dir(&proj.root)
+        .output()
+        .expect("run vector-db-benchmark");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "--skip-upload against a dropped KiviDB index must be a hard error.\n{combined}"
+    );
+    assert!(
+        combined.contains(&format!("holds 0 of the {} rows", common::N_DOCS)),
+        "the count must track the drop, proving it is a live read.\n{combined}"
+    );
+
+    flush_db(&mut conn);
+    fs::remove_dir_all(&proj.root).ok();
+}

--- a/tests/integration_mongodb.rs
+++ b/tests/integration_mongodb.rs
@@ -1750,3 +1750,184 @@ fn test_binary_mongodb_out_of_range_hnsw_config_fails_loudly() {
     drop_test_collection();
     let _ = fs::remove_dir_all(&project);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #238 — `--skip-upload` must reuse the corpus, not destroy it
+// ---------------------------------------------------------------------------
+
+/// Count documents in the benchmark collection, server-side.
+fn count_test_docs() -> u64 {
+    mongodb_client()
+        .database(TEST_DB)
+        .collection::<Document>(TEST_COLLECTION)
+        .count_documents(doc! {})
+        .run()
+        .expect("countDocuments")
+}
+
+/// MongoDB's destruction path is a third shape: `collection.drop()`, which is
+/// unbounded — unlike Redis/Valkey, whose `DD`/UNLINK are scoped to this config's
+/// namespace, it removes the entire benchmark collection.
+///
+/// RED on the pre-fix branch: `countDocuments` 400 -> 0 while the run printed
+/// QPS lines and exited 0.
+#[test]
+fn test_binary_mongodb_skip_upload_skip_vector_index_preserves_corpus() {
+    wait_for_mongodb();
+    drop_test_collection();
+
+    let port: u16 = std::env::var("MONGODB_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(MONGODB_PORT);
+    let port_s = port.to_string();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "cfg238mg", "engine": "mongodb",
+        "search_params": [{"parallel": 1, "num_candidates": 20}],
+        "upload_params": {"parallel": 1}
+    }]);
+    let proj = common::write_match_any_project(
+        "cfg238mg-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let envs: [(&str, &str); 4] = [
+        ("MONGODB_PORT", port_s.as_str()),
+        ("MONGODB_DB", TEST_DB),
+        ("MONGODB_COLLECTION", TEST_COLLECTION),
+        ("MONGODB_INDEX_NAME", TEST_INDEX),
+    ];
+
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg238mg",
+            "cfg238mg-test",
+            MONGODB_HOST,
+            &envs,
+            &["--skip-vector-index", "--keep-data", "--skip-search"],
+        ),
+        "phase 1 (upload with --skip-vector-index) failed"
+    );
+    let before = count_test_docs();
+    assert_eq!(before, common::N_DOCS as u64, "phase 1 corpus");
+
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg238mg",
+            "cfg238mg-test",
+            MONGODB_HOST,
+            &envs,
+            &["--skip-upload", "--skip-vector-index", "--keep-data"],
+        ),
+        "phase 2 (--skip-upload --skip-vector-index) failed"
+    );
+
+    let after = count_test_docs();
+    assert_eq!(
+        after, before,
+        "--skip-upload --skip-vector-index dropped the collection it was told to \
+         reuse ({before} -> {after} docs) — issue #238"
+    );
+
+    drop_test_collection();
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+/// MongoDB's `corpus_row_count()` must be a live `countDocuments`, proven by
+/// deleting documents behind the tool's back and watching the number follow.
+#[test]
+fn test_binary_mongodb_skip_upload_short_corpus_is_fatal() {
+    wait_for_mongodb();
+    drop_test_collection();
+
+    let port: u16 = std::env::var("MONGODB_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(MONGODB_PORT);
+    let port_s = port.to_string();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "cfg238mgshort", "engine": "mongodb",
+        "search_params": [{"parallel": 1, "num_candidates": 20}],
+        "upload_params": {"parallel": 1}
+    }]);
+    let proj = common::write_match_any_project(
+        "cfg238mgshort-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let envs: [(&str, &str); 4] = [
+        ("MONGODB_PORT", port_s.as_str()),
+        ("MONGODB_DB", TEST_DB),
+        ("MONGODB_COLLECTION", TEST_COLLECTION),
+        ("MONGODB_INDEX_NAME", TEST_INDEX),
+    ];
+
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg238mgshort",
+            "cfg238mgshort-test",
+            MONGODB_HOST,
+            &envs,
+            &["--keep-data", "--skip-search"],
+        ),
+        "phase 1 (upload) failed"
+    );
+    assert_eq!(count_test_docs(), common::N_DOCS as u64, "phase 1 corpus");
+
+    let half = (common::N_DOCS / 2) as i64;
+    mongodb_client()
+        .database(TEST_DB)
+        .collection::<Document>(TEST_COLLECTION)
+        .delete_many(doc! { "_id": { "$lt": half } })
+        .run()
+        .expect("delete_many");
+    assert_eq!(
+        count_test_docs(),
+        half as u64,
+        "half the corpus should remain"
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "--engines",
+            "cfg238mgshort",
+            "--datasets",
+            "cfg238mgshort-test",
+            "--host",
+            MONGODB_HOST,
+            "--skip-if-exists",
+            "false",
+            "--skip-upload",
+            "--keep-data",
+        ])
+        .env("MONGODB_PORT", &port_s)
+        .env("MONGODB_DB", TEST_DB)
+        .env("MONGODB_COLLECTION", TEST_COLLECTION)
+        .env("MONGODB_INDEX_NAME", TEST_INDEX)
+        .current_dir(&proj.root)
+        .output()
+        .expect("run vector-db-benchmark");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "--skip-upload against a half-deleted MongoDB collection must be a hard error.\n{combined}"
+    );
+    assert!(
+        combined.contains(&format!("holds {half} of the {} rows", common::N_DOCS)),
+        "the count must track the deletion, proving it is a live countDocuments.\n{combined}"
+    );
+
+    drop_test_collection();
+    fs::remove_dir_all(&proj.root).ok();
+}

--- a/tests/integration_qdrant.rs
+++ b/tests/integration_qdrant.rs
@@ -2,7 +2,7 @@
 //!
 //! Requires Qdrant running on gRPC port 6335 and REST port 6334.
 //! Start with: docker compose -f tests/docker-compose.test.yml up -d qdrant
-//! Run with:   QDRANT_GRPC_PORT=6335 cargo test --test integration_qdrant -- --test-threads=1
+//! Run with:   qdrant_grpc_port()=6335 cargo test --test integration_qdrant -- --test-threads=1
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -15,17 +15,30 @@ mod common;
 // Helpers
 // ---------------------------------------------------------------------------
 
-const QDRANT_REST_PORT: u16 = 6334;
-const QDRANT_GRPC_PORT: u16 = 6335;
+/// Qdrant ports under test. Overridable so a session can run against its OWN
+/// container instead of the shared one — these tests delete the collection.
+fn qdrant_rest_port() -> u16 {
+    std::env::var("QDRANT_TEST_REST_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6334)
+}
+
+fn qdrant_grpc_port() -> u16 {
+    std::env::var("QDRANT_TEST_GRPC_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6335)
+}
 const QDRANT_HOST: &str = "127.0.0.1";
 const COLLECTION: &str = "bench_test";
 
 fn rest_url() -> String {
-    format!("http://{}:{}", QDRANT_HOST, QDRANT_REST_PORT)
+    format!("http://{}:{}", QDRANT_HOST, qdrant_rest_port())
 }
 
 fn grpc_url() -> String {
-    format!("http://{}:{}", QDRANT_HOST, QDRANT_GRPC_PORT)
+    format!("http://{}:{}", QDRANT_HOST, qdrant_grpc_port())
 }
 
 fn rest_client() -> reqwest::blocking::Client {
@@ -48,7 +61,7 @@ fn wait_for_qdrant() {
         if Instant::now() > deadline {
             panic!(
                 "Qdrant not available on port {} after 60s",
-                QDRANT_REST_PORT
+                qdrant_rest_port()
             );
         }
         thread::sleep(Duration::from_millis(500));
@@ -106,8 +119,8 @@ fn run_binary_capture(root: &std::path::Path, engine: &str, dataset: &str) -> (b
         "false",
     ])
     .current_dir(root)
-    .env("QDRANT_GRPC_PORT", QDRANT_GRPC_PORT.to_string())
-    .env("QDRANT_REST_PORT", QDRANT_REST_PORT.to_string());
+    .env("QDRANT_GRPC_PORT", qdrant_grpc_port().to_string())
+    .env("QDRANT_REST_PORT", qdrant_rest_port().to_string());
     let out = cmd.output().expect("run vector-db-benchmark");
     let combined = format!(
         "stdout:\n{}\nstderr:\n{}",
@@ -500,8 +513,8 @@ fn run_qdrant_binary(root: &std::path::Path, engine: &str, dataset: &str) -> boo
             "--skip-if-exists",
             "false",
         ])
-        .env("QDRANT_GRPC_PORT", QDRANT_GRPC_PORT.to_string())
-        .env("QDRANT_REST_PORT", QDRANT_REST_PORT.to_string())
+        .env("QDRANT_GRPC_PORT", qdrant_grpc_port().to_string())
+        .env("QDRANT_REST_PORT", qdrant_rest_port().to_string())
         .current_dir(root)
         .output()
         .expect("run vector-db-benchmark");
@@ -718,8 +731,8 @@ fn test_binary_qdrant_match_any() {
         proj.matching_docs
     );
 
-    let grpc = QDRANT_GRPC_PORT.to_string();
-    let rest = QDRANT_REST_PORT.to_string();
+    let grpc = qdrant_grpc_port().to_string();
+    let rest = qdrant_rest_port().to_string();
     assert!(
         common::run_binary(
             &proj.root,
@@ -1097,8 +1110,8 @@ fn test_binary_qdrant_geo() {
     let proj =
         common::write_geo_project("geo-test", &serde_json::to_string(&configs).unwrap(), dim);
     assert!(proj.matching_docs >= proj.top);
-    let grpc = QDRANT_GRPC_PORT.to_string();
-    let rest = QDRANT_REST_PORT.to_string();
+    let grpc = qdrant_grpc_port().to_string();
+    let rest = qdrant_rest_port().to_string();
     assert!(
         common::run_binary(
             &proj.root,
@@ -1135,8 +1148,8 @@ fn test_binary_qdrant_and_filter() {
         dim,
     );
     assert!(proj.matching_docs >= proj.top);
-    let grpc = QDRANT_GRPC_PORT.to_string();
-    let rest = QDRANT_REST_PORT.to_string();
+    let grpc = qdrant_grpc_port().to_string();
+    let rest = qdrant_rest_port().to_string();
     assert!(
         common::run_binary(
             &proj.root,
@@ -1174,8 +1187,8 @@ fn test_binary_qdrant_or_filter() {
     let proj =
         common::write_or_filter_project("or-test", &serde_json::to_string(&configs).unwrap(), dim);
     assert!(proj.matching_docs >= proj.top);
-    let grpc = QDRANT_GRPC_PORT.to_string();
-    let rest = QDRANT_REST_PORT.to_string();
+    let grpc = qdrant_grpc_port().to_string();
+    let rest = qdrant_rest_port().to_string();
     assert!(
         common::run_binary(
             &proj.root,
@@ -1216,8 +1229,8 @@ fn test_binary_qdrant_nested_filter() {
         dim,
     );
     assert!(proj.matching_docs >= proj.top);
-    let grpc = QDRANT_GRPC_PORT.to_string();
-    let rest = QDRANT_REST_PORT.to_string();
+    let grpc = qdrant_grpc_port().to_string();
+    let rest = qdrant_rest_port().to_string();
     assert!(
         common::run_binary(
             &proj.root,
@@ -1257,8 +1270,8 @@ fn test_binary_qdrant_uuid() {
     let proj =
         common::write_uuid_project("uuid-test", &serde_json::to_string(&configs).unwrap(), dim);
     assert!(proj.matching_docs >= proj.top);
-    let grpc = QDRANT_GRPC_PORT.to_string();
-    let rest = QDRANT_REST_PORT.to_string();
+    let grpc = qdrant_grpc_port().to_string();
+    let rest = qdrant_rest_port().to_string();
     assert!(
         common::run_binary(
             &proj.root,
@@ -1297,8 +1310,8 @@ fn test_binary_qdrant_selectivity() {
         dim,
     );
     assert!(proj.matching_docs >= proj.top);
-    let grpc = QDRANT_GRPC_PORT.to_string();
-    let rest = QDRANT_REST_PORT.to_string();
+    let grpc = qdrant_grpc_port().to_string();
+    let rest = qdrant_rest_port().to_string();
     assert!(
         common::run_binary(
             &proj.root,
@@ -1348,8 +1361,8 @@ fn test_binary_qdrant_match_any_labels() {
         proj.matching_docs
     );
 
-    let grpc = QDRANT_GRPC_PORT.to_string();
-    let rest = QDRANT_REST_PORT.to_string();
+    let grpc = qdrant_grpc_port().to_string();
+    let rest = qdrant_rest_port().to_string();
     assert!(
         common::run_binary(
             &proj.root,
@@ -1710,8 +1723,8 @@ fn run_qdrant_binary_keep_collection(
             "false",
             "--keep-data",
         ])
-        .env("QDRANT_GRPC_PORT", QDRANT_GRPC_PORT.to_string())
-        .env("QDRANT_REST_PORT", QDRANT_REST_PORT.to_string())
+        .env("QDRANT_GRPC_PORT", qdrant_grpc_port().to_string())
+        .env("QDRANT_REST_PORT", qdrant_rest_port().to_string())
         .env("QDRANT_COLLECTION_NAME", collection)
         .current_dir(root)
         .output()
@@ -1974,4 +1987,185 @@ fn test_binary_qdrant_sparse_binary_ground_truth_end_to_end() {
          not line up with the point ids the uploader assigns",
         precision
     );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #238 — `--skip-upload` reuse precondition, Qdrant
+// ---------------------------------------------------------------------------
+
+/// `points_count` straight off `GET /collections/<n>`.
+fn qdrant_points_count(collection: &str) -> u64 {
+    let v: serde_json::Value = rest_client()
+        .get(format!("{}/collections/{}", rest_url(), collection))
+        .send()
+        .expect("collection info")
+        .json()
+        .expect("collection info json");
+    v["result"]["points_count"].as_u64().unwrap_or(0)
+}
+
+/// Qdrant's `corpus_row_count()` is a live read, and a short collection is
+/// fatal — proven by deleting points behind the tool's back (#238).
+///
+/// Recall cannot serve as this guard: on a 100-point corpus whose ground truth
+/// lives in the low ids, deleting the UPPER half leaves `mean_recall: 1.0`.
+/// This test deletes the upper half deliberately, so it fails on the pre-fix
+/// branch exactly where a recall assertion would have passed.
+#[test]
+fn test_binary_qdrant_skip_upload_short_corpus_is_fatal() {
+    wait_for_qdrant();
+    delete_collection();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "cfg238qd", "engine": "qdrant",
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 64}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "cfg238qd-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let collection = std::env::var("QDRANT_COLLECTION_NAME").unwrap_or("benchmark".to_string());
+
+    let run = |extra: &[&str]| {
+        let mut cmd = std::process::Command::new(common::binary_path());
+        cmd.args([
+            "--engines",
+            "cfg238qd",
+            "--datasets",
+            "cfg238qd-test",
+            "--host",
+            "localhost",
+            "--skip-if-exists",
+            "false",
+        ])
+        .args(extra)
+        .current_dir(&proj.root)
+        .env("QDRANT_GRPC_PORT", qdrant_grpc_port().to_string())
+        .env("QDRANT_REST_PORT", qdrant_rest_port().to_string());
+        cmd.output().expect("run vector-db-benchmark")
+    };
+
+    assert!(
+        run(&["--keep-data", "--skip-search"]).status.success(),
+        "phase 1 (upload) failed"
+    );
+    assert_eq!(
+        qdrant_points_count(&collection),
+        common::N_DOCS as u64,
+        "phase 1 corpus"
+    );
+
+    // Delete the UPPER half: the half whose absence recall does NOT notice.
+    let half = common::N_DOCS / 2;
+    let ids: Vec<u64> = (half as u64..common::N_DOCS as u64).collect();
+    rest_client()
+        .post(format!(
+            "{}/collections/{}/points/delete?wait=true",
+            rest_url(),
+            collection
+        ))
+        .json(&serde_json::json!({ "points": ids }))
+        .send()
+        .expect("delete points");
+    assert_eq!(
+        qdrant_points_count(&collection),
+        half as u64,
+        "the amputation must be visible server-side"
+    );
+
+    let out = run(&["--skip-upload", "--keep-data"]);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "--skip-upload against a half-deleted Qdrant collection must be a hard error.\n{combined}"
+    );
+    assert!(
+        combined.contains(&format!("holds {half} of the {} rows", common::N_DOCS)),
+        "the count must track the amputation, proving it is a live points_count read.\n{combined}"
+    );
+    assert_no_search_result(&proj.root, "cfg238qd");
+
+    // And the check itself must be read-only.
+    assert_eq!(
+        qdrant_points_count(&collection),
+        half as u64,
+        "the reuse check must never modify the corpus"
+    );
+
+    delete_collection();
+    std::fs::remove_dir_all(&proj.root).ok();
+}
+
+/// `--skip-upload` with NO `--keep-data` must not delete the collection (#238).
+///
+/// RED on the pre-fix branch: the collection is MISSING afterwards — the run
+/// printed a green reuse check, benchmarked, then ran `Cleanup (deleting index
+/// and data)` and exited 0.
+#[test]
+fn test_binary_qdrant_skip_upload_without_keep_data_preserves_corpus() {
+    wait_for_qdrant();
+    delete_collection();
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "cfg238qdnokeep", "engine": "qdrant",
+        "search_params": [{"parallel": 1, "search_params": {"hnsw_ef": 64}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "cfg238qdnokeep-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let collection = std::env::var("QDRANT_COLLECTION_NAME").unwrap_or("benchmark".to_string());
+
+    let run = |extra: &[&str]| {
+        let mut cmd = std::process::Command::new(common::binary_path());
+        cmd.args([
+            "--engines",
+            "cfg238qdnokeep",
+            "--datasets",
+            "cfg238qdnokeep-test",
+            "--host",
+            "localhost",
+            "--skip-if-exists",
+            "false",
+        ])
+        .args(extra)
+        .current_dir(&proj.root)
+        .env("QDRANT_GRPC_PORT", qdrant_grpc_port().to_string())
+        .env("QDRANT_REST_PORT", qdrant_rest_port().to_string());
+        cmd.output().expect("run vector-db-benchmark")
+    };
+
+    assert!(
+        run(&["--keep-data", "--skip-search"]).status.success(),
+        "phase 1 (upload) failed"
+    );
+    let before = qdrant_points_count(&collection);
+    assert_eq!(before, common::N_DOCS as u64, "phase 1 corpus");
+
+    // Deliberately NO --keep-data.
+    let out = run(&["--skip-upload"]);
+    assert!(
+        out.status.success(),
+        "phase 2 failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        qdrant_points_count(&collection),
+        before,
+        "--skip-upload without --keep-data deleted the collection it reused — issue #238"
+    );
+
+    delete_collection();
+    std::fs::remove_dir_all(&proj.root).ok();
 }

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -21,11 +21,19 @@ mod common;
 // Helpers
 // ---------------------------------------------------------------------------
 
-const TEST_PORT: u16 = 6399;
+/// Redis port under test. Overridable so a session can run against its OWN
+/// container instead of the shared 6399 one — these tests call `flush_db()`, so
+/// two sessions sharing an instance clobber each other.
+fn test_port() -> u16 {
+    std::env::var("REDIS_TEST_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6399)
+}
 const TEST_HOST: &str = "127.0.0.1";
 
 fn get_test_connection() -> Connection {
-    let url = format!("redis://{}:{}/", TEST_HOST, TEST_PORT);
+    let url = format!("redis://{}:{}/", TEST_HOST, test_port());
     let client = redis::Client::open(url.as_str()).expect("Failed to create Redis client");
     client
         .get_connection()
@@ -35,7 +43,7 @@ fn get_test_connection() -> Connection {
 fn wait_for_redis() {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
-        let url = format!("redis://{}:{}/", TEST_HOST, TEST_PORT);
+        let url = format!("redis://{}:{}/", TEST_HOST, test_port());
         if let Ok(client) = redis::Client::open(url.as_str()) {
             if let Ok(mut conn) = client.get_connection() {
                 let pong: Result<String, _> = redis::cmd("PING").query(&mut conn);
@@ -45,7 +53,7 @@ fn wait_for_redis() {
             }
         }
         if Instant::now() > deadline {
-            panic!("Redis not available on port {} after 10s", TEST_PORT);
+            panic!("Redis not available on port {} after 10s", test_port());
         }
         thread::sleep(Duration::from_millis(200));
     }
@@ -1501,7 +1509,7 @@ fn test_binary_redis_end_to_end() {
             "--host",
             "localhost",
         ])
-        .env("REDIS_PORT", TEST_PORT.to_string())
+        .env("REDIS_PORT", test_port().to_string())
         .current_dir(&project_root)
         .output()
         .expect("Failed to run vector-db-benchmark");
@@ -1598,7 +1606,7 @@ fn test_binary_redis_svs_vamana() {
             "--host",
             "localhost",
         ])
-        .env("REDIS_PORT", TEST_PORT.to_string())
+        .env("REDIS_PORT", test_port().to_string())
         .current_dir(&project_root)
         .output()
         .expect("Failed to run vector-db-benchmark");
@@ -1683,7 +1691,7 @@ fn test_binary_redis_open_loop_fixed_qps() {
             "--repetitions",
             "1",
         ])
-        .env("REDIS_PORT", TEST_PORT.to_string())
+        .env("REDIS_PORT", test_port().to_string())
         .current_dir(&project_root)
         .output()
         .expect("Failed to run open-loop benchmark");
@@ -1786,7 +1794,7 @@ fn test_binary_vectorsets_end_to_end() {
             "--host",
             "localhost",
         ])
-        .env("REDIS_PORT", TEST_PORT.to_string())
+        .env("REDIS_PORT", test_port().to_string())
         .current_dir(&project_root)
         .output()
         .expect("Failed to run vector-db-benchmark");
@@ -1926,7 +1934,7 @@ fn test_binary_redis_mixed_benchmark() {
             "--repetitions",
             "1",
         ])
-        .env("REDIS_PORT", TEST_PORT.to_string())
+        .env("REDIS_PORT", test_port().to_string())
         .current_dir(&project_root)
         .output()
         .expect("Failed to run vector-db-benchmark");
@@ -2027,7 +2035,7 @@ fn test_binary_redis_filter_only() {
     );
     assert!(proj.matching_docs >= proj.top);
 
-    let port = TEST_PORT.to_string();
+    let port = test_port().to_string();
     assert!(
         common::run_binary_extra(
             &proj.root,
@@ -2090,7 +2098,7 @@ fn test_binary_redis_mixed_parallel() {
     );
     assert!(proj.matching_docs >= proj.top);
 
-    let port = TEST_PORT.to_string();
+    let port = test_port().to_string();
     assert!(
         common::run_binary_extra(
             &proj.root,
@@ -2158,7 +2166,7 @@ fn test_binary_redis_match_any() {
             "redis-ma",
             "match-any-test",
             "localhost",
-            &[("REDIS_PORT", &TEST_PORT.to_string())],
+            &[("REDIS_PORT", &test_port().to_string())],
         ),
         "redis match_any run failed"
     );
@@ -2190,7 +2198,7 @@ fn test_binary_redis_match_any_resp3() {
     );
     assert!(proj.matching_docs >= proj.top);
 
-    let resp3_uri = format!("redis://localhost:{}/?protocol=resp3", TEST_PORT);
+    let resp3_uri = format!("redis://localhost:{}/?protocol=resp3", test_port());
     assert!(
         common::run_binary(
             &proj.root,
@@ -2244,7 +2252,7 @@ fn run_filter_recall_test(
             name,
             dataset,
             "localhost",
-            &[("REDIS_PORT", &TEST_PORT.to_string())],
+            &[("REDIS_PORT", &test_port().to_string())],
         ),
         "redis {} run failed",
         name
@@ -2338,7 +2346,7 @@ fn test_binary_redis_keep_data_sweep_frees_prior_configs() {
             "redis-sweep*",
             "sweep-test",
             "localhost",
-            &[("REDIS_PORT", &TEST_PORT.to_string())],
+            &[("REDIS_PORT", &test_port().to_string())],
             &["--keep-data", "--reset-between-configs"],
         ),
         "redis keep-data sweep run failed"
@@ -2412,7 +2420,7 @@ fn test_binary_redis_shared_corpus_upload_once() {
             "--skip-if-exists",
             "false",
         ])
-        .env("REDIS_PORT", TEST_PORT.to_string())
+        .env("REDIS_PORT", test_port().to_string())
         .env("REDIS_KEY_PREFIX", "shared_sc:")
         .current_dir(&proj.root)
         .output()
@@ -2535,7 +2543,7 @@ fn test_binary_redis_tenancy() {
             "redis-tenancy",
             "tenancy-test",
             "localhost",
-            &[("REDIS_PORT", &TEST_PORT.to_string())],
+            &[("REDIS_PORT", &test_port().to_string())],
             &["--dump-raw-latencies"],
         ),
         "redis tenancy run failed"
@@ -2646,7 +2654,7 @@ fn test_binary_redis_coexistence_skip_upload() {
         dim,
     );
     let bin = binary_path();
-    let port = TEST_PORT.to_string();
+    let port = test_port().to_string();
     let results_dir = root.join("results");
 
     // Phase 1: upload + search BOTH configs, KEEPING data for the skip-upload phase.
@@ -2817,7 +2825,7 @@ fn test_binary_redis_skip_upload_without_prior_upload_errors() {
             "--skip-if-exists",
             "false",
         ])
-        .env("REDIS_PORT", TEST_PORT.to_string())
+        .env("REDIS_PORT", test_port().to_string())
         .current_dir(&root)
         .output()
         .expect("run skip-upload-no-index");
@@ -2885,7 +2893,7 @@ fn test_binary_redis_skip_upload_skip_vector_index_preserves_corpus() {
         &serde_json::to_string(&configs).unwrap(),
         dim,
     );
-    let port = TEST_PORT.to_string();
+    let port = test_port().to_string();
     let envs: [(&str, &str); 1] = [("REDIS_PORT", port.as_str())];
 
     // Phase 1: build the filter-only corpus the second phase is told to reuse.
@@ -2947,9 +2955,13 @@ fn test_binary_redis_skip_upload_skip_vector_index_preserves_corpus() {
 /// SHORT corpus must not quietly measure it.
 ///
 /// Deleting half the docs leaves an index that answers every query without
-/// error, so no behavioural assertion catches it — and recall does not either
-/// (the same experiment on Qdrant reported `mean_recall: 1.0` with half the
-/// collection gone). Only a server-side row count does.
+/// error, so no behavioural assertion catches it — and recall is not a reliable
+/// detector either. Whether a truncated corpus shows up in recall depends on
+/// WHICH rows went: on `random-100` (9 queries, one ground-truth neighbour each,
+/// ids 0-8) deleting the upper half of a Qdrant collection leaves
+/// `mean_recall: 1.0`, while deleting the lower half gives `0.0`. A metric that
+/// is a coin flip on the deletion pattern cannot be the guard; a server-side row
+/// count is not.
 ///
 /// RED on unfixed code: phase 2 exits 0 and writes a search result file.
 #[test]
@@ -2960,24 +2972,24 @@ fn test_binary_redis_skip_upload_short_corpus_is_fatal() {
 
     let dim = 8;
     let configs = serde_json::json!([{
-        "name": "redis-238-short", "engine": "redis",
+        "name": "cfg238short", "engine": "redis",
         "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
         "upload_params": {"parallel": 1, "batch_size": 100}
     }]);
     let proj = common::write_match_any_project(
-        "redis-238-short-test",
+        "cfg238short-test",
         &serde_json::to_string(&configs).unwrap(),
         dim,
     );
-    let port = TEST_PORT.to_string();
+    let port = test_port().to_string();
     let envs: [(&str, &str); 1] = [("REDIS_PORT", port.as_str())];
     let results_dir = proj.root.join("results");
 
     assert!(
         common::run_binary_extra(
             &proj.root,
-            "redis-238-short",
-            "redis-238-short-test",
+            "cfg238short",
+            "cfg238short-test",
             "localhost",
             &envs,
             &["--keep-data", "--skip-search"],
@@ -2985,7 +2997,7 @@ fn test_binary_redis_skip_upload_short_corpus_is_fatal() {
         "phase 1 (upload) failed"
     );
     assert_eq!(
-        ft_info_num_docs(&mut conn, "idx:redis-238-short"),
+        ft_info_num_docs(&mut conn, "idx:cfg238short"),
         common::N_DOCS as i64,
         "phase 1 must leave a complete corpus"
     );
@@ -2994,11 +3006,11 @@ fn test_binary_redis_skip_upload_short_corpus_is_fatal() {
     let half = common::N_DOCS / 2;
     for id in 0..half {
         let _: () = redis::cmd("UNLINK")
-            .arg(format!("redis-238-short:{id}"))
+            .arg(format!("cfg238short:{id}"))
             .query(&mut conn)
             .unwrap();
     }
-    let remaining = ft_info_num_docs(&mut conn, "idx:redis-238-short");
+    let remaining = ft_info_num_docs(&mut conn, "idx:cfg238short");
     assert_eq!(remaining, half as i64, "half the corpus should remain");
 
     delete_search_result_files(&results_dir);
@@ -3008,9 +3020,9 @@ fn test_binary_redis_skip_upload_short_corpus_is_fatal() {
         let mut cmd = Command::new(&bin);
         cmd.args([
             "--engines",
-            "redis-238-short",
+            "cfg238short",
             "--datasets",
-            "redis-238-short-test",
+            "cfg238short-test",
             "--host",
             "localhost",
             "--skip-if-exists",
@@ -3064,9 +3076,187 @@ fn test_binary_redis_skip_upload_short_corpus_is_fatal() {
         "the override must still warn"
     );
     assert_eq!(
-        ft_info_num_docs(&mut conn, "idx:redis-238-short"),
+        ft_info_num_docs(&mut conn, "idx:cfg238short"),
         half as i64,
         "the reuse check must never modify the corpus"
+    );
+
+    // The waived run must SAY it was waived. A verified run, an unverified run
+    // and a waived run over a half-deleted corpus produced structurally
+    // identical artifacts before #238, so the verdict travels in the file.
+    let reuse = common::read_params_obj(&proj.root, "cfg238short")["corpus_reuse"].clone();
+    assert_eq!(reuse["status"], "short", "recorded verdict: {reuse}");
+    assert_eq!(reuse["expected_rows"], common::N_DOCS as u64);
+    assert_eq!(reuse["actual_rows"], half as u64);
+    assert_eq!(reuse["waived_by_allow_partial_corpus"], true);
+    assert_eq!(reuse["actual_is_estimate"], false);
+
+    flush_db(&mut conn);
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+/// The SURPLUS arm of the guard, exercised end to end (issue #238).
+///
+/// The classifier unit test only proves the variant is returned; this proves the
+/// handler *warns and continues* rather than aborting — the arm that decides
+/// warn-vs-abort is the one that matters, and it had no runtime coverage.
+#[test]
+fn test_binary_redis_skip_upload_surplus_warns_and_continues() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "cfg238surplus", "engine": "redis",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "cfg238surplus-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let port = test_port().to_string();
+    let envs: [(&str, &str); 1] = [("REDIS_PORT", port.as_str())];
+
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg238surplus",
+            "cfg238surplus-test",
+            "localhost",
+            &envs,
+            &["--keep-data", "--skip-search"],
+        ),
+        "phase 1 (upload) failed"
+    );
+
+    // Five extra indexed docs under this config's prefix: a real superset corpus.
+    for id in 10_000..10_005 {
+        let _: () = redis::cmd("HSET")
+            .arg(format!("cfg238surplus:{id}"))
+            .arg("vector")
+            .arg(vec_to_bytes(&vec![0.0f32; dim]))
+            .query(&mut conn)
+            .unwrap();
+    }
+    let expected_surplus = common::N_DOCS as i64 + 5;
+    for _ in 0..50 {
+        if ft_info_num_docs(&mut conn, "idx:cfg238surplus") == expected_surplus {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:cfg238surplus"),
+        expected_surplus,
+        "the extra docs must be indexed for this to be a surplus"
+    );
+
+    delete_search_result_files(&proj.root.join("results"));
+
+    let out = Command::new(binary_path())
+        .args([
+            "--engines",
+            "cfg238surplus",
+            "--datasets",
+            "cfg238surplus-test",
+            "--host",
+            "localhost",
+            "--skip-if-exists",
+            "false",
+            "--skip-upload",
+            "--keep-data",
+        ])
+        .env("REDIS_PORT", &port)
+        .current_dir(&proj.root)
+        .output()
+        .expect("run vector-db-benchmark");
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(
+        out.status.success(),
+        "a surplus corpus must WARN and continue, not abort.\nstdout: {}\nstderr: {stderr}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        stderr.contains("WARNING: --skip-upload")
+            && stderr.contains(&format!("holds {expected_surplus} rows")),
+        "the surplus warning must name the count it found.\nstderr: {stderr}"
+    );
+    let reuse = common::read_params_obj(&proj.root, "cfg238surplus")["corpus_reuse"].clone();
+    assert_eq!(reuse["status"], "surplus", "recorded verdict: {reuse}");
+    assert_eq!(reuse["actual_rows"], expected_surplus as u64);
+
+    flush_db(&mut conn);
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+/// `--skip-upload` with NO `--keep-data` must not delete the corpus it reused
+/// (issue #238, second destructive path).
+///
+/// `--keep-data` defaults to false and `engine.delete()` runs at the end of every
+/// successful experiment, so the plainest form of the flag used to benchmark a
+/// corpus and then destroy it — exit 0, no warning. The other #238 regression
+/// tests all pass `--keep-data`, so none of them covered this.
+///
+/// RED before the fix: `DBSIZE` 400 -> 0.
+#[test]
+fn test_binary_redis_skip_upload_without_keep_data_preserves_corpus() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "cfg238nokeep", "engine": "redis",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "cfg238nokeep-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let port = test_port().to_string();
+    let envs: [(&str, &str); 1] = [("REDIS_PORT", port.as_str())];
+
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg238nokeep",
+            "cfg238nokeep-test",
+            "localhost",
+            &envs,
+            &["--keep-data", "--skip-search"],
+        ),
+        "phase 1 (upload) failed"
+    );
+    let before = ft_info_num_docs(&mut conn, "idx:cfg238nokeep");
+    assert_eq!(before, common::N_DOCS as i64, "phase 1 corpus");
+
+    // Deliberately NO --keep-data.
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg238nokeep",
+            "cfg238nokeep-test",
+            "localhost",
+            &envs,
+            &["--skip-upload"],
+        ),
+        "phase 2 (--skip-upload, no --keep-data) failed"
+    );
+
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:cfg238nokeep"),
+        before,
+        "--skip-upload without --keep-data deleted the corpus it reused — issue #238"
+    );
+    assert_eq!(
+        count_prefix(&mut conn, "cfg238nokeep:"),
+        common::N_DOCS as i64,
+        "--skip-upload without --keep-data unlinked the keyspace it reused — issue #238"
     );
 
     flush_db(&mut conn);

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -2842,3 +2842,233 @@ fn test_binary_redis_skip_upload_without_prior_upload_errors() {
 
     fs::remove_dir_all(&root).ok();
 }
+
+// ---------------------------------------------------------------------------
+// Issue #238 — `--skip-upload` must NOT destroy the corpus it was told to reuse
+// ---------------------------------------------------------------------------
+
+/// Count keys under a literal prefix, server-side.
+fn count_prefix(conn: &mut Connection, prefix: &str) -> i64 {
+    redis::cmd("EVAL")
+        .arg("return #redis.call('keys', KEYS[1])")
+        .arg(1)
+        .arg(format!("{prefix}*"))
+        .query(conn)
+        .unwrap()
+}
+
+/// Regression test for #238: `--skip-upload --skip-vector-index` destroyed the
+/// corpus and then measured the empty index, reporting a QPS number and exiting
+/// 0.
+///
+/// The assertions read state back **off the live server** (`FT.INFO num_docs`
+/// plus a keyspace count), because the run's own output cannot detect this: on
+/// the unfixed binary phase 2 prints a perfectly ordinary QPS line.
+///
+/// RED on unfixed code: `configure()` ran on the skip-upload path and issued
+/// `FT.DROPINDEX idx:redis-no-vector DD`, so both counts come back 0 instead of
+/// 400 (verified live on redis 8.2: DBSIZE 400 -> 0).
+#[test]
+fn test_binary_redis_skip_upload_skip_vector_index_preserves_corpus() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "redis-238-keep", "engine": "redis",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "redis-238-keep-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let port = TEST_PORT.to_string();
+    let envs: [(&str, &str); 1] = [("REDIS_PORT", port.as_str())];
+
+    // Phase 1: build the filter-only corpus the second phase is told to reuse.
+    // `--skip-vector-index` rewrites the config name to `<engine>-no-vector`, so
+    // the index/keyspace phase 2 addresses is the one phase 1 wrote.
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "redis-238-keep",
+            "redis-238-keep-test",
+            "localhost",
+            &envs,
+            &["--skip-vector-index", "--keep-data", "--skip-search"],
+        ),
+        "phase 1 (upload with --skip-vector-index) failed"
+    );
+
+    let docs_before = ft_info_num_docs(&mut conn, "idx:redis-no-vector");
+    let keys_before = count_prefix(&mut conn, "redis-no-vector:");
+    assert_eq!(
+        docs_before,
+        common::N_DOCS as i64,
+        "phase 1 must leave a complete corpus indexed"
+    );
+    assert_eq!(keys_before, common::N_DOCS as i64, "phase 1 keyspace");
+
+    // Phase 2: the flag combination that means "do not upload, do not build an
+    // index, just use what is there".
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "redis-238-keep",
+            "redis-238-keep-test",
+            "localhost",
+            &envs,
+            &["--skip-upload", "--skip-vector-index", "--keep-data"],
+        ),
+        "phase 2 (--skip-upload --skip-vector-index) failed"
+    );
+
+    let docs_after = ft_info_num_docs(&mut conn, "idx:redis-no-vector");
+    let keys_after = count_prefix(&mut conn, "redis-no-vector:");
+    assert_eq!(
+        docs_after, docs_before,
+        "--skip-upload --skip-vector-index destroyed the indexed corpus \
+         ({docs_before} -> {docs_after} docs) — issue #238"
+    );
+    assert_eq!(
+        keys_after, keys_before,
+        "--skip-upload --skip-vector-index destroyed the keyspace \
+         ({keys_before} -> {keys_after} keys) — issue #238"
+    );
+
+    flush_db(&mut conn);
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+/// Regression test for #238's second half: a `--skip-upload` run against a
+/// SHORT corpus must not quietly measure it.
+///
+/// Deleting half the docs leaves an index that answers every query without
+/// error, so no behavioural assertion catches it — and recall does not either
+/// (the same experiment on Qdrant reported `mean_recall: 1.0` with half the
+/// collection gone). Only a server-side row count does.
+///
+/// RED on unfixed code: phase 2 exits 0 and writes a search result file.
+#[test]
+fn test_binary_redis_skip_upload_short_corpus_is_fatal() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "redis-238-short", "engine": "redis",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "redis-238-short-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let port = TEST_PORT.to_string();
+    let envs: [(&str, &str); 1] = [("REDIS_PORT", port.as_str())];
+    let results_dir = proj.root.join("results");
+
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "redis-238-short",
+            "redis-238-short-test",
+            "localhost",
+            &envs,
+            &["--keep-data", "--skip-search"],
+        ),
+        "phase 1 (upload) failed"
+    );
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:redis-238-short"),
+        common::N_DOCS as i64,
+        "phase 1 must leave a complete corpus"
+    );
+
+    // Amputate half the corpus behind the tool's back.
+    let half = common::N_DOCS / 2;
+    for id in 0..half {
+        let _: () = redis::cmd("UNLINK")
+            .arg(format!("redis-238-short:{id}"))
+            .query(&mut conn)
+            .unwrap();
+    }
+    let remaining = ft_info_num_docs(&mut conn, "idx:redis-238-short");
+    assert_eq!(remaining, half as i64, "half the corpus should remain");
+
+    delete_search_result_files(&results_dir);
+
+    let bin = binary_path();
+    let run = |extra: &[&str]| {
+        let mut cmd = Command::new(&bin);
+        cmd.args([
+            "--engines",
+            "redis-238-short",
+            "--datasets",
+            "redis-238-short-test",
+            "--host",
+            "localhost",
+            "--skip-if-exists",
+            "false",
+            "--skip-upload",
+            "--keep-data",
+        ]);
+        cmd.args(extra);
+        cmd.env("REDIS_PORT", &port)
+            .current_dir(&proj.root)
+            .output()
+            .expect("run vector-db-benchmark")
+    };
+
+    let out = run(&[]);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "--skip-upload against a half-deleted corpus must be a hard error \
+         (issue #238), but the run succeeded.\n{combined}"
+    );
+    assert!(
+        combined.contains("the corpus you asked to reuse is incomplete")
+            && combined.contains(&format!("holds {half} of the {} rows", common::N_DOCS)),
+        "the error must name the shortfall it found.\n{combined}"
+    );
+    let wrote_results = fs::read_dir(&results_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .any(|e| e.file_name().to_string_lossy().contains("-search-"));
+    assert!(
+        !wrote_results,
+        "a rejected --skip-upload run must not leave a search result file behind"
+    );
+
+    // The guard must be deliberately overridable — and must never have been a
+    // reason to touch the data.
+    let out2 = run(&["--allow-partial-corpus"]);
+    assert!(
+        out2.status.success(),
+        "--allow-partial-corpus must downgrade the guard to a warning.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out2.stdout),
+        String::from_utf8_lossy(&out2.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out2.stderr).contains("WARNING: --skip-upload"),
+        "the override must still warn"
+    );
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:redis-238-short"),
+        half as i64,
+        "the reuse check must never modify the corpus"
+    );
+
+    flush_db(&mut conn);
+    fs::remove_dir_all(&proj.root).ok();
+}

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -1719,3 +1719,157 @@ fn test_valkey_skip_upload_without_prior_upload_errors() {
 
     fs::remove_dir_all(&root).ok();
 }
+
+// ---------------------------------------------------------------------------
+// Issue #238 — `--skip-upload` must reuse the corpus, not destroy it
+// ---------------------------------------------------------------------------
+
+/// Valkey's destruction path differs from Redis's: no `DD` flag on
+/// `FT.DROPINDEX`, so `configure()` drops the index and then SCAN+UNLINKs every
+/// key under this config's prefix.
+///
+/// RED on the pre-fix branch: 400 keys -> 0, `num_docs` 400 -> 0, while the run
+/// printed a QPS line and exited 0.
+#[test]
+fn test_binary_valkey_skip_upload_skip_vector_index_preserves_corpus() {
+    wait_for_valkey();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "cfg238vk", "engine": "valkey",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "cfg238vk-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let port = test_port().to_string();
+    let envs: [(&str, &str); 1] = [("VALKEY_PORT", port.as_str())];
+
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg238vk",
+            "cfg238vk-test",
+            "localhost",
+            &envs,
+            &["--skip-vector-index", "--keep-data", "--skip-search"],
+        ),
+        "phase 1 (upload with --skip-vector-index) failed"
+    );
+
+    let keys_before: i64 = redis::cmd("EVAL")
+        .arg("return #redis.call('keys', KEYS[1])")
+        .arg(1)
+        .arg("valkey-no-vector:*")
+        .query(&mut conn)
+        .unwrap();
+    assert_eq!(keys_before, common::N_DOCS as i64, "phase 1 keyspace");
+
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg238vk",
+            "cfg238vk-test",
+            "localhost",
+            &envs,
+            &["--skip-upload", "--skip-vector-index", "--keep-data"],
+        ),
+        "phase 2 (--skip-upload --skip-vector-index) failed"
+    );
+
+    let keys_after: i64 = redis::cmd("EVAL")
+        .arg("return #redis.call('keys', KEYS[1])")
+        .arg(1)
+        .arg("valkey-no-vector:*")
+        .query(&mut conn)
+        .unwrap();
+    assert_eq!(
+        keys_after, keys_before,
+        "--skip-upload --skip-vector-index unlinked the corpus it was told to reuse \
+         ({keys_before} -> {keys_after} keys) — issue #238"
+    );
+
+    flush_db(&mut conn);
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+/// `corpus_row_count()` must be a real server read, not a constant: amputate the
+/// corpus behind the tool's back and the reported number has to follow (#238).
+#[test]
+fn test_binary_valkey_skip_upload_short_corpus_is_fatal() {
+    wait_for_valkey();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "cfg238vkshort", "engine": "valkey",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "cfg238vkshort-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let port = test_port().to_string();
+
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg238vkshort",
+            "cfg238vkshort-test",
+            "localhost",
+            &[("VALKEY_PORT", port.as_str())],
+            &["--keep-data", "--skip-search"],
+        ),
+        "phase 1 (upload) failed"
+    );
+
+    let half = common::N_DOCS / 2;
+    for id in 0..half {
+        let _: () = redis::cmd("UNLINK")
+            .arg(format!("cfg238vkshort:{id}"))
+            .query(&mut conn)
+            .unwrap();
+    }
+
+    let out = Command::new(binary_path())
+        .args([
+            "--engines",
+            "cfg238vkshort",
+            "--datasets",
+            "cfg238vkshort-test",
+            "--host",
+            "localhost",
+            "--skip-if-exists",
+            "false",
+            "--skip-upload",
+            "--keep-data",
+        ])
+        .env("VALKEY_PORT", &port)
+        .current_dir(&proj.root)
+        .output()
+        .expect("run vector-db-benchmark");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "--skip-upload against a half-deleted valkey corpus must be a hard error.\n{combined}"
+    );
+    assert!(
+        combined.contains(&format!("holds {half} of the {} rows", common::N_DOCS)),
+        "the count must track the amputation, proving it is a live server read.\n{combined}"
+    );
+
+    flush_db(&mut conn);
+    fs::remove_dir_all(&proj.root).ok();
+}


### PR DESCRIPTION
## The bug

`--skip-upload` exists to reuse an already-populated corpus. Two separate paths destroyed it instead.

**Path 1 — `configure()`.** With `--skip-vector-index` also set, `experiment.rs` still routed through `Engine::configure()`, destructive on **14 of the 15 engines** (only Vertex is not). The flag pair meaning *"do not upload, do not build an index, just use what is there"* deleted the corpus, then benchmarked the empty index, printed a QPS number and exited 0.

**Path 2 — `engine.delete()`.** Cleanup runs at the end of every successful experiment unless `--keep-data`, which defaults to **false**. So the plainest form of the flag reused a corpus, measured it, and then deleted it. Found in review; both original regression tests passed `--keep-data`, so neither covered it.

## Empirical matrix (established live)

`--skip-vector-index` is wired for **redis / valkey / mongodb** only (`experiment.rs:274`); every other engine's config is skipped with a warning before `configure()` is reached, so path 1 is reachable on exactly those three — and all three destroy. Path 2 applies to **every** engine.

| engine | path 1 (`--skip-upload --skip-vector-index`) | path 2 (`--skip-upload`, no `--keep-data`) |
|---|---|---|
| redis | **DESTROYS** — `FT.DROPINDEX … DD` | **DESTROYS** — `DBSIZE` 400 → 0 |
| valkey | **DESTROYS** — `FT.DROPINDEX` + `SCAN`/`UNLINK` | DESTROYS (same `delete()`) |
| mongodb | **DESTROYS** — `collection.drop()`, **unbounded**: unlike redis/valkey's namespace-scoped `DD`/UNLINK it removes the whole benchmark collection | DESTROYS |
| qdrant | not reached (config skipped) | **DESTROYS** — `points_count` 100 → collection MISSING |
| vectorsets | not reached | **DESTROYS** — `VCARD idx` 100 → 0 |
| chroma, es, opensearch, pgvector, weaviate, milvus, turbopuffer, kividb, dragonfly | not reached (`configure()` is destructive for all of them anyway) | DESTROYS |
| vertex | not reached | non-destructive `configure()`; `delete()` guarded by `reuse_index_ids()` |

A third shape survives and the new guard is what catches it: if phase 1 was a *normal* upload, phase 2 destroys nothing — it publishes a QPS number from an empty `<engine>-no-vector` index while the real corpus sits untouched under the original config name.

## Semantics

> `--skip-upload` = *"the server already holds the corpus I want; do not create, drop, recreate or otherwise modify it."*

1. **`configure()` never runs** on that path, in any flag combination. The removed arm was unnecessary anyway: `--skip-vector-index` rewrites the config name to `<engine>-no-vector`, so the prior `--skip-vector-index --keep-data` upload already left the schema-only index the second phase needs.
2. **Cleanup never runs either.** `keep_data` is forced on for `--skip-upload`.
3. **The corpus is verified before anything is measured.** `Engine::corpus_row_count()` reads the count off the live server and the runner compares it with the corpus **measured on disk**:
   - fewer rows than the corpus holds, including zero → **hard error**;
   - more → warning;
   - an **estimate** that comes up short → warning only (see pgvector below);
   - a **probe failure** → a hard error that says *probe failure*, never "the corpus is empty";
   - no count implemented → a printed note that the reuse went unverified.

   Implemented for redis, valkey, dragonfly, kividb, vectorsets, qdrant, elasticsearch, opensearch, pgvector, mongodb. Chroma, Milvus and Weaviate all expose a count we have not wired up (#285); only Turbopuffer and Vertex are genuinely uncountable.

## Proof — server-side row counts, both binaries

Binaries confirmed distinct by a `strings` probe for a symbol added here (`did not create this corpus`: absent in pre, present in post). Digests are recorded but are not the load-bearing evidence — a debug binary embeds its build path, so they cannot falsify anything on their own.

**Path 2, three engines with different code paths** (pre = `0a1bb3f`, this branch's first commit; post = HEAD):

```
                              BEFORE            AFTER (pre)       AFTER (post)
qdrant      points_count        100          collection MISSING       100
vectorsets  VCARD idx           100                 0                 100
redis       DBSIZE              400                 0                 400
```
All three pre-fix runs printed `Cleanup (deleting index and data)` and exited 0; the qdrant one printed `Reuse check — server holds 100 of 100 expected rows` first, then deleted the collection it had just certified. Post-fix all three print `Keep data (--skip-upload did not create this corpus, so it does not delete it)`.

**Path 1, vs master (`6f8b814`)** — redis `FT.INFO num_docs` 400 → **0** while printing `QPS: 825.2`; mongodb `countDocuments` 400 → **0** while printing 118.2/38.6 QPS; valkey `DBSIZE` 400 → **0**. All 400 → 400 on this branch.

**Probe failures no longer fabricate an empty corpus** (corpus intact in all three):
```
redis   FT.INFO ACL-denied, real num_docs=400
        → "could not read the server-side corpus size … (NoPerm: User lim has no
           permissions to run the 'FT.INFO' command). This is a PROBE failure, not a
           verdict on the corpus — the data may well be intact."   corpus after: 400
qdrant  dead gRPC port, real points_count=100  → same shape, names the connect error
mongo   dead port                              → same shape, names the topology error
```

**A wrong `vector_count` no longer disables the guard** (server holding 0 of 100, `datasets.json` under-declaring 50):
```
pre    Reuse check — SKIPPED (dataset does not declare … a corpus size)
       → QPS: 3171.7, Recall: 0.0000    exit 0, result file written
post   WARNING: dataset 'd238' declares vector_count 50 but its corpus on disk holds 100.
       The --skip-upload reuse check uses the MEASURED 100; fix vector_count …
       Experiment failed: … holds 0 of the 100 rows …    exit 1, no file
```

**The verdict now reaches the artifact** (2-config sweep, `e-m16` amputated to 50, `e-m32` intact at 100):

| run | rc | search files | outcome |
|---|---|---|---|
| default (`--exit-on-error` true) | 1 | 0 | m32's *correct* measurement is lost too |
| **`--exit-on-error false`** | 0 | 1 | m32 recall 1.0 published; summary `rejected_experiments` names `e-m16` — **the remedy the error message and README now teach** |
| `--allow-partial-corpus` | 0 | 2 | m16's wrong 0.42 published, tagged `waived_by_allow_partial_corpus: true` |

Every result file carries `params.corpus_reuse` — e.g. `{"status":"verified","expected_rows":100,"actual_rows":100,"actual_is_estimate":false,"waived_by_allow_partial_corpus":false}`.

## Engine state that `configure()` used to set

Making "configure never runs here" a documented contract required auditing what depends on it:

- **pgvector** — `distance_op` was empty on this path, splicing as `embedding  $1` and failing **every** query after a green reuse check. Now re-derived in `search()` (pure function of the dataset). `hnsw_ops_class` is *not* read in search — that half of the reported claim did not hold.
- **turbopuffer** — `distance_metric` defaulted to `cosine_distance`: an l2/dot dataset measured under the wrong metric, no error, plausible file. Re-derived.
- **milvus** — `metric_type` empty. Re-derived.
- **chroma** — `collection_id` comes from a server response, so it is not derivable; now resolved by name.
- **All five Redis-wire engines** — `commandstats_baseline: None` means *"RESETSTAT ran, counters are zero"*. With `configure()` skipped, nothing reset them, so `check_commandstats` compared this run against zero while the counters held every failure since server start — a hard error on a run in which nothing failed. A `commandstats_primed` flag disambiguates and `search()` primes exactly once. (This also restores the `CONFIG RESETSTAT` that master's `--skip-vector-index` path performed.)
- **vertex** — already self-heals in `search()`; untouched. The claim that it is inoperable did not hold.
- **mongodb** — `load_schema_types` in `search()` is kept as *defensive symmetry* with redis/valkey, and the comment now says so. It is not load-bearing for a pure search: the filter builders type literals off the JSON value and never read the cache.

## pgvector's count is an estimate on purpose — measured, not asserted

The original finding was measurement integrity: `count(*)` primed the page cache immediately before the search phase, converting a cold-cache run into a warm one. "Estimates only warn" addresses the abort behaviour and not that, so here is the cache half, measured on a cold 1M-row / 768-dim table built exactly like this engine's (SERIAL PK + `vector NOT NULL`, `STORAGE PLAIN`, never VACUUMed; **3906 MB, 500000 relpages**), postgres restarted between runs:

| | heap blocks touched | cache primed | cold wall clock |
|---|---|---|---|
| `SELECT count(*) FROM items` | 500,000 | **3906 MB** (the whole heap) | 1.58 s |
| `ANALYZE items` | 30,001 | **234 MB** | 0.84 s |

`EXPLAIN (ANALYZE, BUFFERS)` confirms the plan: `Parallel Seq Scan on items … Buffers: shared hit=96 read=499904`.

**Is ANALYZE cheap on a 1M-row table? Yes, and — more importantly — it is *bounded*.** ANALYZE samples `300 × default_statistics_target` = 30,000 rows **regardless of table size**, so its footprint is constant while `count(*)` grows linearly with the corpus. At 1536 dims (~7.8 GB) `count(*)` primes all 7.8 GB; ANALYZE still touches ~30,000 blocks.

**But bounded is not free**, and the body should not claim otherwise: ANALYZE still pulls ~234 MB — about 6% of this heap — into cache before the search phase, and it writes statistics. The perturbation is capped, not eliminated. That is stated in the shipped code comment and the README rather than left as a favourable silence.

Live behaviour: `Reuse check — server holds ≈100 of 100 expected rows`, then a clean search (which failed on *every* query before the `distance_op` fix).

## Merged with #263's start gate, and exercised rather than assumed

This branch is merged (not rebased — it is published, and rebasing it once already produced a non-fast-forward that must never be resolved by force-push) with master `01145d4`. #263 replaced the fixed-count `Barrier` in all 14 engine search harnesses with `start_gate`, touching the same worker-spawn and error-propagation paths this branch adds `corpus_row_count()` and a pre-search hard error to. The merge was textually conflict-free — which is exactly the case where a clean merge that does not compile is the risk — so it was verified, not assumed:

- **Both sides survive and compile.** `src/start_gate.rs` 994 lines, 14 engines routing through it, 11 `corpus_row_count` impls, 8 `prime_commandstats_if_needed` call sites, the `keep_data` forcing intact. `cargo build --bins --tests` clean.
- **The reuse error still reaches `exit(1)`.** #263 converted an in-search `return Err` into `fatal_search_error` + `break 'search_phase` so `pending_saves` is flushed first. My guard fires *before* the search phase and returns through `?` directly, so that restructuring does not intercept it. Live on the merged binary, against a half-deleted Qdrant collection: **`EXIT CODE = 1`**.
- **No partial or empty artifact for `--plot` to chart.** Same run: **0** search result files, **0** summary files, **0** chart lines, and #263's `wrote N completed search point(s)` message correctly does *not* fire (`pending_saves` is empty because nothing had run yet).
- **The complement works too** — guard passes → #263's gate runs a real search → `Reuse check — server holds 100 of 100 expected rows`, three reps, and with **no** `--keep-data` the collection still holds 100 afterwards, with `params.corpus_reuse` `{"status":"verified", …}` in the artifact.
- **INV-4 / INV-4b / INV-4c pass.** In all 8 search entry points across the five Redis-wire engines, `prime_commandstats_if_needed()?` sits immediately after the signature — before every dispatch and before every `WorkerPool::new` — so its early return cannot strand a gate (INV-4c's concern). No `Barrier` was added.

## Tests

**8 live integration tests across 5 engines**, all verified RED. Against master (`6f8b814`):

```
valkey   --skip-upload --skip-vector-index unlinked the corpus it was told to reuse
         (400 -> 0 keys) — issue #238
mongodb  --skip-upload --skip-vector-index dropped the collection it was told to
         reuse (400 -> 0 docs) — issue #238
redis    destroyed the indexed corpus (400 -> 0 docs)  [first commit]
```
Against this branch's first commit `0a1bb3f` (i.e. the review round's own regressions):
```
redis    --skip-upload without --keep-data deleted the corpus it reused  left: -1  right: 400
redis    recorded verdict: null   left: Null  right: "short"     (nothing reached the artifact)
redis    recorded verdict: null   left: Null  right: "surplus"
qdrant   --skip-upload without --keep-data deleted the collection it reused  left: 0  right: 400
kividb   KiviDB must report a count (hnsw_live_count), not degrade to a note
```

**Mutation probe (both directions).** With the guard mutated to fire only for configs whose name contains `redis`:
```
config named cfg238short   → test FAILED   (mutant killed)
config named redis-238-short → test ok     (mutant survives)
```
`Engine::name()` returns the *config* name, so the rename is what makes the test discriminating.

A note on KiviDB: its HNSW graph is independent of the hashes — UNLINKing 45 of 100 documents leaves `hnsw_live_count` at 100 **and** recall at 1.0000 (measured), so the count is right and there is nothing to catch. The test amputates with `FT.DROPINDEX` instead, which is what actually removes the searchable corpus.

**Gates**, on the tree merged with current master `01145d4` (#263's start gate):
- `cargo test --lib --bins`: **872 passed, 0 failed** across all six binaries (126 + 0 + 0 + 0 + 2 + 744). Master baseline is **860**; +12 is the new unit tests.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- `tests/overhead_invariants.rs` **9/9**, including `inv4_no_fixed_count_start_barrier`, `inv4_search_harnesses_route_through_the_start_gate` and `inv4_bare_start_gate_users_hold_an_abort_guard`. `integration_cli` 4/4.
- Suites, on dedicated containers: `integration_redis` 38/38, `integration_valkey` 26/26, `integration_qdrant` 27/27, `integration_mongodb` 19/19, `integration_kividb` 20/20 (`test_kividb_flat_algorithm_works` filtered — it hangs >40 min on this box, uses no `--skip-upload`, and hangs on master too).
- `integration_redis` and `integration_qdrant` gain the `REDIS_TEST_PORT` / `QDRANT_TEST_{REST,GRPC}_PORT` overrides the valkey/kividb/mongodb suites already had, so a session can test its own container rather than flushing a shared one.

**Correction to my earlier body:** I previously reported `integration_opensearch` failing 16/16 and attributed it to container contention. The suite passes 16/16 on master and on this branch; the failure was disk pressure — the shared cluster had crossed the 90% watermark, so index creation returned `index_create_block_exception: blocked by [FORBIDDEN/10/cluster create-index blocked (api)]`, tripping `assert!(resp.status().is_success())` everywhere. Not this change, but the stated cause was wrong. Also corrected: the claim that Valkey Search rejects a vector-less `FT.CREATE` — it does not on the image `docker-compose.test.yml` pins (valkey 9.1.1); the real result is stronger, master destroys 400 keys *while printing a QPS line and exiting 0*.

**On recall as a detector:** the `mean_recall: 1.0` I quoted for a half-deleted Qdrant collection is deletion-pattern-dependent, not a property. `random-100` has 9 queries with one ground-truth neighbour each in ids 0-8, so deleting the *upper* half removes no ground-truth point → 1.0, and deleting the *lower* half → 0.0. Recall is a coin flip on which rows went; a server-side count is not. The qualification is now in the code comments and the test doc, and the new Qdrant test deletes the upper half deliberately.

## Follow-ups filed, deliberately not fixed here

#279 (cardinality is not identity — a sibling config's corpus certifies as this one's on the 6 single-object engines), #280 (`--skip-if-exists` is a no-op without `--skip-upload`), #281 (`--reset-between-configs` on a run that never uploads), #282 (`--update-search-ratio` mutates the reused corpus by design), #283 (`--skip-vector-index` collapses every config into `<type>-no-vector`, defeating #151-4; the collision guard runs on pre-rewrite names), #284 (ES/OS `_count` is refresh-scoped), #285 (wire the count for Chroma/Milvus/Weaviate).

Also out of scope: #251 filter builders, #246 force-merge, #263 harness start gate, #264 results-JSON config recording (the reuse verdict should join its provenance block once both land); Valkey Search's own `--skip-vector-index` behaviour; the hardcoded VectorSets `idx` key (#236).

One new per-experiment cost, only on the `--skip-upload` path: measuring the corpus is a header read for npy/hdf5, but a full-file line count for the two `jsonl` datasets — cheap at their size, noted in the code.

Closes #238

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
