### PR TITLE
fix(vectorsets): derive the vector-set key per config so concurrent runs stop clobbering each other

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,12 +344,19 @@ experiment is listed in the summary under `rejected_experiments` — otherwise a
 sweep that lost most of its configs produces a summary and a chart
 indistinguishable from a complete one.
 
-**What the check cannot do: cardinality is not identity.** Only the four
-Redis-wire engines address a per-config index and keyspace (#151-4). MongoDB,
-pgvector, Elasticsearch/OpenSearch, Qdrant, Milvus and VectorSets each have ONE
-corpus object per server, shared by every config *and every dataset* — so a
-full-size corpus uploaded by a sibling config, or by a different dataset, passes.
-The count proves the corpus is the right SIZE, never that it is the right corpus.
+**What the check cannot do: cardinality is not identity.** Only the five
+Redis-wire engines address a per-config object: Redis / Valkey / Dragonfly /
+KiviDB each own an index plus a keyspace (#151-4), and VectorSets owns the single
+key `idx:<config>` (#236 — a vector set *is* one key). MongoDB, pgvector,
+Elasticsearch/OpenSearch, Qdrant and Milvus each have ONE corpus object per
+server, shared by every config *and every dataset* — so a full-size corpus
+uploaded by a sibling config, or by a different dataset, passes. The count proves
+the corpus is the right SIZE, never that it is the right corpus.
+
+On the five per-config engines a sibling's corpus does **not** pass, because the
+count is read from this config's own object. What still passes there is the same
+config re-run against a **different dataset** of equal size — the key is derived
+from the config name alone, not from the dataset.
 
 **pgvector's count is an estimate on purpose.** The engine never `VACUUM`s and
 forces `STORAGE PLAIN`, so `SELECT count(*) FROM items` plans a Seq Scan over the
@@ -382,7 +389,7 @@ config `name`: index `"<base>:<config>"` (base `idx`) with docs keyed
 `"<config>:<id>"`. This lets an M×EF_CONSTRUCTION **sweep** run all its configs
 against one server and coexist, so you can upload every config once and then
 search each in a later `--skip-upload` pass — each config reads its own graph, and
-memory is reported per-index via `FT.INFO` (issue #151-4).
+memory is reported per-config as `index_memory_bytes` (issue #151-4).
 
 **VectorSets** joined this in #236 with the same derivation and the same knobs, but
 a different shape: it has no RediSearch index and no doc keyspace — its entire
@@ -390,6 +397,21 @@ corpus is the **single key** `"<base>:<config>"` that `VADD`/`VSIM`/`VINFO`/`VCA
 address, so that key *is* the namespace and there is no doc-key prefix. Before #236
 every VectorSets config used the literal key `idx` and `configure()` opened with
 `DEL idx`, so starting a second config **deleted the first's entire corpus**.
+
+**Reading the memory numbers.** Every upload result file carries two figures, and
+on a coexisting sweep they mean different things:
+
+| field | source | scope |
+|---|---|---|
+| `index_memory_bytes` | `FT.INFO` (Redis / Valkey / Dragonfly / KiviDB), `MEMORY USAGE <key>` (VectorSets, #236) | **this config only** — the number to quote |
+| `used_memory` | `INFO memory` | **server-wide**: the SUM over every config resident at that moment |
+
+Before per-config isolation the two were interchangeable for VectorSets, because
+exactly one corpus could be resident. They are not interchangeable now, so a
+`used_memory` figure from a pre-#236 run and one from a current sweep are not
+comparable quantities. Note also that nothing deletes a legacy `idx` left by an old
+binary — it stays resident and inflates `used_memory` in every later result file
+until you `DEL` it.
 
 - `REDIS_INDEX_NAME` / `VALKEY_INDEX_NAME` / `DRAGONFLY_INDEX_NAME` / `KIVIDB_INDEX_NAME` /
   `VECTORSETS_INDEX_NAME` now set the **base namespace**, not the whole index name;
@@ -400,12 +422,23 @@ every VectorSets config used the literal key `idx` and `configure()` opened with
 - Indexes/keys written by any **pre-#151-4** binary are incompatible — re-upload.
   For VectorSets the equivalent cut-off is **pre-#236**: a corpus left under the bare
   `idx` key is neither found nor deleted by a current binary (`DEL idx` to reclaim it).
-  `--skip-upload` against a missing/mismatched index now **hard-errors** instead of
+  `--skip-upload` against a missing/mismatched index **hard-errors** instead of
   silently writing a `recall 0.0` file — including for VectorSets, where `VSIM`
   against a missing key returns an **empty array with no error**, so nothing
   downstream could otherwise tell "no data" from "no matches". The `VCARD`-based
-  corpus-reuse check (#238/#271) is what makes that promise true for the fifth
-  member of this family.
+  corpus-reuse check (#238/#271) is what makes that promise reach the fifth member
+  of this family.
+
+  **The guarantee is conditional on the tool knowing how many rows to expect.**
+  The check compares a server-side count against the corpus measured on disk; when
+  that expected count cannot be determined — sparse/`h5-multi` dataset layouts, an
+  unresolvable dataset path, or any error reading it — the verdict is
+  `Unverifiable`, which prints `Reuse check — SKIPPED` and **lets the run
+  proceed**. On that path a missing corpus is still measured and still published.
+  The result file records `params.corpus_reuse.status = "unverified"`, so it is not
+  silent, but it is not a hard error either: treat a `SKIPPED` line as "this run's
+  corpus was never verified" and check it yourself. (Inherited from #238/#271, not
+  specific to VectorSets.)
 - Two-phase coexistence sweep: `… --keep-data` (upload + search all configs,
   keep the data), then `… --skip-upload --keep-data --skip-if-exists false`
   (search each against its own index). Per-config prefixing stores N copies of
@@ -434,20 +467,32 @@ VSIM coerces a non-numeric attribute to `0` in a numeric comparison — so a
 (a two-sided range matches nothing → recall 0; a one-sided `lt`/`lte` matches
 everything). **Re-upload before searching.**
 
-`--skip-upload` does check that the corpus is **present and complete** on
-VectorSets too (`VCARD idx:<config>`, see above), but it cannot check that the
-corpus is *current*: a pre-#230 corpus is the right size and the wrong encoding,
-so it is found, the run succeeds, and only the recall number is wrong. That is the
-one failure mode left here.
+`--skip-upload` checks that the corpus is **present and complete** on VectorSets
+(`VCARD idx:<config>`, see above), but it cannot check that the corpus is
+*current*: a pre-#230 corpus is the right size and the wrong encoding, so it is
+found, the run succeeds, and only the recall number is wrong.
 
-Note the interaction with **#236**, which is a different cut-off. A corpus written
-by a pre-#236 binary sits under the bare key `idx`, not `idx:<config>`, so it is
-**not** found: `VCARD` answers 0, the reuse check classifies it `Short`, and the run
-is rejected. That is deliberate. `VSIM` against a missing key returns an **empty
-array with rc=0**, so the run would otherwise have published `recall 0.0` at an
-*inflated* QPS (an empty search returns instantly — measured 437 → 3413 QPS), with
-`failed_queries` still 0 and every guard keying off it silent. Re-upload, or
-`DEL idx` and re-upload.
+**In practice #236 makes that case unreachable by default**, because #230 shipped
+before #236: any corpus old enough to hold ISO-8601 strings is also old enough to
+sit under the bare key `idx`, where a current binary does not look for it. Such a
+corpus is **not** found — `VCARD idx:<config>` answers 0, the reuse check
+classifies it `Short`, and the run is rejected. That is deliberate: `VSIM` against
+a missing key returns an **empty array with rc=0**, so the run would otherwise have
+published `recall 0.0` at an *inflated* QPS (an empty search returns instantly —
+measured on a 400-vector corpus, `ef=400 parallel=1`: **637.6 QPS at recall 1.000
+with the corpus present, 2679.3 QPS at recall 0.000 with the key deleted** — 4.2×
+*faster* for measuring nothing), with `failed_queries: 0` in both runs and every guard keying off
+it silent. Re-upload, or `DEL idx` and re-upload.
+
+Exactly two things get you back to the wrong-encoding case, and neither is a
+migration path this README recommends:
+
+- `VECTORSETS_INDEX_NAME_EXACT=1` with the base left at `idx`, which pins a single
+  config onto the legacy key; or
+- renaming the legacy key by hand (`RENAME idx idx:<config>`).
+
+Both hand the old corpus to a current binary under a name it will accept. If you do
+either, you own the encoding check — the size check will pass.
 
 ### Charts
 

--- a/README.md
+++ b/README.md
@@ -435,11 +435,19 @@ VSIM coerces a non-numeric attribute to `0` in a numeric comparison — so a
 everything). **Re-upload before searching.**
 
 `--skip-upload` does check that the corpus is **present and complete** on
-VectorSets too (`VCARD idx`, see above), but it cannot check that the corpus is
-*current*: a pre-#230 corpus is the right size and the wrong encoding. And because
-the engine uses a single hardcoded key (`idx`, issue #236), there is not even a
-name change for the tool to detect. A stale corpus of the right size is found, the
-run succeeds, and only the recall number is wrong.
+VectorSets too (`VCARD idx:<config>`, see above), but it cannot check that the
+corpus is *current*: a pre-#230 corpus is the right size and the wrong encoding,
+so it is found, the run succeeds, and only the recall number is wrong. That is the
+one failure mode left here.
+
+Note the interaction with **#236**, which is a different cut-off. A corpus written
+by a pre-#236 binary sits under the bare key `idx`, not `idx:<config>`, so it is
+**not** found: `VCARD` answers 0, the reuse check classifies it `Short`, and the run
+is rejected. That is deliberate. `VSIM` against a missing key returns an **empty
+array with rc=0**, so the run would otherwise have published `recall 0.0` at an
+*inflated* QPS (an empty search returns instantly — measured 437 → 3413 QPS), with
+`failed_queries` still 0 and every guard keying off it silent. Re-upload, or
+`DEL idx` and re-upload.
 
 ### Charts
 

--- a/src/bin/vector_db_benchmark/engine/index_naming.rs
+++ b/src/bin/vector_db_benchmark/engine/index_naming.rs
@@ -1,5 +1,5 @@
 //! Per-config index-name and key-prefix derivation for the Redis-wire engines
-//! (Redis / Valkey / Dragonfly).
+//! (Redis / Valkey / Dragonfly / KiviDB / VectorSets).
 //!
 //! Issue #151-4: an M×EF_CONSTRUCTION sweep runs several configs of the same
 //! engine against one server. When every config used the literal index name
@@ -10,6 +10,12 @@
 //!
 //! The fix makes each config address a *disjoint* index + keyspace derived
 //! purely from `engine_config.name`, so N configs coexist on one server.
+//!
+//! VectorSets (#236) joined late. It has no FT index and no doc keyspace — its
+//! whole corpus is ONE Redis key that VADD/VSIM/VINFO/DEL address — so it uses
+//! [`derive_index_name`] for that key and has no use for [`derive_key_prefix`].
+//! The failure mode was identical and worse: `configure()` issued a literal
+//! `DEL idx`, so starting config B deleted config A's entire corpus outright.
 
 /// Map any char outside `[A-Za-z0-9_-]` to `_`. Guarantees: (a) the only `:` in
 /// a derived name/prefix is our own separator; (b) no SCAN glob metacharacters
@@ -86,6 +92,46 @@ mod tests {
             derive_index_name("NONEXISTENT_ENV_151_4", "idx", "redis-m-8"),
             "idx:redis-m-8"
         );
+    }
+
+    /// #236: two VectorSets configs must derive two DIFFERENT keys, because that
+    /// key is the whole corpus — a shared one means `configure()`'s `DEL` wipes
+    /// the sibling. Pinned to the literal expected strings so a future change to
+    /// the separator or the default base has to be made deliberately.
+    #[test]
+    fn vectorsets_configs_derive_distinct_keys() {
+        let a = derive_index_name("VECTORSETS_INDEX_NAME_UNSET_236", "idx", "vectorsets-fp32");
+        let b = derive_index_name("VECTORSETS_INDEX_NAME_UNSET_236", "idx", "vectorsets-q8");
+        assert_eq!(a, "idx:vectorsets-fp32");
+        assert_eq!(b, "idx:vectorsets-q8");
+        assert_ne!(a, b);
+        // And neither may be the bare legacy key that every config used to share.
+        assert_ne!(a, "idx");
+        assert_ne!(b, "idx");
+    }
+
+    /// The `_EXACT` escape hatch drops the config suffix entirely. Two configs
+    /// then DO collide by design — which is why `experiment::run`'s startup guard
+    /// rejects exact mode with >1 config for the engine. Uses a private env name
+    /// so no other test observes it.
+    #[test]
+    fn exact_pin_drops_the_config_suffix() {
+        let base_env = "VECTORSETS_INDEX_NAME_EXACTTEST_236";
+        std::env::set_var(base_env, "myvset");
+        std::env::set_var(format!("{base_env}_EXACT"), "1");
+        assert!(index_name_exact(base_env));
+        assert_eq!(
+            derive_index_name(base_env, "idx", "vectorsets-fp32"),
+            "myvset"
+        );
+        // Without the pin the base is still honoured, but the suffix returns.
+        std::env::remove_var(format!("{base_env}_EXACT"));
+        assert!(!index_name_exact(base_env));
+        assert_eq!(
+            derive_index_name(base_env, "idx", "vectorsets-fp32"),
+            "myvset:vectorsets-fp32"
+        );
+        std::env::remove_var(base_env);
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -494,11 +494,13 @@ pub trait Engine {
     ///   reuse went unverified and proceeds; an unimplemented probe must not make
     ///   the engine unusable.
     ///
-    /// Scope, and its limits. Only the four Redis-wire engines address a
-    /// per-config object (each config owns `idx:<config>` and a `<config>:`
-    /// keyspace, #151-4). MongoDB (`bench.vectors`), pgvector (`items`),
-    /// Elasticsearch/OpenSearch (`bench`), Qdrant (`benchmark`), Milvus and
-    /// VectorSets (`idx`, #236) each have exactly ONE such object per server,
+    /// Scope, and its limits. Only the five Redis-wire engines address a
+    /// per-config object: redis/valkey/dragonfly/kividb each own `idx:<config>`
+    /// plus a `<config>:` keyspace (#151-4), and VectorSets owns the single key
+    /// `idx:<config>` (#236 — a vector set is one key, so that key is the whole
+    /// object). MongoDB (`bench.vectors`), pgvector (`items`),
+    /// Elasticsearch/OpenSearch (`bench`), Qdrant (`benchmark`) and Milvus each
+    /// have exactly ONE such object per server,
     /// shared by every config and every dataset. On those, a full-size corpus
     /// uploaded by a SIBLING config — or by a different dataset entirely —
     /// certifies as this config's. The count therefore proves the corpus is the

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -495,12 +495,18 @@ impl VectorSetsEngine {
 
 impl Engine for VectorSetsEngine {
     /// Server-side corpus size, for the `--skip-upload` reuse precondition
-    /// (issue #238). `VCARD idx` — the cardinality of the vector set this engine
+    /// (issue #238). `VCARD <key>` — the cardinality of the vector set this engine
     /// searches. A missing key answers 0 (VCARD returns 0 for a non-existent key),
     /// which is exactly the "nothing to reuse" verdict we want.
     ///
-    /// The key is the hardcoded `idx` (issue #236): this count therefore cannot
-    /// distinguish two configs sharing one server, and neither can the search.
+    /// The key is this config's derived `idx:<config>` (#236), so unlike the
+    /// single-object engines the count is scoped to the corpus THIS config
+    /// uploaded — a sibling config's full-size corpus cannot certify as this
+    /// one's. It is also what makes the promise in the `--skip-upload` docs true
+    /// for VectorSets: `VSIM` against a missing key returns an empty array with
+    /// **no error**, so "the search succeeded" is not evidence of anything, and
+    /// this count is the only thing standing between a stale/absent corpus and a
+    /// published `recall 0.0` at inflated QPS.
     fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let mut conn = self.get_connection()?;
         // VCARD answers 0 for a key that does not exist, so a missing corpus and
@@ -1118,6 +1124,13 @@ impl Engine for VectorSetsEngine {
     fn get_memory_usage(&mut self) -> Option<serde_json::Value> {
         let mut conn = self.get_connection().ok()?;
 
+        // Server-wide used_memory is kept only as a SECONDARY/global figure.
+        // Before #236 it was also the per-config figure, and correctly so: the
+        // hardcoded key plus a destructive `DEL` in `configure()` guaranteed
+        // exactly ONE resident corpus, so server total == this config's cost.
+        // Per-config keys make coexistence possible, which makes this number the
+        // SUM over every resident config. Mirrors the same caveat on redis.rs;
+        // the per-config figure below is the honest one.
         let info_str: String = redis::cmd("INFO").arg("memory").query(&mut conn).ok()?;
         let used_memory: i64 = info_str
             .lines()
@@ -1125,6 +1138,19 @@ impl Engine for VectorSetsEngine {
             .and_then(|l| l.strip_prefix("used_memory:"))
             .and_then(|v| v.trim().parse().ok())
             .unwrap_or(0);
+
+        // Per-config memory. The FT engines get this from `FT.INFO`; `VINFO` has
+        // no memory field at all (verified live), but the corpus is a single key,
+        // so `MEMORY USAGE <key>` attributes it exactly. Reported under the same
+        // `index_memory_bytes` name the Redis-wire engines already publish, so
+        // downstream consumers need no special case. Best effort: a missing key or
+        // an older server degrades to null rather than to a wrong number.
+        let index_memory_bytes: Option<i64> = redis::cmd("MEMORY")
+            .arg("USAGE")
+            .arg(&self.config.key)
+            .query::<Option<i64>>(&mut conn)
+            .ok()
+            .flatten();
 
         // Vector-set stats via VINFO (quant-type, hnsw-m, vector-dim, size, ...).
         let index_info: Option<serde_json::Value> = redis::cmd("VINFO")
@@ -1135,6 +1161,7 @@ impl Engine for VectorSetsEngine {
 
         Some(serde_json::json!({
             "used_memory": used_memory,
+            "index_memory_bytes": index_memory_bytes,
             "shards": 1,
             "index_info": index_info,
         }))

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -15,6 +15,7 @@ use redis::Connection;
 use super::redis_utils;
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
+use crate::engine::index_naming::derive_index_name;
 use crate::engine::{Engine, SearchResults, UpdateSearchRatio, UploadStats};
 use vector_db_benchmark::parsers::datetime_to_epoch_secs;
 use vector_db_benchmark::query_filter::QueryFilter;
@@ -24,6 +25,11 @@ use vector_db_benchmark::start_gate::WorkerPool;
 /// VectorSets engine configuration
 #[derive(Clone)]
 pub struct VectorSetsConfig {
+    /// The Redis key holding this config's vector set — the single addressable
+    /// namespace for VADD/VSIM/VINFO/DEL. Derived per config (#236, mirroring
+    /// #151-4) so two VectorSets configs on one server cannot clobber each
+    /// other's corpus. See [`VectorSetsEngine::new`].
+    pub key: String,
     pub quant: String,
     pub m: i64,
     pub ef_construction: i64,
@@ -91,6 +97,16 @@ impl VectorSetsEngine {
             name: engine_config.name.clone(),
             redis_url,
             config: VectorSetsConfig {
+                // #236: VectorSets addresses ONE Redis key, and it used to be the
+                // literal `idx` for every config. Two configs (or two datasets, or
+                // two concurrent runs) on one server therefore shared one vector
+                // set and `configure()`'s `DEL` wiped the neighbour mid-flight.
+                // Derive it from the config name exactly as the Redis-wire engines
+                // derive their index name (#151-4), including the
+                // `VECTORSETS_INDEX_NAME` base override and its `_EXACT` pin.
+                // There is no key-prefix analogue: a vector set is a single key,
+                // not a keyspace of doc hashes, so this name IS the namespace.
+                key: derive_index_name("VECTORSETS_INDEX_NAME", "idx", &engine_config.name),
                 quant,
                 m,
                 ef_construction,
@@ -220,7 +236,8 @@ impl VectorSetsEngine {
 }
 
 /// Execute a batch of VADD commands via pipeline.
-/// VADD idx FP32 <vec_bytes> <id> <quant> M <M> EF <EF_CONSTRUCTION> [CAS] [SETATTR '<json>']
+/// VADD <key> FP32 <vec_bytes> <id> <quant> M <M> EF <EF_CONSTRUCTION> [CAS] [SETATTR '<json>']
+/// (`<key>` is `config.key`, the per-config vector set — see [`VectorSetsConfig::key`].)
 fn vadd_batch(
     conn: &mut Connection,
     config: &VectorSetsConfig,
@@ -234,7 +251,7 @@ fn vadd_batch(
         let vec_bytes: Vec<u8> = vectors[i].iter().flat_map(|f| f.to_le_bytes()).collect();
 
         let mut cmd = redis::cmd("VADD");
-        cmd.arg("idx")
+        cmd.arg(&config.key)
             .arg("FP32")
             .arg(&vec_bytes[..])
             .arg(ids[i].to_string())
@@ -341,7 +358,7 @@ fn encode_query_vector(query_vector: &[f32]) -> Vec<u8> {
 }
 
 /// Execute VSIM query and return (id, score) pairs.
-/// VSIM idx FP32 <vec_bytes> WITHSCORES COUNT <top> EF <ef> [FILTER '<expr>' [FILTER-EF <n>]]
+/// VSIM <key> FP32 <vec_bytes> WITHSCORES COUNT <top> EF <ef> [FILTER '<expr>' [FILTER-EF <n>]]
 /// Response: alternating [id, score, id, score, ...]
 /// Score conversion: 1.0 - score (VectorSets: 1=identical, 0=opposite)
 ///
@@ -350,6 +367,7 @@ fn encode_query_vector(query_vector: &[f32]) -> Vec<u8> {
 /// parse (all legitimate server latency).
 fn vsim_search(
     conn: &mut Connection,
+    key: &str,
     vec_bytes: &[u8],
     top: usize,
     ef: i64,
@@ -357,7 +375,7 @@ fn vsim_search(
     filter_ef: Option<i64>,
 ) -> Result<Vec<(i64, f64)>, String> {
     let mut cmd = redis::cmd("VSIM");
-    cmd.arg("idx")
+    cmd.arg(key)
         .arg("FP32")
         .arg(vec_bytes)
         .arg("WITHSCORES")
@@ -426,7 +444,7 @@ fn vadd_single(
     let vec_bytes: Vec<u8> = vector.iter().flat_map(|f| f.to_le_bytes()).collect();
 
     let mut cmd = redis::cmd("VADD");
-    cmd.arg("idx")
+    cmd.arg(&config.key)
         .arg("FP32")
         .arg(&vec_bytes[..])
         .arg(id.to_string())
@@ -465,12 +483,20 @@ impl Engine for VectorSetsEngine {
         let mut conn = self.get_connection()?;
 
         println!(
-            "Using VectorSets with QUANT: {}, M: {}, EF_CONSTRUCTION: {}, CAS: {}",
-            self.config.quant, self.config.m, self.config.ef_construction, self.config.cas
+            "Using VectorSets key '{}' with QUANT: {}, M: {}, EF_CONSTRUCTION: {}, CAS: {}",
+            self.config.key,
+            self.config.quant,
+            self.config.m,
+            self.config.ef_construction,
+            self.config.cas
         );
 
-        // Delete existing key if any
-        let _ = redis::cmd("DEL").arg("idx").query::<()>(&mut conn);
+        // Delete THIS config's key if any. Scoped to the derived per-config key
+        // (#236), so a sibling config's vector set on the same server survives —
+        // before, this `DEL idx` wiped every VectorSets config's corpus.
+        let _ = redis::cmd("DEL")
+            .arg(&self.config.key)
+            .query::<()>(&mut conn);
 
         self.commandstats_baseline = redis_utils::reset_commandstats(&mut conn)?;
         Ok(())
@@ -598,6 +624,9 @@ impl Engine for VectorSetsEngine {
 
         let measured_start = std::thread::scope(|s| -> Result<Instant, String> {
             let mut pool = WorkerPool::new(s, "vectorsets-search", parallel);
+            // Borrowed (not cloned) per worker: `&str` is Copy, and the scope
+            // guarantees `self` outlives every worker.
+            let key: &str = &self.config.key;
             for _ in 0..parallel {
                 let redis_url = self.redis_url.clone();
                 let neighbors = &neighbors;
@@ -642,6 +671,7 @@ impl Engine for VectorSetsEngine {
                         let prime_top = explicit_top.unwrap_or(10);
                         let _ = vsim_search(
                             &mut conn,
+                            key,
                             &encoded_queries[0],
                             prime_top,
                             ef,
@@ -679,6 +709,7 @@ impl Engine for VectorSetsEngine {
                         let query_start = Instant::now();
                         let results = vsim_search(
                             &mut conn,
+                            key,
                             &encoded_queries[idx],
                             top,
                             ef,
@@ -882,8 +913,15 @@ impl Engine for VectorSetsEngine {
                             // measurement behavior exactly.
                             let query_start = Instant::now();
                             let vec_bytes = encode_query_vector(&queries[idx]);
-                            let results =
-                                vsim_search(&mut conn, &vec_bytes, top, ef, filter_ref, filter_ef);
+                            let results = vsim_search(
+                                &mut conn,
+                                &config.key,
+                                &vec_bytes,
+                                top,
+                                ef,
+                                filter_ref,
+                                filter_ef,
+                            );
                             let query_time = query_start.elapsed().as_secs_f64();
 
                             match results {
@@ -1002,7 +1040,11 @@ impl Engine for VectorSetsEngine {
 
     fn delete(&mut self) -> Result<(), String> {
         let mut conn = self.get_connection()?;
-        let _ = redis::cmd("DEL").arg("idx").query::<()>(&mut conn);
+        // Scoped to this config's key (#236): tearing one config down leaves the
+        // other configs sharing the server intact.
+        let _ = redis::cmd("DEL")
+            .arg(&self.config.key)
+            .query::<()>(&mut conn);
         Ok(())
     }
 
@@ -1019,7 +1061,7 @@ impl Engine for VectorSetsEngine {
 
         // Vector-set stats via VINFO (quant-type, hnsw-m, vector-dim, size, ...).
         let index_info: Option<serde_json::Value> = redis::cmd("VINFO")
-            .arg("idx")
+            .arg(&self.config.key)
             .query::<redis::Value>(&mut conn)
             .ok()
             .map(|v| redis_utils::value_to_json(&v));
@@ -1037,7 +1079,7 @@ impl Engine for VectorSetsEngine {
         // VectorSets has no FT index; VINFO returns the vector-set metadata.
         // Errors on the BEFORE snapshot (vset not yet created) → index_info: null.
         let vinfo = redis::cmd("VINFO")
-            .arg("idx")
+            .arg(&self.config.key)
             .query::<redis::Value>(&mut conn)
             .ok()
             .map(|v| redis_utils::value_to_json(&v));

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -26,9 +26,12 @@ use vector_db_benchmark::start_gate::WorkerPool;
 #[derive(Clone)]
 pub struct VectorSetsConfig {
     /// The Redis key holding this config's vector set — the single addressable
-    /// namespace for VADD/VSIM/VINFO/DEL. Derived per config (#236, mirroring
-    /// #151-4) so two VectorSets configs on one server cannot clobber each
-    /// other's corpus. See [`VectorSetsEngine::new`].
+    /// namespace for VADD/VSIM/VINFO/VCARD/DEL. Derived per config (#236,
+    /// mirroring #151-4) so two VectorSets configs on one server cannot clobber
+    /// each other's corpus. See [`VectorSetsEngine::new`].
+    ///
+    /// This buys **data** isolation, not **measurement** isolation — see the
+    /// caveat in [`VectorSetsEngine::new`] before running two benchmarks at once.
     pub key: String,
     pub quant: String,
     pub m: i64,
@@ -108,14 +111,33 @@ impl VectorSetsEngine {
             redis_url,
             config: VectorSetsConfig {
                 // #236: VectorSets addresses ONE Redis key, and it used to be the
-                // literal `idx` for every config. Two configs (or two datasets, or
-                // two concurrent runs) on one server therefore shared one vector
-                // set and `configure()`'s `DEL` wiped the neighbour mid-flight.
-                // Derive it from the config name exactly as the Redis-wire engines
-                // derive their index name (#151-4), including the
-                // `VECTORSETS_INDEX_NAME` base override and its `_EXACT` pin.
-                // There is no key-prefix analogue: a vector set is a single key,
-                // not a keyspace of doc hashes, so this name IS the namespace.
+                // literal `idx` for every config. Two configs on one server
+                // therefore shared one vector set and `configure()`'s `DEL` wiped
+                // the neighbour mid-flight. Derive it from the config name exactly
+                // as the Redis-wire engines derive their index name (#151-4),
+                // including the `VECTORSETS_INDEX_NAME` base override and its
+                // `_EXACT` pin. There is no key-prefix analogue: a vector set is a
+                // single key, not a keyspace of doc hashes, so this name IS the
+                // namespace.
+                //
+                // SCOPE — read before relying on this for concurrency. The key is
+                // derived from the CONFIG NAME alone, so:
+                //  * two CONFIGS on one server are isolated (the fix);
+                //  * one config over two DATASETS still shares a key, and so do
+                //    two concurrent runs of the SAME config — identical to the
+                //    Redis family's design, hence not a regression, but not
+                //    covered either.
+                // And even for two configs this is DATA isolation, not
+                // MEASUREMENT isolation. `configure()` calls
+                // `redis_utils::reset_commandstats` → `CONFIG RESETSTAT`, which is
+                // server-GLOBAL: two concurrent runs each wipe the other's
+                // baseline, blinding `check_commandstats`' failed-call guard — the
+                // thing that catches a silently-failing VADD/VSIM. `INFO memory`
+                // is server-wide too (that half is handled: `get_memory_usage`
+                // also publishes a per-key `index_memory_bytes`). Concurrency was
+                // impossible before this change and is newly reachable, so the
+                // caveat is newly relevant: run concurrent VectorSets benchmarks
+                // on separate servers if the commandstats guard matters to you.
                 key: derive_index_name("VECTORSETS_INDEX_NAME", "idx", &engine_config.name),
                 quant,
                 m,

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -731,7 +731,7 @@ fn run_single_experiment(
     // `--keep-data` defaults to FALSE — so the plainest form of the flag
     // (`--skip-upload` alone) used to reuse a corpus, benchmark it, and then
     // delete it. Measured: qdrant 400 points -> collection MISSING, vectorsets
-    // `VCARD idx` 400 -> 0, redis `DBSIZE` 400 -> 0, all exit 0. A run that did
+    // `VCARD idx:<config>` 400 -> 0, redis `DBSIZE` 400 -> 0, all exit 0. A run that did
     // not create the corpus must not tear it down, whatever `--keep-data` says.
     let keep_data =
         args.skip_upload || (args.keep_data && (is_last_config || !args.reset_between_configs));
@@ -794,7 +794,7 @@ fn run_single_experiment(
         // do not create, drop, recreate or otherwise modify it. `configure()` is
         // destructive on 14 of the 15 engines (FT.DROPINDEX ... DD, SCAN+UNLINK,
         // collection.drop(), DROP TABLE, DELETE /collections/<n>, indices.delete,
-        // DEL idx — only Vertex is not), so it must NOT run here under any flag
+        // DEL <key> — only Vertex is not), so it must NOT run here under any flag
         // combination.
         //
         // This used to have an `else if args.skip_vector_index` arm that called

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -215,8 +215,8 @@ pub fn run(args: &Args) -> Result<(), String> {
     }
 
     // Collision guard (#151-4): among the selected configs, no two configs of the
-    // same destructive Redis-wire engine (redis/valkey/dragonfly/kividb) may derive
-    // the same index namespace, or a sweep would silently overwrite one config's graph
+    // same destructive Redis-wire engine (redis/valkey/dragonfly/kividb/vectorsets)
+    // may derive the same index namespace, or a sweep would silently overwrite one config's graph
     // and keyspace with another's (the exact bug this fix closes). Also fires when
     // an `*_INDEX_NAME_EXACT` pin is set with >1 config for that engine (every
     // config then resolves to the same verbatim base). In --skip-vector-index mode
@@ -232,6 +232,10 @@ pub fn run(args: &Args) -> Result<(), String> {
                 "valkey" => "VALKEY_INDEX_NAME",
                 "dragonfly" => "DRAGONFLY_INDEX_NAME",
                 "kividb" => "KIVIDB_INDEX_NAME",
+                // #236: VectorSets' "index" is the single Redis key holding the
+                // vector set, derived by the same helper, so it collides the same
+                // way and belongs in the same guard.
+                "vectorsets" => "VECTORSETS_INDEX_NAME",
                 _ => continue,
             };
             let idx = derive_index_name(base_env, "idx", &config.name);

--- a/tests/integration_vectorsets.rs
+++ b/tests/integration_vectorsets.rs
@@ -781,3 +781,231 @@ fn test_vectorsets_skip_upload_hard_errors_on_a_pre_236_corpus() {
     }
     std::fs::remove_dir_all(&proj.root).ok();
 }
+
+/// Issue #238/#271 family test, the VectorSets member that #271 did not ship:
+/// `corpus_row_count()` must be a LIVE read of THIS config's key, not a constant
+/// and not the old shared `idx`. Amputate the corpus behind the tool's back and
+/// the reported number has to follow.
+///
+/// kividb / mongodb / qdrant / valkey each got this test in #271; VectorSets did
+/// not, which is exactly why CI could not see that its probe was hardcoded to
+/// `idx` while #236 moved every other site to `idx:<config>`.
+#[test]
+fn test_vectorsets_corpus_row_count_tracks_the_live_key() {
+    wait_for_vectorsets();
+
+    let name = "vectorsets-rowcount";
+    let key = format!("idx:{name}");
+    let proj = common::write_match_any_cosine_project("vs-rowcount", &vectorsets_config(name), 8);
+    let n = expected_count(&proj.root);
+
+    let mut c = conn();
+    let _ = redis::cmd("DEL").arg(&key).query::<i64>(&mut c);
+
+    let port = test_port().to_string();
+    let env = [("REDIS_PORT", port.as_str())];
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            name,
+            "vs-rowcount",
+            TEST_HOST,
+            &env,
+            &["--keep-data", "--skip-search"]
+        ),
+        "phase 1 (upload) failed"
+    );
+    assert_eq!(vcard(&mut c, &key), n, "upload must land in '{key}'");
+
+    // Amputate half the corpus with VREM, straight on the server.
+    let half = n / 2;
+    for id in 0..half {
+        let removed: i64 = redis::cmd("VREM")
+            .arg(&key)
+            .arg(id.to_string())
+            .query(&mut c)
+            .expect("VREM");
+        assert_eq!(removed, 1, "VREM must actually remove element {id}");
+    }
+    assert_eq!(vcard(&mut c, &key), n - half);
+
+    let out = std::process::Command::new(common::binary_path())
+        .args([
+            "--engines",
+            name,
+            "--datasets",
+            "vs-rowcount",
+            "--host",
+            TEST_HOST,
+            "--skip-if-exists",
+            "false",
+            "--skip-upload",
+            "--keep-data",
+        ])
+        .current_dir(&proj.root)
+        .env("REDIS_PORT", &port)
+        .output()
+        .expect("run vector-db-benchmark");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        !out.status.success(),
+        "--skip-upload against a half-deleted vectorsets corpus must be a hard error.\n{combined}"
+    );
+    assert!(
+        combined.contains(&format!("holds {} of the {n} rows", n - half)),
+        "the count must track the amputation, proving it is a live read of '{key}' \
+         and not a constant or the old shared 'idx'.\n{combined}"
+    );
+
+    let _ = redis::cmd("DEL").arg(&key).query::<i64>(&mut c);
+    std::fs::remove_dir_all(&proj.root).ok();
+}
+
+/// Per-config memory attribution (#236 follow-on).
+///
+/// `get_memory_usage` reports server-wide `INFO memory:used_memory`. That number
+/// was *correct* as a per-config figure before this PR — the hardcoded key plus a
+/// destructive `DEL` in `configure()` guaranteed exactly one resident corpus. Now
+/// that configs coexist it is the SUM over all of them, so every config after the
+/// first over-reports (2× here, N× on an N-config sweep — and the coexistence
+/// test above is precisely that scenario).
+///
+/// `VINFO` carries no memory field, but the corpus is a single key, so
+/// `MEMORY USAGE <key>` attributes it exactly. This asserts the per-config figure
+/// does NOT grow when a sibling config lands on the same server, while the global
+/// `used_memory` does — i.e. that the two numbers now mean different things and
+/// the per-config one is the honest one.
+#[test]
+fn test_vectorsets_index_memory_is_per_config_not_server_wide() {
+    wait_for_vectorsets();
+
+    let name_a = "vectorsets-mem-a";
+    let name_b = "vectorsets-mem-b";
+    let key_a = format!("idx:{name_a}");
+    let key_b = format!("idx:{name_b}");
+
+    let proj_a = common::write_match_any_cosine_project("vs-mem-a", &vectorsets_config(name_a), 8);
+    let proj_b = common::write_match_any_cosine_project("vs-mem-b", &vectorsets_config(name_b), 8);
+
+    let mut c = conn();
+    for k in [key_a.as_str(), key_b.as_str()] {
+        let _ = redis::cmd("DEL").arg(k).query::<i64>(&mut c);
+    }
+
+    let port = test_port().to_string();
+    let env = [("REDIS_PORT", port.as_str())];
+
+    assert!(
+        common::run_binary_extra(
+            &proj_a.root,
+            name_a,
+            "vs-mem-a",
+            TEST_HOST,
+            &env,
+            &["--keep-data", "--skip-search"]
+        ),
+        "config A upload failed"
+    );
+    let (a_alone_index, a_alone_used) = read_upload_memory(&proj_a.root, name_a);
+
+    assert!(
+        common::run_binary_extra(
+            &proj_b.root,
+            name_b,
+            "vs-mem-b",
+            TEST_HOST,
+            &env,
+            &["--keep-data", "--skip-search"]
+        ),
+        "config B upload failed"
+    );
+    let (b_with_a_index, b_with_a_used) = read_upload_memory(&proj_b.root, name_b);
+
+    println!(
+        "#236 memory attribution: A alone index={a_alone_index} used_memory={a_alone_used} | \
+         B with A resident index={b_with_a_index} used_memory={b_with_a_used} | \
+         MEMORY USAGE {key_a}={} {key_b}={}",
+        memory_usage(&mut c, &key_a),
+        memory_usage(&mut c, &key_b),
+    );
+
+    // The per-config figure is attributable: B's own corpus is the same shape as
+    // A's, so B's index memory must stay in A's ballpark even though the SERVER
+    // now holds both. A 1.5× ceiling is far below the 2× a summed figure gives.
+    assert!(
+        b_with_a_index > 0 && a_alone_index > 0,
+        "per-config index_memory_bytes must be reported for both configs \
+         (A={a_alone_index}, B={b_with_a_index})"
+    );
+    assert!(
+        (b_with_a_index as f64) < 1.5 * a_alone_index as f64,
+        "index_memory_bytes must be THIS config's corpus, not the server sum: \
+         A alone={a_alone_index}, B with A resident={b_with_a_index}"
+    );
+    // …and it tracks the actual key, within the slack of the engine's own
+    // bookkeeping between the upload snapshot and this read-back.
+    let live_b = memory_usage(&mut c, &key_b);
+    assert!(
+        live_b > 0 && (b_with_a_index as f64) >= 0.5 * live_b as f64,
+        "index_memory_bytes ({b_with_a_index}) must track MEMORY USAGE {key_b} ({live_b})"
+    );
+    // And the two numbers demonstrably mean different things: the server-wide
+    // figure accounts for far more than this config's corpus, which is exactly
+    // why it cannot serve as the per-config one. Asserted as a floor rather than
+    // as growth between the two runs — `used_memory` is global state that any
+    // concurrently-running test moves in either direction, and a flaky assertion
+    // about the number we are de-emphasising would be its own kind of wrong. The
+    // inequality only gets safer as other corpora land.
+    assert!(
+        b_with_a_used > 2 * b_with_a_index,
+        "server-wide used_memory ({b_with_a_used}) should dwarf this config's own \
+         corpus ({b_with_a_index}); if they are the same number, the per-config \
+         figure is just the server total again"
+    );
+    let _ = a_alone_used; // reported above; not asserted (see note)
+
+    for k in [key_a.as_str(), key_b.as_str()] {
+        let _ = redis::cmd("DEL").arg(k).query::<i64>(&mut c);
+    }
+    std::fs::remove_dir_all(&proj_a.root).ok();
+    std::fs::remove_dir_all(&proj_b.root).ok();
+}
+
+/// `MEMORY USAGE <key>`, or 0 when the key is absent.
+fn memory_usage(conn: &mut redis::Connection, key: &str) -> i64 {
+    redis::cmd("MEMORY")
+        .arg("USAGE")
+        .arg(key)
+        .query::<Option<i64>>(conn)
+        .ok()
+        .flatten()
+        .unwrap_or(0)
+}
+
+/// `(index_memory_bytes, used_memory)` from an engine's upload result JSON.
+fn read_upload_memory(root: &std::path::Path, engine: &str) -> (i64, i64) {
+    let pattern = format!("{engine}-*-upload-*.json");
+    let dir = root.join("results");
+    let path = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            glob::Pattern::new(&pattern)
+                .unwrap()
+                .matches(&p.file_name().unwrap().to_string_lossy())
+        })
+        .unwrap_or_else(|| panic!("no upload result for {engine}"));
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+    let mem = &v["results"]["memory_usage"];
+    (
+        mem["index_memory_bytes"].as_i64().unwrap_or(-1),
+        mem["used_memory"].as_i64().unwrap_or(-1),
+    )
+}

--- a/tests/integration_vectorsets.rs
+++ b/tests/integration_vectorsets.rs
@@ -16,7 +16,14 @@
 //! grammar needs 8.8+). Start with:
 //!   docker run -d --rm -p 6398:6379 redis:8.8.0
 //! Run with:
-//!   VECTORSETS_PORT=6398 cargo test --test integration_vectorsets -- --test-threads=1
+//!   VECTORSETS_PORT=6398 cargo test --test integration_vectorsets
+//!
+//! The suite is parallel-safe since #236: each config's corpus lives in its own
+//! `idx:<config-name>` vector set, so tests no longer share one `idx` key that
+//! each `configure()` deleted out from under its neighbours. (Before that fix the
+//! `--test-threads=1` flag was mandatory, not merely advisable — without it most
+//! of these tests failed at recall 0.000.) Every test below therefore MUST use a
+//! distinct engine-config name; that name is the isolation boundary.
 
 use std::time::{Duration, Instant};
 
@@ -381,6 +388,248 @@ fn test_binary_vectorsets_mixed_benchmark() {
     assert!(
         p50 <= p95 && p95 <= p99,
         "percentiles must be monotone: p50={p50} p95={p95} p99={p99}"
+    );
+    std::fs::remove_dir_all(&proj.root).ok();
+}
+
+// ── #236: per-config key namespacing ─────────────────────────────────────────
+
+/// Open a connection to the live server used by these tests.
+fn conn() -> redis::Connection {
+    let url = format!("redis://{}:{}/", TEST_HOST, test_port());
+    redis::Client::open(url.as_str())
+        .expect("redis client")
+        .get_connection()
+        .expect("redis connection")
+}
+
+/// `VCARD <key>` — element count of a vector set, `0` when the key is absent.
+/// This is the load-bearing read-back: it is answered by the SERVER about the
+/// SERVER's state, so it cannot be satisfied by a plausible-looking recall.
+fn vcard(conn: &mut redis::Connection, key: &str) -> i64 {
+    redis::cmd("VCARD").arg(key).query::<i64>(conn).unwrap_or(0)
+}
+
+/// `VDIM <key>` — dimensionality of the vectors stored in a vector set, `0` when
+/// the key is absent. Two configs uploaded at different dims therefore have
+/// distinguishable *contents*, not merely distinguishable counts.
+fn vdim(conn: &mut redis::Connection, key: &str) -> i64 {
+    redis::cmd("VDIM").arg(key).query::<i64>(conn).unwrap_or(0)
+}
+
+/// `vector_count` as written into the fixture's `datasets/datasets.json`, i.e.
+/// exactly how many vectors a completed upload must leave on the server.
+fn expected_count(root: &std::path::Path) -> i64 {
+    let raw = std::fs::read_to_string(root.join("datasets/datasets.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    v[0]["vector_count"].as_i64().expect("vector_count")
+}
+
+/// Issue #236 — two VectorSets configs sharing one server must own two DISJOINT
+/// vector sets.
+///
+/// Before this fix every config addressed the literal key `idx`, and
+/// `configure()` opened with `DEL idx`. So starting config B did not merely
+/// interleave with config A — it **deleted A's entire corpus**, then rebuilt the
+/// same key with its own. That is the #151-4 hazard the Redis family was fixed
+/// for, applied to a single key instead of an index + keyspace.
+///
+/// The assertions are deliberately all server-side (`VCARD`/`VDIM`/`EXISTS`),
+/// never recall. Two same-shaped corpora produce a perfectly plausible recall
+/// whichever one actually answered the query, which is precisely why this bug
+/// survived a suite full of recall assertions — see the repo's silent-wrong
+/// bug class. The two configs upload at DIFFERENT dimensionalities (8 and 16),
+/// so a surviving key can be attributed to its owner by content and not only by
+/// count.
+///
+/// RED on master: after run B, `VCARD idx:vectorsets-iso-a` is 0 — A's corpus is
+/// gone and only the shared `idx` exists.
+#[test]
+fn test_vectorsets_two_configs_do_not_clobber_each_other() {
+    wait_for_vectorsets();
+
+    let name_a = "vectorsets-iso-a";
+    let name_b = "vectorsets-iso-b";
+    // Must match `index_naming::derive_index_name("VECTORSETS_INDEX_NAME", "idx", …)`.
+    // Spelled out literally rather than imported: the point of the test is to pin
+    // the on-the-wire key, so it must fail if the derivation changes shape.
+    let key_a = format!("idx:{name_a}");
+    let key_b = format!("idx:{name_b}");
+    const LEGACY_KEY: &str = "idx";
+
+    let proj_a = common::write_match_any_cosine_project("vs-iso-a", &vectorsets_config(name_a), 8);
+    let proj_b = common::write_match_any_cosine_project("vs-iso-b", &vectorsets_config(name_b), 16);
+    let n_a = expected_count(&proj_a.root);
+    let n_b = expected_count(&proj_b.root);
+
+    let mut c = conn();
+    // Clean slate for exactly the three keys this test reasons about (never
+    // FLUSHALL — the suite shares one server with the other VectorSets tests).
+    for k in [key_a.as_str(), key_b.as_str(), LEGACY_KEY] {
+        let _ = redis::cmd("DEL").arg(k).query::<i64>(&mut c);
+    }
+
+    let port = test_port().to_string();
+    let env = [("REDIS_PORT", port.as_str())];
+
+    // ── Run config A, keeping its data resident ──
+    assert!(
+        common::run_binary_extra(
+            &proj_a.root,
+            name_a,
+            "vs-iso-a",
+            TEST_HOST,
+            &env,
+            &["--keep-data"]
+        ),
+        "config A run failed"
+    );
+    // Snapshot rather than assert here: every assertion is deferred to the end so
+    // that a regression prints the WHOLE before/after picture (including what
+    // landed in the legacy shared key) instead of aborting at the first symptom.
+    let card_a_after_a = vcard(&mut c, &key_a);
+    println!(
+        "#236 read-back after config A: VCARD {key_a}={card_a_after_a} (VDIM {}) | \
+         legacy VCARD {LEGACY_KEY}={} (VDIM {})",
+        vdim(&mut c, &key_a),
+        vcard(&mut c, LEGACY_KEY),
+        vdim(&mut c, LEGACY_KEY),
+    );
+
+    // ── Run config B against the SAME server ──
+    assert!(
+        common::run_binary_extra(
+            &proj_b.root,
+            name_b,
+            "vs-iso-b",
+            TEST_HOST,
+            &env,
+            &["--keep-data"]
+        ),
+        "config B run failed"
+    );
+
+    // Both corpora coexist, each with its own count …
+    let card_a = vcard(&mut c, &key_a);
+    let card_b = vcard(&mut c, &key_b);
+    println!(
+        "#236 read-back after config B: VCARD {key_a}={card_a} (VDIM {}), \
+         VCARD {key_b}={card_b} (VDIM {}) | legacy VCARD {LEGACY_KEY}={} (VDIM {})",
+        vdim(&mut c, &key_a),
+        vdim(&mut c, &key_b),
+        vcard(&mut c, LEGACY_KEY),
+        vdim(&mut c, LEGACY_KEY),
+    );
+    assert_eq!(
+        card_a_after_a, n_a,
+        "config A must upload into its own key '{key_a}' (#236)"
+    );
+    assert_eq!(
+        card_a, n_a,
+        "config B clobbered config A's corpus (#236): VCARD {key_a} = {card_a}, expected {n_a}"
+    );
+    assert_eq!(
+        card_b, n_b,
+        "config B did not land in its own key (#236): VCARD {key_b} = {card_b}, expected {n_b}"
+    );
+
+    // … and neither key holds the other's vectors: the dims are the ones each
+    // config uploaded, so no key was rebuilt from the other's corpus.
+    assert_eq!(
+        vdim(&mut c, &key_a),
+        8,
+        "'{key_a}' does not hold A's 8-d vectors"
+    );
+    assert_eq!(
+        vdim(&mut c, &key_b),
+        16,
+        "'{key_b}' does not hold B's 16-d vectors"
+    );
+
+    // And nothing was written to the old shared key at all.
+    let legacy_exists: i64 = redis::cmd("EXISTS")
+        .arg(LEGACY_KEY)
+        .query(&mut c)
+        .unwrap_or(0);
+    assert_eq!(
+        legacy_exists, 0,
+        "the hardcoded shared key '{LEGACY_KEY}' must no longer be written (#236)"
+    );
+
+    // Teardown: this test opted into --keep-data, so it owns the cleanup.
+    for k in [key_a.as_str(), key_b.as_str(), LEGACY_KEY] {
+        let _ = redis::cmd("DEL").arg(k).query::<i64>(&mut c);
+    }
+    std::fs::remove_dir_all(&proj_a.root).ok();
+    std::fs::remove_dir_all(&proj_b.root).ok();
+}
+
+/// Issue #236, part 2 — VectorSets must PARTICIPATE in the #151-4 startup
+/// collision guard, not just derive a good default.
+///
+/// The derivation alone leaves one way back into the shared-key world: the
+/// `VECTORSETS_INDEX_NAME_EXACT` pin drops the per-config suffix, so N configs
+/// resolve to one verbatim key again. The Redis-family engines have that case
+/// rejected at startup; before this fix `experiment::run`'s guard did not know
+/// the string `"vectorsets"` at all, so the pin silently re-armed the bug.
+///
+/// Asserted on the ERROR TEXT, not merely a non-zero exit: without a live
+/// server (or with any other misconfiguration) the run would fail anyway, and a
+/// bare exit-code assertion would pass against a removed guard.
+#[test]
+fn test_vectorsets_exact_pin_with_two_configs_is_rejected_at_startup() {
+    let configs = serde_json::json!([
+        {
+            "name": "vectorsets-guard-a",
+            "engine": "vectorsets",
+            "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
+        },
+        {
+            "name": "vectorsets-guard-b",
+            "engine": "vectorsets",
+            "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
+        },
+    ]);
+    let proj = common::write_match_any_cosine_project(
+        "vs-guard",
+        &serde_json::to_string(&configs).unwrap(),
+        8,
+    );
+
+    let out = std::process::Command::new(common::binary_path())
+        .args([
+            "--engines",
+            "vectorsets-guard-*",
+            "--datasets",
+            "vs-guard",
+            "--host",
+            TEST_HOST,
+            "--skip-if-exists",
+            "false",
+        ])
+        .current_dir(&proj.root)
+        .env("REDIS_PORT", test_port().to_string())
+        .env("VECTORSETS_INDEX_NAME", "shared-vset")
+        .env("VECTORSETS_INDEX_NAME_EXACT", "1")
+        .output()
+        .expect("run vector-db-benchmark");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "exact-pinned sweep of 2 vectorsets configs must be rejected, not run: {combined}"
+    );
+    assert!(
+        combined.contains("derive the same index namespace"),
+        "the failure must be the #151-4 collision guard, not an incidental error: {combined}"
+    );
+    assert!(
+        combined.contains("VECTORSETS_INDEX_NAME_EXACT is set"),
+        "the guard must name the exact-pin as the cause so the fix is obvious: {combined}"
     );
     std::fs::remove_dir_all(&proj.root).ok();
 }

--- a/tests/integration_vectorsets.rs
+++ b/tests/integration_vectorsets.rs
@@ -650,15 +650,25 @@ fn test_vectorsets_exact_pin_with_two_configs_is_rejected_at_startup() {
 /// `Engine::corpus_row_count` (#271 — `VCARD <key>` for VectorSets) and hard-errors
 /// when the server holds fewer rows than the dataset declares.
 ///
-/// The legacy key is seeded with EXACTLY the expected row count. That is what
-/// makes the test sharp: a `corpus_row_count` that probed the old hardcoded `idx`
-/// — which is precisely what merging #271 into this branch produced before the
-/// key was threaded through it — would read 400 of 400, return `Ok`, and let the
-/// run proceed to measure the empty per-config key. The guard has to be reading
-/// THIS config's key for the error below to appear at all.
+/// Where the teeth actually are, stated precisely because an earlier version of
+/// this comment got it wrong. The legacy key is seeded with exactly the expected
+/// row count, which *looks* like the load-bearing part — as if a probe hardcoded
+/// to `idx` would read 400 of 400 and wave the run through. It would not: this
+/// test runs over a PRIVATE base (`BASE` below, not the literal `idx`, for the
+/// isolation reason given there), so a hardcoded probe reads an empty `idx`, gets
+/// 0 of 400, and hard-errors — passing the negative half for the wrong reason.
 ///
-/// A positive control follows the negative one so the test cannot pass merely by
-/// the guard rejecting everything.
+/// The half that actually fails against a wrong-key probe is the **positive
+/// control** at the end: `--skip-upload` against the corpus this config really
+/// uploaded must SUCCEED, and a probe reading `idx` sees 0 there and rejects it.
+/// Verified by counterfactual — with `corpus_row_count` patched back to
+/// `.arg("idx")`, this test fails at the positive control, not at any assertion
+/// above it. (`test_vectorsets_corpus_row_count_tracks_the_live_key` fails too,
+/// and its `holds 200 of the 400 rows` assertion IS a direct wrong-key detector.)
+///
+/// The seeding still earns its place: it makes the scenario the realistic one (a
+/// legacy corpus present, not merely absent) and proves the run is rejected even
+/// when a full-size corpus is sitting right there on the server.
 #[test]
 fn test_vectorsets_skip_upload_hard_errors_on_a_pre_236_corpus() {
     wait_for_vectorsets();
@@ -891,6 +901,7 @@ fn test_vectorsets_index_memory_is_per_config_not_server_wide() {
 
     let proj_a = common::write_match_any_cosine_project("vs-mem-a", &vectorsets_config(name_a), 8);
     let proj_b = common::write_match_any_cosine_project("vs-mem-b", &vectorsets_config(name_b), 8);
+    let n_b = expected_count(&proj_b.root);
 
     let mut c = conn();
     for k in [key_a.as_str(), key_b.as_str()] {
@@ -953,6 +964,29 @@ fn test_vectorsets_index_memory_is_per_config_not_server_wide() {
     assert!(
         live_b > 0 && (b_with_a_index as f64) >= 0.5 * live_b as f64,
         "index_memory_bytes ({b_with_a_index}) must track MEMORY USAGE {key_b} ({live_b})"
+    );
+    // …and it SCALES with the corpus rather than reporting a constant. Every
+    // assertion above is satisfied by a fixed per-key overhead figure, which is
+    // the plausible way `MEMORY USAGE` could be meaningless here (a module type
+    // with no `mem_usage` callback reports bare key overhead). Compare against a
+    // one-element vector set of the same dimensionality on the same server: 400
+    // elements must cost an order of magnitude more than 1.
+    let tiny_key = "idx:vs-mem-tiny";
+    let _ = redis::cmd("DEL").arg(tiny_key).query::<i64>(&mut c);
+    let mut seed = redis::cmd("VADD");
+    seed.arg(tiny_key).arg("VALUES").arg(8);
+    for d in 0..8 {
+        seed.arg(d.to_string());
+    }
+    seed.arg("solo");
+    seed.query::<i64>(&mut c)
+        .expect("seed 1-element vector set");
+    let tiny = memory_usage(&mut c, tiny_key);
+    let _ = redis::cmd("DEL").arg(tiny_key).query::<i64>(&mut c);
+    assert!(
+        tiny > 0 && b_with_a_index > 10 * tiny,
+        "index_memory_bytes must scale with the corpus, not report a constant: \
+         {n_b} elements = {b_with_a_index} B vs 1 element = {tiny} B"
     );
     // And the two numbers demonstrably mean different things: the server-wide
     // figure accounts for far more than this config's corpus, which is exactly


### PR DESCRIPTION
## The bug

`vectorsets.rs` hardcoded the key `idx` at every site. It never got the #151-4 /
PR #153 per-config namespacing that redis / valkey / dragonfly / kividb have, and
because there was no derived name, there was nothing for the startup collision
guard to detect either.

This is worse than the Redis-family version. VectorSets' whole corpus is **one
key**, and `configure()` opened with `DEL idx` — so starting config B did not
interleave with config A's data, it **deleted config A's corpus outright** and
rebuilt the same key with its own.

**Scope of the fix, precisely.** `derive_index_name` keys off `engine_config.name`
alone, so this fixes the **two-configs** case. One config across two *datasets*,
and two concurrent runs of the *same* config, still share a key — identical to the
Redis family's design, so not a regression, but not covered either.

And even for two configs it is **data** isolation, not **measurement** isolation:
`configure()` calls server-global `CONFIG RESETSTAT`, so two concurrent runs no
longer destroy each other's corpus but do still corrupt each other's commandstats
baseline — blinding the failed-call guard that catches a silently-failing
VADD/VSIM. Concurrency was impossible before this PR and is newly reachable, so
the caveat is newly relevant; it is documented at the derivation site. The
`used_memory` half of that problem is fixed below.

## The fix

```rust
key: derive_index_name("VECTORSETS_INDEX_NAME", "idx", &engine_config.name)
```

Same helper, same `<base>:<sanitized-config-name>` shape, same
`VECTORSETS_INDEX_NAME_EXACT` escape hatch, same defaulting as the four siblings.
No `derive_key_prefix` analogue — a vector set is a single key, not an index over
a keyspace of doc hashes, so this name *is* the namespace.

All eleven sites that named the key moved, since a half-migration is worse than
none: `configure` (`DEL`), `upload`→`vadd_batch` (`VADD`), `search` (`VSIM`, query
**and** the priming query), `search_mixed` (`VSIM` + `vadd_single`'s `VADD`),
`delete` (`DEL`), `get_memory_usage` + `server_metadata` (`VINFO`), and
`corpus_row_count` (`VCARD`). `vectorsets.rs` no longer contains the string `"idx"`
anywhere except the default-base argument.

> **What the test suite actually guards, which is less than eleven.** A mutation
> campaign over this branch points each site back at `idx` one at a time. Five
> sites are killed; **six have no guard at all** — `vadd_single`, `delete`,
> `configure`'s `DEL`, and both `VINFO` sites (the priming `VSIM` is a legitimate
> equivalent mutant, its result is `let _ =`-discarded). Two of those six are
> demonstrably silent-wrong when mutated: pointing `vadd_single` at `idx` leaves
> `VCARD idx = 399` while the searched corpus receives zero updates and
> `mixed_benchmark` stays green; pointing `delete` at `idx` leaks all 7 per-config
> keys with the suite still 12/12. And `search`/`search_mixed` are killed **only**
> by pre-existing recall tests, not by anything this PR added. The fix is correct
> at all eleven sites — this is a statement about coverage, not about the code.
> The `vadd_single` case is a pre-existing metric-validity bug (`update_count`
> counts client-side attempts, never the server's acceptance into the searched
> corpus); filed as **#293**, not fixed here.

`experiment::run`'s collision guard now maps `"vectorsets" => "VECTORSETS_INDEX_NAME"`.

## Two things the merge with #271 forced, and one it created

**`corpus_row_count` — a silent-wrong born from a clean merge.** #271 landed
`Engine::corpus_row_count()` for vectorsets as `VCARD idx`, hardcoded, with a doc
comment reading *"The key is the hardcoded `idx` (issue #236)"* — written before
this PR existed. Git conflicts only on the import line. Resolved naively you get
writes to `idx:<config>` and a reuse probe reading `idx`. Reproduced live on the
merge, seeding the legacy key with exactly the expected 400 rows:

```
Experiment stage: Reuse check — server holds 400 of 400 expected rows
→ QPS: 1924.5, Recall: 0.0000, Precision@returned: 0.0000, MRR: 0.0000
exit 0
```

Fixed in the merge commit, with a comment naming the hazard. #271 shipped
`corpus_row_count` tests for redis/kividb/mongodb/qdrant/valkey but **not**
vectorsets, which is why CI could not see this — that test is added here (`VREM`
half the corpus, assert `holds 200 of the 400 rows`).

**`get_memory_usage` — a metric that was right, made wrong by coexistence.** It
returns server-wide `used_memory`. That was *correct* per-config before this PR:
the hardcoded key plus the destructive `DEL` guaranteed exactly one resident
corpus. Now every config after the first reports the sum. `VINFO` has no memory
field, but the corpus is one key, so `MEMORY USAGE <key>` attributes it exactly —
published as `index_memory_bytes`, the same field the four FT engines already use.

```
A alone:            index_memory_bytes=287,740  used_memory=1,985,664
B, with A resident: index_memory_bytes=287,740  used_memory=2,319,864
MEMORY USAGE idx:vectorsets-mem-a=287,740  idx:vectorsets-mem-b=287,740
```

**Joining the family's guard — nothing new added, because #271 already gives it.**
VectorSets has no `ensure_index_exists` analogue, and `VSIM` on a missing key
returns an empty array with rc=0, so `failed_queries` stays 0 and the empty search
returns *fast*. Measured on this tree (400 vectors, `ef=400 parallel=1`, same
server, key deleted then `--skip-upload --allow-partial-corpus`):

```
FULL   VCARD=400 rps=637.55  recall=1.0  failed_queries=0
EMPTY  VCARD=0   rps=2679.26 recall=0.0  failed_queries=0
```

4.2× *faster* for measuring nothing. With `corpus_row_count` reading the derived
key, `--skip-upload` now routes through `check_corpus_reuse_precondition` →
`Short` → hard error, so that run is rejected instead of published. A
`VCARD`-in-`search` gate would be a second, redundant mechanism on the same path.

**The guarantee is conditional, and the README now says so.** When the expected row
count cannot be determined (sparse/`h5-multi` layouts, unresolvable dataset path),
the verdict is `Unverifiable` — prints `SKIPPED`, records
`params.corpus_reuse.status = "unverified"`, and **lets the run proceed**. Inherited
from #238/#271, filed separately as #290; scoped here, not fixed here.

## Migration

An `idx` key from a pre-#236 binary is not found and not deleted. **Accepted and
now loud**: the reuse check rejects the run rather than measuring nothing. `DEL idx`
to reclaim the memory and re-upload. Note it also keeps inflating `used_memory` in
every later result file until deleted.

## Verification — server-side, not recall

Two configs back-to-back on **one** live `redis:8.8.0`. All assertions are
`VCARD`/`VDIM`/`EXISTS` read off the server; a recall assertion cannot catch this,
because two same-shaped corpora produce a plausible recall whichever one answered.

**RED on master** (test file only, `src/` reverted):

```
#236 read-back after config A: VCARD idx:vectorsets-iso-a=0 (VDIM 0) | legacy VCARD idx=400 (VDIM 8)
#236 read-back after config B: VCARD idx:vectorsets-iso-a=0 (VDIM 0), VCARD idx:vectorsets-iso-b=0 (VDIM 0) | legacy VCARD idx=400 (VDIM 16)

panicked: assertion `left == right` failed: config A must upload into its own key 'idx:vectorsets-iso-a' (#236)
  left: 0
 right: 400
```

One key. After A it holds 400 8-d vectors; after B the *same* key holds 400 16-d
vectors. A's corpus is gone.

**GREEN on this branch** (verbatim):

```
#236 read-back after config A: VCARD idx:vectorsets-iso-a=400 (VDIM 8) | legacy VCARD idx=0 (VDIM 0)
#236 read-back after config B: VCARD idx:vectorsets-iso-a=400 (VDIM 8), VCARD idx:vectorsets-iso-b=400 (VDIM 16) | legacy VCARD idx=0 (VDIM 0)
```

(`EXISTS idx == 0` is asserted separately.)

The load-bearing assertion is `card_a_after_a == n_a` — config A's count
snapshotted **before** B runs. The two fixtures upload at different
dimensionalities (8 and 16) and the `VDIM` assertions check them, but that is
belt-and-braces, not what makes the test work: rebuilding both fixtures at dim 8
and relaxing both `VDIM` assertions leaves master RED with an identical
`left: 0 / right: 400`. Earlier revisions of this description claimed the differing
dims were what made a surviving key attributable; they are not.

Five new integration tests plus two `index_naming` unit tests. **Where the teeth
actually are**, since an earlier version of this body got it wrong: the migration
test runs over a *private* base, so its exact-count seeding is not what catches a
wrong-key probe. Counterfactual with `corpus_row_count` patched back to
`.arg("idx")`, live:

```
test_vectorsets_corpus_row_count_tracks_the_live_key        ... FAILED  (holds 200 of the 400 rows)
test_vectorsets_skip_upload_hard_errors_on_a_pre_236_corpus ... FAILED  (the POSITIVE CONTROL)
10 passed; 2 failed
```

Both catch it; the seeded-negative half does not. Corrected in the test's doc
comment.

Two of the new tests are the *unique* killer of their mutant:
`exact_pin_drops_the_config_suffix` for removing the `_EXACT` hatch (which had zero
coverage anywhere in the repo before this PR), and the startup-rejection test for
deleting the `"vectorsets" => "VECTORSETS_INDEX_NAME"` guard row. The memory floor
is the sole assertion that kills `index_memory_bytes = used_memory`, panicking with
`server-wide used_memory (2312344) should dwarf this config's own corpus
(2312344)`. Honest counterweights: the 10× scaling assertion added in the last
revision kills no mutant the suite did not already kill — the constant-1 case dies
one assertion earlier — so it is defence-in-depth against a server-side property
that cannot be expressed as a source mutation, not a new killer; and
`vectorsets_configs_derive_distinct_keys` is redundant with the pre-existing
`derive_index_name_appends_sanitized_config` and uses a *fake* env name, so the
literal `format!("idx:{name}")` in the integration tests is what actually pins the
wire key.

### Side effect: the integration suite is parallel-safe

Every test wrote to the same `idx` and each `configure()` wiped its neighbours
mid-flight, which is why CI pins `--test-threads=1`. At **default** test threads on
master this is a **race, not a number** — 11 runs at `fd92603`, dedicated
container, `FLUSHALL` between:

| master (`fd92603`, 7 tests) | frequency |
|---|---|
| 0 passed / 7 failed | 3/11 |
| 1 passed / 6 failed | 7/11 |
| 2 passed / 5 failed | 1/11 |

So 0–2 of 7 pass depending on interleaving. **This branch: 12/12 at default threads
×3, and 12/12 at `--test-threads=1`, with `KEYS *` empty after every run** — the
order-independence is real, not a lucky interleaving. Master carrying this same
test file scores 0/12 at default threads.

The `--test-threads=1` flag in `.github/workflows/ci.yml` is left alone — still
correct, just no longer load-bearing.

## Docs

`README.md` asserted the opposite of the code in **four** places, all now fixed:
the "Per-config index isolation" heading + knob list; the `--skip-upload`
destructive-configure list (`DEL <key>`); the #230 datetime section; and the
"cardinality is not identity" paragraph, which still said "only the **four**
Redis-wire engines" and listed VectorSets among the one-object-per-server engines
— the exact twin of the `engine/mod.rs` trait doc, fixed in Rust and initially
missed in Markdown.

Also: the #230 section was **chronologically impossible** (it claimed a pre-#230
corpus is silently found, while the next paragraph said pre-#236 corpora are
rejected — and pre-#230 ⊂ pre-#236, since `66fcaaa` predates this branch). Now
scoped to the only two things that reach it: `VECTORSETS_INDEX_NAME_EXACT=1` at
base `idx`, or `RENAME idx idx:<config>`.

`index_memory_bytes` was documented nowhere outside code comments and the section
that now owns it still said `FT.INFO`; there is now a table giving both memory
fields, their sources and their scopes, and noting that a pre-#236 `used_memory`
and a current one are not comparable quantities.

`experiment.rs`'s two stale comments (`VCARD idx` at :734, `DEL idx` at :797) are
fixed — comment-only; re-checked that #264 still merges clean over them.

## Merge state

`git merge-tree` against #264 (`feat/record-effective-config-212`): **zero conflict
markers**. #264 reroutes the `*_INDEX_NAME` reads through
`effective_config::env_or`/`env_flag` while my `exact_pin_drops_the_config_suffix`
drives them via `std::env::set_var`. **Verified rather than assumed** — performed
the merge in a scratch worktree and ran it live: 5/5 `index_naming` unit tests,
12/12 integration tests, 931 unit tests total.

## Gates

Baseline: master `fd92603` = **872**.

- `cargo test --lib --bins` — **874 passed, 0 failed** (lib 126,
  `vector-db-benchmark` 746, `generate-dataset` 2, three `bench_*` 0). +2 = the new
  `index_naming` tests; the 5 new integration tests are docker-gated.
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test --test integration_vectorsets` — **12/12** at default threads ×3, and
  12/12 at `--test-threads=1`
- `cargo test --test overhead_invariants` — 9/9

## Deliberately out of scope

- `experiment.rs`/`effective_config.rs` beyond the guard registration and two
  comments (#264).
- The `Unverifiable` reuse-guard hole — filed as **#290**.
- `update_count` counting client-side attempts rather than server acceptance —
  filed as **#293**.
- `src/vectorsets/{search,upload,configure}.rs` still hardcode `"idx"`. That module
  is **dead code that never compiles** (`src/lib.rs` does not declare it;
  `engine/mod.rs:25` resolves to `engine/vectorsets.rs`), and two open PRs are
  editing it. Filed as **#291** rather than deleted here.
- No test anywhere asserts the collision guard's *sanitize-collision* path (two
  distinct names collapsing to one token) for any engine — only the `_EXACT` path,
  which this PR adds. Filed as **#294**.
- The memory test cannot distinguish a per-config figure from any fixed fraction of
  the server total between its 1.5× ceiling and its 2× floor (`used_memory/3` is
  2.7× the true value and passes everything). Known, not fixed.
- `v0/engine/clients/vectorsets/*.py` still hardcode `"idx"`; a mixed v0/Rust
  workflow no longer shares a corpus.
- `sanitize_token` is non-injective, and its guard is per-invocation: two
  *sequential* single-config runs whose names sanitise together still clobber, as
  does `_EXACT` plus two sequential runs. Pre-existing and family-wide; all 19
  shipped `vectorsets-*` configs are sanitize-clean.
- The dataset-level and same-config-concurrency cases, and commandstats isolation
  (see Scope above).

Closes #236

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
