### PR TITLE
fix(skip-upload): an undeterminable corpus size is fatal, not a printed note (#290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,19 +327,34 @@ rules follow, and all three are enforced:
      failure*. It is never reported as "the corpus is empty": that names the wrong
      problem and invites a re-upload over a corpus that was fine.
    - the **dataset's own expected row count cannot be determined** → a hard error
-     as well (issue #290). That count is measured from the corpus *file*, so this
-     is squarely a `--skip-upload` situation: a `sparse`/`h5-multi` layout whose
-     files are not on this machine, a corpus file deleted to reclaim disk while
-     `tests.jsonl` (queries + ground truth) stayed behind, or a header read that
-     failed. Until #290 it printed a note and ran anyway — and over an empty
-     corpus that publishes `mean_recall: 0.0` with `failed_queries: 0` and exit 0.
-     It is the same outcome as a short corpus with *less* information, not a
-     milder one. `--allow-partial-corpus` waives it, and the waiver is recorded.
-   - no count implemented for the engine → a printed note that the reuse went
-     unverified. Implemented for Redis, Valkey, Dragonfly, KiviDB, VectorSets,
-     Qdrant, Elasticsearch, OpenSearch, pgvector and MongoDB. Chroma, Milvus and
-     Weaviate all expose a count we have simply not wired up yet; Turbopuffer and
-     Vertex are the only genuinely uncountable ones.
+     as well (issue #290), because it is the same outcome as a short corpus with
+     *less* information. Until #290 it printed a note and ran anyway, and over an
+     empty corpus that publishes `mean_recall: 0.0` with `failed_queries: 0` and
+     exit 0. Where the count comes from depends on the layout, and so does the
+     remedy:
+     - measurable layouts (`tar`, `h5`, `jsonl`, `hybrid` — 53 of the 57 shipped
+       datasets) read it from the corpus file's header/line count. **The check
+       fetches the dataset first**, using the same `get_path()` the search phase
+       is about to call, so "not downloaded yet" is not an error — only a corpus
+       that is neither present nor fetchable is. The realistic case is a corpus
+       file deleted to reclaim disk while `tests.jsonl` (queries + ground truth)
+       stayed behind, so the run still searches and still publishes.
+     - `sparse` and `h5-multi` have no cheap row count, so the number comes from
+       `vector_count` in `datasets.json` — and, unlike the shared-corpus upload
+       gate, **without** requiring every corpus file to be present locally, since
+       `--skip-upload` never uploads. Missing `vector_count` is the error, and
+       the message says so.
+
+     `--allow-partial-corpus` waives it, and the waiver is recorded.
+   - no count read back for the engine → a printed note that the reuse went
+     unverified, **whatever the dataset side says**: with neither side available
+     there is nothing to compare in either direction, so this never escalates to
+     an abort. A probe is implemented for Redis, Valkey, Dragonfly, KiviDB,
+     VectorSets, Qdrant, Elasticsearch, OpenSearch, pgvector and MongoDB. Chroma,
+     Milvus and Weaviate all expose a count we have simply not wired up yet;
+     Turbopuffer and Vertex are the only genuinely uncountable ones. (Qdrant's
+     probe is wired up but can reply without a `points_count`, which lands here
+     too — hence "no count read back" rather than "not implemented".)
 
    **On a sweep, the right remedy for a rejected config is `--exit-on-error false`**
    (`--exit-on-error` defaults to true, so one stale config otherwise kills the
@@ -350,8 +365,10 @@ rules follow, and all three are enforced:
 
 The verdict is recorded in every result file it applies to, under
 `params.corpus_reuse` (`status` — one of `verified`, `surplus`, `short`,
-`corpus_size_unknown`, `unverified` — plus `expected_rows`, `actual_rows`,
-`actual_is_estimate`, `waived_by_allow_partial_corpus`), and a rejected
+`corpus_size_unknown`, `unverified`, or `probe_failed`, which is written by the
+probe-failure branch and carries `detail` instead of the count fields — plus
+`expected_rows`, `actual_rows`, `actual_is_estimate`,
+`waived_by_allow_partial_corpus`), and a rejected
 experiment is listed in the summary under `rejected_experiments` — otherwise a
 sweep that lost most of its configs produces a summary and a chart
 indistinguishable from a complete one.
@@ -441,16 +458,18 @@ until you `DEL` it.
   corpus-reuse check (#238/#271) is what makes that promise reach the fifth member
   of this family.
 
-  **The guarantee is conditional on the tool knowing how many rows to expect.**
-  The check compares a server-side count against the corpus measured on disk; when
-  that expected count cannot be determined — sparse/`h5-multi` dataset layouts, an
-  unresolvable dataset path, or any error reading it — the verdict is
-  `Unverifiable`, which prints `Reuse check — SKIPPED` and **lets the run
-  proceed**. On that path a missing corpus is still measured and still published.
-  The result file records `params.corpus_reuse.status = "unverified"`, so it is not
-  silent, but it is not a hard error either: treat a `SKIPPED` line as "this run's
-  corpus was never verified" and check it yourself. (Inherited from #238/#271, not
-  specific to VectorSets.)
+  **The guarantee is conditional on the tool knowing how many rows to expect** —
+  and since #290 it stops rather than guesses. When the expected count cannot be
+  determined (an unmeasurable layout with no `vector_count`, or a corpus that is
+  neither on this machine nor fetchable), the verdict is `corpus_size_unknown`
+  and the run is a **hard error**, waivable with `--allow-partial-corpus`. Before
+  #290 that path printed `Reuse check — SKIPPED` and let the run proceed, so a
+  missing corpus was still measured and still published as `recall 0.0` at exit 0.
+  One softer case remains and still prints `SKIPPED`: when no server-side count is
+  read back at all (`status = "unverified"`, e.g. Chroma/Milvus/Weaviate/
+  Turbopuffer/Vertex), there is nothing to compare in either direction, so the run
+  continues — treat that `SKIPPED` line as "this run's corpus was never verified"
+  and check it yourself. (Inherited from #238/#271, not specific to VectorSets.)
 - Two-phase coexistence sweep: `… --keep-data` (upload + search all configs,
   keep the data), then `… --skip-upload --keep-data --skip-if-exists false`
   (search each against its own index). Per-config prefixing stores N copies of

--- a/README.md
+++ b/README.md
@@ -332,18 +332,26 @@ rules follow, and all three are enforced:
      empty corpus that publishes `mean_recall: 0.0` with `failed_queries: 0` and
      exit 0. Where the count comes from depends on the layout, and so does the
      remedy:
-     - measurable layouts (`tar`, `h5`, `jsonl`, `hybrid` — 53 of the 57 shipped
-       datasets) read it from the corpus file's header/line count. **The check
-       fetches the dataset first**, using the same `get_path()` the search phase
-       is about to call, so "not downloaded yet" is not an error — only a corpus
-       that is neither present nor fetchable is. The realistic case is a corpus
-       file deleted to reclaim disk while `tests.jsonl` (queries + ground truth)
-       stayed behind, so the run still searches and still publishes.
-     - `sparse` and `h5-multi` have no cheap row count, so the number comes from
-       `vector_count` in `datasets.json` — and, unlike the shared-corpus upload
-       gate, **without** requiring every corpus file to be present locally, since
-       `--skip-upload` never uploads. Missing `vector_count` is the error, and
-       the message says so.
+     - measurable layouts (`tar`, `h5`, `jsonl`, `hybrid`, and `sparse` — 56 of
+       the 57 shipped datasets) read it from the corpus file's header or line
+       count. **The check resolves the dataset first**, using the same
+       `get_path()` the search phase is about to call, so a dataset that is
+       simply not downloaded yet is fetched rather than rejected. Two things it
+       does *not* do, both worth knowing: it resolves only **after** the
+       server-side probe succeeds, so an unreachable server still aborts without
+       paying for a download; and it does **not** re-fetch a dataset whose
+       directory already exists. That second one is the realistic failure — a
+       corpus file deleted to reclaim disk while `tests.jsonl` (queries + ground
+       truth) stayed behind, so the run would still search and still publish. A
+       valid `link` will not repair it; delete the directory or restore the file.
+       The error says which of the two you have.
+     - `h5-multi` is the one layout with no cheap row count — its total is the
+       sum of 100 part headers — so its number comes from `vector_count` in
+       `datasets.json`, and, unlike the shared-corpus upload gate, **without**
+       requiring every part to be present locally, since `--skip-upload` never
+       uploads. Missing `vector_count` is the error, and the message says so.
+       `sparse` uses the same fallback only when `data.csr` is absent; when it is
+       present the header is read and the declaration is checked, not trusted.
 
      `--allow-partial-corpus` waives it, and the waiver is recorded.
    - no count read back for the engine → a printed note that the reuse went

--- a/README.md
+++ b/README.md
@@ -324,6 +324,15 @@ rules follow, and all three are enforced:
      ES index, a shard that did not answer) → a hard error that says *probe
      failure*. It is never reported as "the corpus is empty": that names the wrong
      problem and invites a re-upload over a corpus that was fine.
+   - the **dataset's own expected row count cannot be determined** → a hard error
+     as well (issue #290). That count is measured from the corpus *file*, so this
+     is squarely a `--skip-upload` situation: a `sparse`/`h5-multi` layout whose
+     files are not on this machine, a corpus file deleted to reclaim disk while
+     `tests.jsonl` (queries + ground truth) stayed behind, or a header read that
+     failed. Until #290 it printed a note and ran anyway — and over an empty
+     corpus that publishes `mean_recall: 0.0` with `failed_queries: 0` and exit 0.
+     It is the same outcome as a short corpus with *less* information, not a
+     milder one. `--allow-partial-corpus` waives it, and the waiver is recorded.
    - no count implemented for the engine → a printed note that the reuse went
      unverified. Implemented for Redis, Valkey, Dragonfly, KiviDB, VectorSets,
      Qdrant, Elasticsearch, OpenSearch, pgvector and MongoDB. Chroma, Milvus and
@@ -338,7 +347,8 @@ rules follow, and all three are enforced:
    so reach for it last, and only deliberately.
 
 The verdict is recorded in every result file it applies to, under
-`params.corpus_reuse` (`status`, `expected_rows`, `actual_rows`,
+`params.corpus_reuse` (`status` — one of `verified`, `surplus`, `short`,
+`corpus_size_unknown`, `unverified` — plus `expected_rows`, `actual_rows`,
 `actual_is_estimate`, `waived_by_allow_partial_corpus`), and a rejected
 experiment is listed in the summary under `rejected_experiments` — otherwise a
 sweep that lost most of its configs produces a summary and a chart

--- a/datasets/datasets.json
+++ b/datasets/datasets.json
@@ -1412,6 +1412,7 @@
   {
     "name": "synthetic-sparse-300",
     "vector_size": 300,
+    "vector_count": 150,
     "distance": "dot",
     "type": "sparse",
     "path": "synthetic-sparse-300",

--- a/src/bin/generate_dataset.rs
+++ b/src/bin/generate_dataset.rs
@@ -34,7 +34,8 @@ use rand::{Rng, SeedableRng};
 
 use vector_db_benchmark::readers::{write_npy_vectors, write_sparse_matrix};
 use vector_db_benchmark::synthetic::{
-    generate_hybrid, generate_sparse, write_neighbours_jsonl, SparseData,
+    generate_hybrid, generate_sparse, write_neighbours_jsonl, SparseData, SYNTHETIC_SPARSE_DIM,
+    SYNTHETIC_SPARSE_ROWS,
 };
 
 /// Dataset names as registered in `datasets/datasets.json`.
@@ -106,12 +107,21 @@ fn file_name(path: &Path) -> String {
 // ── sparse ──────────────────────────────────────────────────────────────────
 
 fn gen_sparse(base: &Path) -> Result<(), String> {
-    // dim=300, nnz=10, 150 docs, 10 queries, top-10 GT. Fixed seed → reproducible.
+    // nnz=10, 10 queries, top-10 GT. Fixed seed → reproducible. The corpus size
+    // and dimensionality come from shared constants so the `datasets.json` guard
+    // can check the declared vector_count against the number actually written.
     let SparseData {
         data,
         queries,
         neighbours,
-    } = generate_sparse(0x5A5A_5EED, 300, 10, 150, 10, 10);
+    } = generate_sparse(
+        0x5A5A_5EED,
+        SYNTHETIC_SPARSE_DIM,
+        10,
+        SYNTHETIC_SPARSE_ROWS,
+        10,
+        10,
+    );
 
     let dir = base.join(SPARSE_NAME);
     std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;

--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -49,14 +49,18 @@ pub struct Args {
     pub skip_upload: bool,
 
     /// Downgrade the `--skip-upload` reuse precondition from a hard error to a
-    /// warning (issue #238).
+    /// warning (issues #238, #290).
     ///
     /// By default a `--skip-upload` run aborts when the engine holds fewer rows
     /// than the dataset declares — including zero, i.e. a missing index — because
     /// recall is scored against ground truth for the FULL corpus and a short
     /// corpus therefore publishes a wrong number under a config name that claims
-    /// otherwise. Set this to measure a deliberately partial corpus, or when the
-    /// server-side count cannot be read at all (restrictive ACLs).
+    /// otherwise. It also aborts when the check cannot be made at all: when the
+    /// server-side count cannot be read (restrictive ACLs, unreachable server),
+    /// and when the dataset's own expected row count cannot be determined —
+    /// typically because its corpus is not on this machine, which is exactly the
+    /// `--skip-upload` situation (#290). Set this to run anyway; the waiver is
+    /// recorded in the result file under `params.corpus_reuse`.
     #[arg(long, default_value = "false")]
     pub allow_partial_corpus: bool,
 

--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -58,8 +58,10 @@ pub struct Args {
     /// otherwise. It also aborts when the probe for the server-side count FAILS
     /// (restrictive ACLs, unreachable server), and when the dataset's own
     /// expected row count cannot be determined even after the corpus has been
-    /// fetched — an unmeasurable layout with no `vector_count`, or a corpus that
-    /// is neither on this machine nor downloadable (#290).
+    /// resolved — an unmeasurable layout with no `vector_count`, a dataset that
+    /// is not on this machine, or a dataset directory that is here but has lost
+    /// its corpus file (#290). Note the last one is not re-downloaded: a path
+    /// that already exists is never re-fetched, whatever its link says.
     ///
     /// It does NOT abort when an engine simply has no row-count probe wired up
     /// (Chroma, Milvus, Weaviate, Turbopuffer, Vertex): that prints a note and

--- a/src/bin/vector_db_benchmark/cli.rs
+++ b/src/bin/vector_db_benchmark/cli.rs
@@ -55,12 +55,17 @@ pub struct Args {
     /// than the dataset declares — including zero, i.e. a missing index — because
     /// recall is scored against ground truth for the FULL corpus and a short
     /// corpus therefore publishes a wrong number under a config name that claims
-    /// otherwise. It also aborts when the check cannot be made at all: when the
-    /// server-side count cannot be read (restrictive ACLs, unreachable server),
-    /// and when the dataset's own expected row count cannot be determined —
-    /// typically because its corpus is not on this machine, which is exactly the
-    /// `--skip-upload` situation (#290). Set this to run anyway; the waiver is
-    /// recorded in the result file under `params.corpus_reuse`.
+    /// otherwise. It also aborts when the probe for the server-side count FAILS
+    /// (restrictive ACLs, unreachable server), and when the dataset's own
+    /// expected row count cannot be determined even after the corpus has been
+    /// fetched — an unmeasurable layout with no `vector_count`, or a corpus that
+    /// is neither on this machine nor downloadable (#290).
+    ///
+    /// It does NOT abort when an engine simply has no row-count probe wired up
+    /// (Chroma, Milvus, Weaviate, Turbopuffer, Vertex): that prints a note and
+    /// runs, with or without this flag. Set this to run anyway in the cases that
+    /// do abort; the waiver is recorded in the result file under
+    /// `params.corpus_reuse`.
     #[arg(long, default_value = "false")]
     pub allow_partial_corpus: bool,
 

--- a/src/bin/vector_db_benchmark/config.rs
+++ b/src/bin/vector_db_benchmark/config.rs
@@ -891,13 +891,29 @@ mod tests {
     /// expects, and no suite exercises `--skip-upload` against it. This catches
     /// the class from `datasets.json` alone, with no corpus on disk.
     ///
-    /// It deliberately does NOT check the value — nothing here can measure a
-    /// CSR corpus — only that a value exists. The sibling test above is what
-    /// polices values whose path advertises a size.
+    /// It also checks the VALUE, two ways from `datasets.json` alone plus one
+    /// that needs the corpus. `synthetic-sparse-300` is pinned to the
+    /// generator's `SYNTHETIC_SPARSE_ROWS`, and an `h5-multi` count must equal
+    /// the span its own parts declare — laion's 100 parts carry
+    /// `start_idx`/`end_idx`, so its 1e9 is checkable with no corpus and no
+    /// network, which matters because that layout stays TRUSTED at runtime.
+    /// Third, and only when the corpus happens to be on this machine: `sparse` is measurable now (`csr_row_count` reads `n_row` from
+    /// `data.csr`'s 24-byte header), so a developer who has run
+    /// `generate-dataset` gets the declaration policed for free. CI has no
+    /// corpus on disk, so there the value check is a no-op and only the presence
+    /// check runs — stated plainly because a reviewer measured exactly this gap:
+    /// setting `synthetic-sparse-300` to `300` (the dimension, not the row
+    /// count) left the whole suite green. What closes that at RUNTIME is the
+    /// header read: with `data.csr` present the measurement wins, so a wrong
+    /// declaration can no longer classify a correct corpus as `Short` or a short
+    /// one as `Surplus`. The residual is a wrong declaration on a machine that
+    /// does not have the corpus, where there is nothing to measure against.
+    /// `h5-multi` has no cheap count at all and is trusted outright.
     #[test]
     fn unmeasurable_shipped_layouts_declare_a_vector_count() {
         let configs = read_dataset_configs().expect("datasets.json must parse");
         let mut checked = 0;
+        let mut measured_against = 0;
         let mut missing = Vec::new();
         for (name, cfg) in &configs {
             if !matches!(
@@ -907,13 +923,80 @@ mod tests {
                 continue;
             }
             checked += 1;
-            if cfg.vector_count.filter(|&n| n > 0).is_none() {
+            let declared = cfg.vector_count.filter(|&n| n > 0);
+            let Some(declared) = declared else {
                 missing.push(format!(
-                    "  dataset '{name}' has layout '{}' (no measurable row count) but declares \
-                     vector_count {:?}",
+                    "  dataset '{name}' has layout '{}' (not measurable without its corpus) but \
+                     declares vector_count {:?}",
                     cfg.dataset_type.as_deref().unwrap_or(""),
                     cfg.vector_count,
                 ));
+                continue;
+            };
+            // Value pin 1, from datasets.json ALONE: the one shipped sparse
+            // dataset this repo generates itself is checked against the
+            // generator's own constant. Its name says 300, which is the
+            // DIMENSION — a reviewer proposed exactly that as the row count, and
+            // it would have made a correct 150-row corpus classify as `Short`.
+            if name == "synthetic-sparse-300" {
+                measured_against += 1;
+                let expected = vector_db_benchmark::synthetic::SYNTHETIC_SPARSE_ROWS as i64;
+                if declared != expected {
+                    missing.push(format!(
+                        "  dataset '{name}' declares vector_count {declared} but \
+                         generate-dataset writes {expected} rows (SYNTHETIC_SPARSE_ROWS); \
+                         note {} is its DIMENSION, not its row count",
+                        vector_db_benchmark::synthetic::SYNTHETIC_SPARSE_DIM,
+                    ));
+                }
+            }
+
+            // Value pin 2, also from datasets.json alone: an `h5-multi` count
+            // must equal the span its own parts describe. laion's 100 parts each
+            // carry start_idx/end_idx, so the declared total is checkable with
+            // no corpus and no network — and this layout is the one that stays
+            // TRUSTED at runtime, since summing 100 headers is not an option.
+            if cfg.dataset_type.as_deref() == Some("h5-multi") {
+                if let Some(parts) = cfg.path.get("data").and_then(|d| d.as_array()) {
+                    let span: i64 = parts
+                        .iter()
+                        .filter_map(|p| {
+                            Some(p.get("end_idx")?.as_i64()? - p.get("start_idx")?.as_i64()?)
+                        })
+                        .sum();
+                    if span > 0 {
+                        measured_against += 1;
+                        if span != declared {
+                            missing.push(format!(
+                                "  dataset '{name}' declares vector_count {declared} but its \
+                                 {} parts span {span} rows",
+                                parts.len()
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // Value check, only when the corpus is actually here (a no-op in CI).
+            if cfg.dataset_type.as_deref() == Some("sparse") {
+                let csr = cfg
+                    .path
+                    .as_str()
+                    .map(|p| datasets_dir().join(p).join("data.csr"));
+                if let Some(csr) = csr.filter(|p| p.exists()) {
+                    measured_against += 1;
+                    match vector_db_benchmark::readers::csr_row_count(csr.to_str().unwrap()) {
+                        Ok(rows) if rows != declared as u64 => missing.push(format!(
+                            "  dataset '{name}' declares vector_count {declared} but its \
+                             {} holds {rows} rows",
+                            csr.display()
+                        )),
+                        Ok(_) => {}
+                        Err(e) => missing.push(format!(
+                            "  dataset '{name}' has a data.csr that cannot be read: {e}"
+                        )),
+                    }
+                }
             }
         }
         missing.sort();
@@ -928,6 +1011,12 @@ mod tests {
             checked >= 4,
             "expected to find the shipped sparse/h5-multi datasets, found {checked}"
         );
+        // Not an assertion on `measured_against`: CI has no corpus on disk, so
+        // it is legitimately 0 there. Printed so a local run says whether the
+        // value check actually ran.
+        if measured_against > 0 {
+            println!("(value-checked {measured_against} sparse corpora present on this machine)");
+        }
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/config.rs
+++ b/src/bin/vector_db_benchmark/config.rs
@@ -879,36 +879,40 @@ mod tests {
         );
     }
 
-    /// A shipped dataset whose layout has NO cheap row count must declare a
-    /// `vector_count` (#290 review).
+    /// A shipped dataset that cannot be measured without its corpus must
+    /// declare a `vector_count` (#290 review).
     ///
-    /// `sparse` (CSR) and `h5-multi` cannot be measured from their files, so
-    /// `vector_count` is the only answer the `--skip-upload` reuse check can
-    /// get. Without it that check has nothing to compare a server-side count
-    /// against and the run is rejected — which is how `synthetic-sparse-300`
-    /// (150 rows, no declared count) was found, by reading the entry rather
-    /// than by any test: it is `sparse`, its files are exactly where the code
-    /// expects, and no suite exercises `--skip-upload` against it. This catches
-    /// the class from `datasets.json` alone, with no corpus on disk.
+    /// `h5-multi` has no cheap row count at all — its total is the sum of 100
+    /// part headers. `sparse` IS measurable now (`csr_row_count` reads `n_row`
+    /// from `data.csr`'s 24-byte header), but only where that file is, which
+    /// under `--skip-upload` is often not this machine. For both, then,
+    /// `vector_count` is the fallback the reuse check falls back TO, and without
+    /// it the check has nothing to compare a server-side count against and the
+    /// run is rejected. That is how `synthetic-sparse-300` (150 rows, no
+    /// declared count) was found — by reading the entry, not by any test: its
+    /// files are exactly where the code expects, and no suite exercises
+    /// `--skip-upload` against it. This catches the class from `datasets.json`
+    /// alone, with no corpus on disk.
     ///
     /// It also checks the VALUE, two ways from `datasets.json` alone plus one
-    /// that needs the corpus. `synthetic-sparse-300` is pinned to the
-    /// generator's `SYNTHETIC_SPARSE_ROWS`, and an `h5-multi` count must equal
-    /// the span its own parts declare — laion's 100 parts carry
-    /// `start_idx`/`end_idx`, so its 1e9 is checkable with no corpus and no
-    /// network, which matters because that layout stays TRUSTED at runtime.
-    /// Third, and only when the corpus happens to be on this machine: `sparse` is measurable now (`csr_row_count` reads `n_row` from
-    /// `data.csr`'s 24-byte header), so a developer who has run
-    /// `generate-dataset` gets the declaration policed for free. CI has no
-    /// corpus on disk, so there the value check is a no-op and only the presence
-    /// check runs — stated plainly because a reviewer measured exactly this gap:
-    /// setting `synthetic-sparse-300` to `300` (the dimension, not the row
-    /// count) left the whole suite green. What closes that at RUNTIME is the
-    /// header read: with `data.csr` present the measurement wins, so a wrong
-    /// declaration can no longer classify a correct corpus as `Short` or a short
-    /// one as `Surplus`. The residual is a wrong declaration on a machine that
-    /// does not have the corpus, where there is nothing to measure against.
-    /// `h5-multi` has no cheap count at all and is trusted outright.
+    /// that needs the corpus:
+    ///
+    /// 1. `synthetic-sparse-300` against the generator's own
+    ///    `SYNTHETIC_SPARSE_ROWS`. Its name says 300, which is the DIMENSION —
+    ///    a reviewer proposed exactly that as the row count, and it would have
+    ///    made a correct 150-row corpus classify as `Short`.
+    /// 2. An `h5-multi` count against the span its own parts declare: laion's
+    ///    100 parts carry `start_idx`/`end_idx`, so its 1e9 is checkable with no
+    ///    corpus and no network. That matters most for this layout, since it is
+    ///    the one still TRUSTED at runtime.
+    /// 3. Any `sparse` corpus that happens to be on this machine, measured. A
+    ///    no-op in CI, which has none.
+    ///
+    /// What closes the wrong-value class at RUNTIME is the header read: with
+    /// `data.csr` present the measurement wins, so no declaration can steer the
+    /// verdict. The residual is a wrong declaration on a machine WITHOUT the
+    /// corpus, where there is nothing to measure against — which is what checks
+    /// 1 and 2 exist to cover for the shipped set.
     #[test]
     fn unmeasurable_shipped_layouts_declare_a_vector_count() {
         let configs = read_dataset_configs().expect("datasets.json must parse");

--- a/src/bin/vector_db_benchmark/config.rs
+++ b/src/bin/vector_db_benchmark/config.rs
@@ -879,6 +879,57 @@ mod tests {
         );
     }
 
+    /// A shipped dataset whose layout has NO cheap row count must declare a
+    /// `vector_count` (#290 review).
+    ///
+    /// `sparse` (CSR) and `h5-multi` cannot be measured from their files, so
+    /// `vector_count` is the only answer the `--skip-upload` reuse check can
+    /// get. Without it that check has nothing to compare a server-side count
+    /// against and the run is rejected — which is how `synthetic-sparse-300`
+    /// (150 rows, no declared count) was found, by reading the entry rather
+    /// than by any test: it is `sparse`, its files are exactly where the code
+    /// expects, and no suite exercises `--skip-upload` against it. This catches
+    /// the class from `datasets.json` alone, with no corpus on disk.
+    ///
+    /// It deliberately does NOT check the value — nothing here can measure a
+    /// CSR corpus — only that a value exists. The sibling test above is what
+    /// polices values whose path advertises a size.
+    #[test]
+    fn unmeasurable_shipped_layouts_declare_a_vector_count() {
+        let configs = read_dataset_configs().expect("datasets.json must parse");
+        let mut checked = 0;
+        let mut missing = Vec::new();
+        for (name, cfg) in &configs {
+            if !matches!(
+                cfg.dataset_type.as_deref().unwrap_or(""),
+                "sparse" | "h5-multi"
+            ) {
+                continue;
+            }
+            checked += 1;
+            if cfg.vector_count.filter(|&n| n > 0).is_none() {
+                missing.push(format!(
+                    "  dataset '{name}' has layout '{}' (no measurable row count) but declares \
+                     vector_count {:?}",
+                    cfg.dataset_type.as_deref().unwrap_or(""),
+                    cfg.vector_count,
+                ));
+            }
+        }
+        missing.sort();
+        assert!(
+            missing.is_empty(),
+            "{} unmeasurable dataset(s) declare no vector_count, so --skip-upload cannot \
+             verify them (#290):\n{}",
+            missing.len(),
+            missing.join("\n"),
+        );
+        assert!(
+            checked >= 4,
+            "expected to find the shipped sparse/h5-multi datasets, found {checked}"
+        );
+    }
+
     #[test]
     fn path_implied_corpus_size_only_fires_on_real_magnitude_tokens() {
         let s = |v: &str| serde_json::Value::String(v.to_string());

--- a/src/bin/vector_db_benchmark/dataset.rs
+++ b/src/bin/vector_db_benchmark/dataset.rs
@@ -9,7 +9,7 @@ use crate::download;
 use vector_db_benchmark::query_filter::QueryConditions;
 use vector_db_benchmark::readers::metadata::MetadataItem;
 use vector_db_benchmark::readers::{
-    hdf5_train_row_count, npy_row_count, read_compound_data, read_compound_queries,
+    csr_row_count, hdf5_train_row_count, npy_row_count, read_compound_data, read_compound_queries,
     read_gt_neighbours, read_hdf5_vectors, read_jsonl_queries, read_jsonl_vectors,
     read_npy_vectors, read_sparse_matrix, SparseVector,
 };
@@ -127,24 +127,19 @@ impl Dataset {
                 "jsonl" => "jsonl",
                 _ => return Ok(None),
             },
-            // "sparse" (CSR) and "h5-multi" (many part files) are not measured
-            // here, so they fall back to the declared count via
-            // `unmeasurable_corpus_is_present`.
-            //
-            // This matters now: `msmarco-sparse-100K` / `-1M` are `sparse` AND
-            // declare a vector_count, so their gate target IS the declared
-            // number. What keeps that honest is the path-size CI check in
-            // config.rs — their leaf segments (`100K`, `1M`) advertise their
-            // size, so a wrong count fails CI from datasets.json alone, with no
-            // corpus on disk. The residual it does NOT cover is a correct count
-            // paired with the wrong `data.csr` (the two sizes share one query
-            // set), which would let the gate skip early.
-            //
-            // Closing that properly is cheap and worth doing: the CSR header's
-            // FIRST i64 is n_row, so a 24-byte read yields an exact row count —
-            // the same trick `npy_row_count` uses. Deliberately left out of the
-            // merge that introduced this collision so it lands with its own
-            // tests rather than riding in as a conflict resolution.
+            // "sparse" (CSR) IS measurable: the header's first i64 is n_row, so
+            // a 24-byte read gives an exact count — the same trick
+            // `npy_row_count` uses. Doing it here is what stops `datasets.json`
+            // being TRUSTED for this layout: a wrong declaration otherwise makes
+            // a correct corpus classify `Short` (false abort) or a short one
+            // classify `Surplus` (warn, publish the wrong number). It also
+            // closes the residual the config.rs path-size check could not:
+            // `msmarco-sparse-100K`/`-1M` share one query set, so a correct
+            // count paired with the WRONG `data.csr` used to pass.
+            "sparse" => "csr",
+            // "h5-multi" (many part files) is the one layout left with no cheap
+            // row count: the total is the sum of 100 part headers and the parts
+            // are not all present. It still falls back to the declared count.
             _ => return Ok(None),
         };
 
@@ -164,6 +159,18 @@ impl Dataset {
             "hdf5" => {
                 let s = path.to_str().ok_or("Invalid HDF5 path encoding")?;
                 hdf5_train_row_count(s).map(Some)
+            }
+            "csr" => {
+                // The corpus lives in <dir>/data.csr; queries.csr is a separate
+                // matrix and must never be counted as the corpus. An absent
+                // data.csr is the --skip-upload case (corpus on the server, not
+                // here), which is "unknown", not zero.
+                let csr = path.join("data.csr");
+                if !csr.exists() {
+                    return Ok(None);
+                }
+                let s = csr.to_str().ok_or("Invalid data.csr path encoding")?;
+                csr_row_count(s).map(Some)
             }
             _ => {
                 let file = if path.is_dir() {
@@ -275,16 +282,33 @@ impl Dataset {
         }
     }
 
-    /// Whether this layout has no cheap row count at all — `sparse` (CSR) and
-    /// `h5-multi` (many part files). For these the declared `vector_count` is
-    /// the only available answer to "how many rows should exist"; everything
-    /// else must be MEASURED (#224).
+    /// Whether anything exists at this dataset's local path — the corpus
+    /// directory or file — WITHOUT triggering a download.
+    ///
+    /// The `--skip-upload` check uses it to tell two failures apart that read
+    /// alike otherwise: a dataset that is not on this machine at all, and a
+    /// dataset directory that IS here but has lost its corpus file. The second
+    /// is not re-fetchable — [`Self::get_path`] returns early when the path
+    /// exists, so a valid `link` is never followed for it — and saying so is the
+    /// difference between an actionable error and a misleading one.
+    pub fn corpus_path_exists(&self) -> bool {
+        self.local_path().is_some()
+    }
+
+    /// Whether the declared `vector_count` may stand in when this layout's
+    /// corpus cannot be measured here.
+    ///
+    /// `sparse` IS measurable now — [`csr_row_count`] reads `n_row` out of
+    /// `data.csr`'s 24-byte header — but only when that file is on this machine,
+    /// which under `--skip-upload` it often is not. `h5-multi` is the one layout
+    /// with no cheap count at all: the total is the sum of 100 part headers.
+    /// Everything else must be MEASURED and is never allowed to fall back (#224).
     ///
     /// Deliberately says nothing about whether the files are present: callers
     /// that must not skip an upload want [`Self::unmeasurable_corpus_is_present`]
     /// as well, but the `--skip-upload` reuse check does not upload and so does
     /// not need it (#290 review).
-    pub fn has_no_cheap_row_count(&self) -> bool {
+    pub fn may_fall_back_to_declared_count(&self) -> bool {
         matches!(
             self.config.dataset_type.as_deref().unwrap_or(""),
             "sparse" | "h5-multi"

--- a/src/bin/vector_db_benchmark/dataset.rs
+++ b/src/bin/vector_db_benchmark/dataset.rs
@@ -275,6 +275,22 @@ impl Dataset {
         }
     }
 
+    /// Whether this layout has no cheap row count at all — `sparse` (CSR) and
+    /// `h5-multi` (many part files). For these the declared `vector_count` is
+    /// the only available answer to "how many rows should exist"; everything
+    /// else must be MEASURED (#224).
+    ///
+    /// Deliberately says nothing about whether the files are present: callers
+    /// that must not skip an upload want [`Self::unmeasurable_corpus_is_present`]
+    /// as well, but the `--skip-upload` reuse check does not upload and so does
+    /// not need it (#290 review).
+    pub fn has_no_cheap_row_count(&self) -> bool {
+        matches!(
+            self.config.dataset_type.as_deref().unwrap_or(""),
+            "sparse" | "h5-multi"
+        )
+    }
+
     /// Whether this is one of the layouts with no cheap row count AND all of its
     /// corpus files are on disk (no download attempted).
     ///

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -1733,7 +1733,7 @@ impl Engine for QdrantEngine {
             // "cannot tell", and `unwrap_or(0)` would turn that into "the corpus
             // is gone" — the exact fabrication `ft_info_num_docs` is careful to
             // avoid (see its `missing_field_is_none_not_zero` test). None here
-            // lands in `Unverifiable`, which says so out loud.
+            // lands in `NoServerCount`, which says so out loud.
             Ok(info) => Ok(info
                 .result
                 .and_then(|r| r.points_count)

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -1733,7 +1733,9 @@ impl Engine for QdrantEngine {
             // "cannot tell", and `unwrap_or(0)` would turn that into "the corpus
             // is gone" — the exact fabrication `ft_info_num_docs` is careful to
             // avoid (see its `missing_field_is_none_not_zero` test). None here
-            // lands in `NoServerCount`, which says so out loud.
+            // lands in `NoServerCount`, whose note covers this case explicitly
+            // ("or the engine replied without one") — the probe IS implemented
+            // for Qdrant, so a note claiming otherwise would be wrong.
             Ok(info) => Ok(info
                 .result
                 .and_then(|r| r.points_count)

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -2969,8 +2969,16 @@ mod tests {
         );
     }
 
-    /// The narrow, deliberate exception: layouts with no cheap row count may use
-    /// the declared count — but only once their corpus files are actually there.
+    /// The narrow, deliberate exception: a layout that cannot be measured here
+    /// may use the declared count — but only once its corpus files are there.
+    ///
+    /// Updated for #290: `sparse` is measurable now (`csr_row_count` reads
+    /// `n_row` from `data.csr`'s header), so the fallback no longer applies to
+    /// it once that file exists. This tightens the shared-corpus gate rather
+    /// than loosening it — the MEASURED corpus wins over a declared count, which
+    /// is exactly #224's rule finally reaching this layout — and a `data.csr`
+    /// that cannot be read is now an error instead of a silent fallback to a
+    /// number nothing checked.
     #[test]
     fn unmeasurable_layouts_fall_back_only_when_their_files_exist() {
         let dir = tempfile::tempdir().unwrap();
@@ -2991,12 +2999,48 @@ mod tests {
             "empty directory is not a corpus"
         );
 
+        // A data.csr that exists but cannot be read is NOT a licence to trust
+        // the declared count — that would let a corrupt corpus authorise the
+        // shared-corpus skip (#224's failure, reached from the corpus side).
         std::fs::write(dir.path().join("data.csr"), b"").unwrap();
+        let err = sparse
+            .corpus_completeness_target()
+            .expect_err("an unreadable data.csr must not silently fall back");
+        assert!(err.contains("not a readable CSR file"), "{err}");
+
+        // A readable one is MEASURED, and the measurement beats the declaration.
+        let rows: Vec<vector_db_benchmark::readers::SparseVector> = (0..3)
+            .map(|_| vector_db_benchmark::readers::SparseVector {
+                indices: vec![0],
+                values: vec![1.0],
+            })
+            .collect();
+        vector_db_benchmark::readers::write_sparse_matrix(
+            dir.path().join("data.csr").to_str().unwrap(),
+            &rows,
+        )
+        .unwrap();
         assert_eq!(
             sparse.corpus_completeness_target().unwrap(),
-            Some(500),
-            "CSR has no cheap row count, so the declared count is all we have"
+            Some(3),
+            "the corpus on disk is the authority, not the declared 500"
         );
+
+        // h5-multi still has no cheap count, so the fallback survives for it.
+        let multi = Dataset::new(DatasetConfig {
+            name: "multi-unit".to_string(),
+            dataset_type: Some("h5-multi".to_string()),
+            path: serde_json::json!({
+                "data": [{ "path": dir.path().join("data.csr").to_str().unwrap() }]
+            }),
+            distance: Some("cosine".to_string()),
+            vector_size: Some(3),
+            vector_count: Some(500),
+            link: None,
+            schema: None,
+            description: None,
+        });
+        assert_eq!(multi.corpus_completeness_target().unwrap(), Some(500));
     }
 
     #[test]

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -424,13 +424,20 @@ pub enum ReusePrecondition {
         expected: u64,
         approximate: bool,
     },
-    /// No server-side count came back for this engine (`corpus_row_count`
-    /// returned `Ok(None)`: unimplemented, or a reply that carried no count).
-    /// Proceed with a note — an engine we have not wired up must not become
-    /// unusable under `--skip-upload`.
+    /// No server-side count came back: `corpus_row_count` returned `Ok(None)`,
+    /// which happens either because no probe is wired up for this engine or
+    /// because the engine's reply carried no count (Qdrant with no
+    /// `points_count`). NOT a probe failure — that is an `Err` and is handled
+    /// before classification. Proceed with a note: an engine we have not wired
+    /// up must not become unusable under `--skip-upload`.
+    ///
+    /// Returned whenever the server side is missing, whatever the dataset side
+    /// says. With neither side available there is nothing to compare in either
+    /// direction, so a missing expected count adds no information and must not
+    /// escalate this to an abort (#290 review).
     NoServerCount(String),
-    /// The DATASET side of the comparison is missing: its expected row count
-    /// could not be determined at all. Fatal unless `--allow-partial-corpus`
+    /// The server side IS available but the DATASET side is not: the expected
+    /// row count could not be determined. Fatal unless `--allow-partial-corpus`
     /// (issue #290). This is the same outcome as `Short` with LESS information,
     /// not a milder one: the server may hold the whole corpus, part of it, or
     /// none of it, and recall is scored against ground truth for the FULL
@@ -481,18 +488,25 @@ pub fn classify_reuse_precondition(
     actual: Option<CorpusCount>,
     engine_name: &str,
 ) -> ReusePrecondition {
+    // The SERVER side is tested first, deliberately. If it is missing there is
+    // nothing to compare against in either direction, so an unavailable expected
+    // count adds no information — escalating to a fatal there would remove
+    // `--skip-upload` from exactly the engines that have no probe, protecting no
+    // number in exchange (#290 review).
+    let Some(actual) = actual else {
+        // Phrased as a gap on THIS side of the wire, not a limitation of the
+        // database: Chroma, Milvus and Weaviate all expose a count we have not
+        // wired up, and Qdrant's probe is wired up but can reply without one.
+        // Deliberately distinct from a probe FAILURE, which is an `Err` handled
+        // before classification and says "probe failure" out loud.
+        return ReusePrecondition::NoServerCount(format!(
+            "this tool read no server-side row count for config '{engine_name}' (either none \
+             is implemented for its engine yet, or the engine replied without one)"
+        ));
+    };
     let expected = match expected {
         Ok(v) => v,
         Err(why) => return ReusePrecondition::CorpusSizeUnknown(why),
-    };
-    let Some(actual) = actual else {
-        // Deliberately phrased as a gap in this tool, not a limitation of the
-        // database: Chroma, Milvus and Weaviate all expose a count, we simply
-        // have not wired one up yet.
-        return ReusePrecondition::NoServerCount(format!(
-            "no server-side row count is implemented here for the engine behind config \
-             '{engine_name}' yet"
-        ));
     };
     let (a, e, approximate) = (actual.rows, expected, actual.approximate);
     if a < e {
@@ -534,9 +548,20 @@ pub fn classify_reuse_precondition(
 /// not a reason to stop checking.
 ///
 /// Returns `Result<u64, _>` rather than `Result<Option<u64>, _>` (issue #290):
-/// "there is no count here" is not a success. The two ways it can fail — a read
-/// that blew up, and a layout/corpus that offers no count — carry different
-/// messages, where before both collapsed into one `None` at the call site.
+/// "there is no count here" is not a success. The three ways it can fail — a
+/// read that blew up, a corpus that is not on this machine, and an unmeasurable
+/// layout with no declared count — carry different messages, where before all
+/// three collapsed into one `None` at the call site.
+///
+/// For `sparse` (CSR) and `h5-multi` the declared `vector_count` is used
+/// WITHOUT requiring every corpus file to be present, which is where this
+/// deliberately parts company with `corpus_completeness_target()`. That
+/// function's file-presence gate exists to stop an UPLOAD being skipped over a
+/// half-present corpus (#188/#224); `--skip-upload` never uploads, so the gate
+/// protects nothing here and costs a great deal — `laion-…-1Billion` is
+/// `h5-multi` with 100 data parts (~3 TB) whose queries live in a separate
+/// file, so requiring all of them would make the check unpassable on exactly
+/// the upload-once/benchmark-later workflow it is meant to serve.
 fn reuse_expected_rows(dataset: &Dataset) -> Result<u64, String> {
     if let Some(measured) = dataset
         .measured_vector_count()
@@ -559,21 +584,30 @@ fn reuse_expected_rows(dataset: &Dataset) -> Result<u64, String> {
         }
         return Ok(measured);
     }
-    // Layouts with no cheap row count (sparse CSR, h5-multi) fall back to the
-    // declared count, but only when their files are actually present.
-    dataset
-        .corpus_completeness_target()
-        .map_err(|e| format!("determining the dataset's corpus size failed: {e}"))?
-        .ok_or_else(|| {
+    let declared = dataset
+        .config
+        .vector_count
+        .filter(|&n| n > 0)
+        .map(|n| n as u64);
+    let dataset_type = dataset.config.dataset_type.as_deref().unwrap_or("<none>");
+    if dataset.has_no_cheap_row_count() {
+        // Nothing to measure by design, so datasets.json IS the answer here.
+        return declared.ok_or_else(|| {
             format!(
-                "the corpus of dataset '{}' could not be measured on disk (dataset_type '{}', \
-                 path {}), and datasets.json's vector_count is only accepted as a fallback for \
-                 the 'sparse' and 'h5-multi' layouts, whose files must all be present",
-                dataset.config.name,
-                dataset.config.dataset_type.as_deref().unwrap_or("<none>"),
-                dataset.config.path,
+                "dataset '{}' uses the '{}' layout, which carries no cheap row count to measure, \
+                 and datasets.json declares no vector_count for it — so there is no number to \
+                 check the server against. Add \"vector_count\" to this dataset's entry in \
+                 datasets/datasets.json.",
+                dataset.config.name, dataset_type,
             )
-        })
+        });
+    }
+    Err(format!(
+        "the corpus of dataset '{}' is not on this machine to be measured (dataset_type '{}', \
+         path {}) — and it was not fetched either, so there is no number to check the server \
+         against",
+        dataset.config.name, dataset_type, dataset.config.path,
+    ))
 }
 
 /// Verify the promise `--skip-upload` makes: that the corpus it is told to reuse
@@ -588,15 +622,13 @@ fn reuse_expected_rows(dataset: &Dataset) -> Result<u64, String> {
 /// LOWER half gives `mean_recall: 0.0`. A metric that is a coin flip on the
 /// deletion pattern cannot be the guard.
 ///
-/// Repo policy on what is fatal: a condition that changes the reported number is
-/// a hard error; only things that affect indexing speed warn. So an exact count
-/// that comes up short is fatal, and so is being unable to determine the
-/// dataset's expected count at all (#290) — that is the same outcome with less
-/// information, not a milder one. `--allow-partial-corpus` waives both, and the
-/// waiver is stamped into the result file. What still only warns: a SURPLUS
-/// corpus, an ESTIMATED short count, and an engine that has no server-side row
-/// count wired up (`NoServerCount`) — refusing there would make `--skip-upload`
-/// unusable on those engines rather than protect a number.
+/// What is fatal: a short corpus changes the reported number, so an exact count
+/// that comes up short is a hard error; everything softer warns. Being unable to
+/// determine the dataset's expected count is fatal too (#290), because it is the
+/// same outcome as a short corpus with less information, not a milder one — but
+/// only once the tool has had its own chance to fetch the corpus (see below) and
+/// only when a server-side count IS available to have compared it against.
+/// `--allow-partial-corpus` waives both.
 ///
 /// Returns the verdict so it can be stamped into every result file this
 /// experiment writes.
@@ -609,6 +641,20 @@ fn check_corpus_reuse_precondition(
     if args.skip_search {
         return Ok(None);
     }
+
+    // Give the tool its own chance to make the corpus measurable BEFORE judging
+    // that it cannot be measured (#290 review). `read_queries()` opens with the
+    // same `get_path()` call in the search phase moments from now, which fetches
+    // a string-path dataset that is not on disk yet — so measuring first turned
+    // "not downloaded yet" into a hard error for every fetchable dataset on a
+    // fresh benchmark client, seconds before the tool would have fetched it.
+    //
+    // This adds no download the run was not already going to do: `--skip-search`
+    // returned above, so the search phase always follows, and it resolves the
+    // same path. The error is dropped on purpose — this is not the place that
+    // reports it, and `read_queries()` re-runs the identical resolution and
+    // fails properly if it must.
+    let _ = dataset.get_path();
 
     // Kept as a Result: an Err here is fatal below (#290), so degrading it to
     // "unknown" would be the very thing this check exists to prevent.
@@ -675,22 +721,24 @@ fn check_corpus_reuse_precondition(
         ReusePrecondition::CorpusSizeUnknown(why) => {
             // Same policy as Short, for the same reason: this changes the
             // reported number. The difference is only that we cannot say by how
-            // much (#290).
-            let held = match actual {
-                Some(c) => format!("{}{} rows", if c.approximate { "≈" } else { "" }, c.rows),
-                None => "not readable either".to_string(),
-            };
+            // much (#290). `actual` is always Some in this arm — a missing
+            // server-side count classifies as NoServerCount before we get here.
+            let held = actual
+                .map(|c| format!("{}{}", if c.approximate { "≈" } else { "" }, c.rows))
+                .unwrap_or_else(|| "?".to_string());
             let msg = format!(
                 "--skip-upload: the reuse check for config '{}' has nothing to compare against — \
                  the expected row count for dataset '{}' could not be determined ({}). The server \
-                 side of the comparison came back as {}. Unverified is not the same as intact: \
-                 recall/precision are scored against ground truth for the FULL corpus, so if the \
-                 corpus behind this config is empty or partial, continuing publishes a wrong \
-                 number (an empty corpus scores recall 0.0 with zero failed queries) under a \
-                 config name that claims otherwise. Make the dataset's corpus measurable on this \
-                 machine — the count is read from the corpus file itself — or drop --skip-upload \
-                 to upload it. --allow-partial-corpus measures whatever the server holds without \
-                 checking; the waiver is recorded in the result file.",
+                 holds {} rows, and this run cannot tell whether that is the whole corpus. \
+                 Unverified is not the same as intact: recall/precision are scored against ground \
+                 truth for the FULL corpus, so if the corpus behind this config is empty or \
+                 partial, continuing publishes a wrong number (an empty corpus scores recall 0.0 \
+                 with zero failed queries) under a config name that claims otherwise. The remedy \
+                 is whatever the reason above asks for — give this machine the dataset's corpus, \
+                 or declare its vector_count in datasets/datasets.json. On a sweep, add \
+                 --exit-on-error false so the configs that DO verify still publish their (correct) \
+                 numbers while this one is skipped. --allow-partial-corpus measures whatever the \
+                 server holds without checking; the waiver is recorded in the result file.",
                 engine.name(),
                 dataset.config.name,
                 why,
@@ -2482,20 +2530,68 @@ mod reuse_precondition_tests {
     // make --skip-upload unusable on that engine rather than protect a number.
     #[test]
     fn missing_server_side_count_is_the_soft_arm() {
-        let why = match classify_reuse_precondition(Ok(400), None, "chroma-y") {
-            ReusePrecondition::NoServerCount(w) => w,
+        let verdict = classify_reuse_precondition(Ok(400), None, "chroma-y");
+        let why = match &verdict {
+            ReusePrecondition::NoServerCount(w) => w.clone(),
             other => panic!("expected NoServerCount, got {other:?}"),
         };
+        // The tag that reaches the result file, so this pins the artifact too.
+        assert_eq!(verdict.status(), "unverified");
         assert!(
             why.contains("chroma-y"),
             "the note must name the config it could not count: {why}"
         );
-        // The wording must blame this tool, not the database: Chroma, Milvus and
-        // Weaviate all expose a count, we simply have not wired one up.
+        // The wording must blame this side of the wire, not the database, AND
+        // must not claim "not implemented" — Qdrant's probe IS implemented and
+        // lands here when the reply carries no points_count.
         assert!(
-            why.contains("implemented"),
-            "the note must read as a gap in this tool, not a database limitation: {why}"
+            why.contains("this tool read no server-side row count"),
+            "the note must read as a gap on this side of the wire: {why}"
         );
+        assert!(
+            why.contains("or the engine replied without one"),
+            "the note must also cover the implemented-but-answered-nothing case \
+             (Qdrant), not assert it is unimplemented: {why}"
+        );
+        // Positive control: with a count present the same call classifies.
+        assert_eq!(
+            classify_reuse_precondition(Ok(400), Some(CorpusCount::exact(400)), "chroma-y"),
+            ReusePrecondition::Ok {
+                actual: 400,
+                expected: 400,
+                approximate: false
+            }
+        );
+    }
+
+    // #290 review: with NEITHER side available there is nothing to compare in
+    // either direction, so an unavailable expected count must not escalate the
+    // soft arm into an abort — that would remove --skip-upload from exactly the
+    // five engines with no probe while protecting no number.
+    #[test]
+    fn neither_side_available_stays_the_soft_arm() {
+        let verdict = classify_reuse_precondition(
+            Err("corpus not on this machine".to_string()),
+            None,
+            "wv-z",
+        );
+        assert!(
+            matches!(verdict, ReusePrecondition::NoServerCount(_)),
+            "expected NoServerCount, got {verdict:?}"
+        );
+        assert_eq!(verdict.status(), "unverified");
+        // Positive control: the SAME unavailable expected count IS fatal once a
+        // server-side count exists to have compared it against.
+        let with_count = classify_reuse_precondition(
+            Err("corpus not on this machine".to_string()),
+            Some(CorpusCount::exact(0)),
+            "wv-z",
+        );
+        assert!(
+            matches!(with_count, ReusePrecondition::CorpusSizeUnknown(_)),
+            "expected CorpusSizeUnknown, got {with_count:?}"
+        );
+        assert_eq!(with_count.status(), "corpus_size_unknown");
     }
 
     // Issue #290: an unavailable EXPECTED count is its own verdict, distinct
@@ -2541,7 +2637,7 @@ mod reuse_precondition_tests {
         let err = reuse_expected_rows(&ds)
             .expect_err("a corpus that is not on disk has no expected row count");
         assert!(
-            err.contains("could not be measured on disk") && err.contains("reuse-unit"),
+            err.contains("is not on this machine to be measured") && err.contains("reuse-unit"),
             "the failure must name the dataset and why: {err}"
         );
         // Positive control: the SAME dataset, with the corpus present, measures.
@@ -2572,6 +2668,47 @@ mod reuse_precondition_tests {
         assert!(
             err.contains("measuring the corpus on disk failed"),
             "a read failure and 'this layout has no cheap count' must not read alike: {err}"
+        );
+        // Positive control: repair the same file and the same call measures it,
+        // so this cannot pass by erroring on everything.
+        let vectors: Vec<Vec<f32>> = (0..5).map(|i| vec![i as f32, 0.0, 0.0]).collect();
+        write_npy_vectors(dir.path().join("vectors.npy").to_str().unwrap(), &vectors).unwrap();
+        assert_eq!(
+            reuse_expected_rows(&dataset_at(dir.path(), "tar", Some(5))).unwrap(),
+            5
+        );
+    }
+
+    // #290 review: `sparse`/`h5-multi` have no header to read, so datasets.json's
+    // vector_count IS the expected count — and it must be usable WITHOUT every
+    // corpus file being present locally. `corpus_completeness_target()`'s
+    // file-presence gate exists to stop an UPLOAD being skipped (#188/#224);
+    // --skip-upload never uploads, and laion-1B is `h5-multi` with 100 parts
+    // (~3 TB) whose queries are a separate file, so demanding them all would make
+    // the check unpassable on the workflow it exists to serve.
+    #[test]
+    fn unmeasurable_layout_uses_the_declared_count_without_every_file() {
+        let dir = tempfile::tempdir().unwrap();
+        // A `sparse` dataset directory with the queries but NOT data.csr — the
+        // shape of a client that searches a server-side corpus it never held.
+        std::fs::write(dir.path().join("queries.csr"), b"\x00").unwrap();
+        assert_eq!(
+            reuse_expected_rows(&dataset_at(dir.path(), "sparse", Some(100_000))).unwrap(),
+            100_000,
+            "the declared count is the only available answer for this layout"
+        );
+
+        // Without a declared count there IS no answer — and the error must name
+        // vector_count, not send the operator hunting for files.
+        let err = reuse_expected_rows(&dataset_at(dir.path(), "sparse", None))
+            .expect_err("no measurement and no declaration is not a number");
+        assert!(
+            err.contains("vector_count") && err.contains("datasets/datasets.json"),
+            "the error must name the field to add, not the files: {err}"
+        );
+        assert!(
+            !err.contains("not on this machine"),
+            "an unmeasurable layout must not be reported as a missing corpus: {err}"
         );
     }
 

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -590,7 +590,15 @@ fn reuse_expected_rows(dataset: &Dataset) -> Result<u64, String> {
         .filter(|&n| n > 0)
         .map(|n| n as u64);
     let dataset_type = dataset.config.dataset_type.as_deref().unwrap_or("<none>");
-    if dataset.has_no_cheap_row_count() {
+    // Render the path as a plain string; `config.path` is a serde_json::Value,
+    // whose Display adds JSON quotes an operator has to look past.
+    let path = dataset
+        .config
+        .path
+        .as_str()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| dataset.config.path.to_string());
+    if dataset.may_fall_back_to_declared_count() {
         // Nothing to measure by design, so datasets.json IS the answer here.
         return declared.ok_or_else(|| {
             format!(
@@ -602,11 +610,24 @@ fn reuse_expected_rows(dataset: &Dataset) -> Result<u64, String> {
             )
         });
     }
+    // Two different situations, and conflating them sends the operator to the
+    // wrong remedy. `get_path()` returns early when the path already exists, so
+    // a dataset directory that is here but has lost its corpus file is NEVER
+    // re-fetched, however valid its link — saying "could not be fetched" there
+    // would describe an attempt that was never made.
+    if dataset.corpus_path_exists() {
+        return Err(format!(
+            "dataset '{}' is present at '{}' but its corpus file is not in it (dataset_type \
+             '{}'), so there is no number to check the server against. A dataset whose path \
+             already exists is never re-downloaded, so restore the corpus file — or delete '{}' \
+             to make the next run fetch it fresh",
+            dataset.config.name, path, dataset_type, path,
+        ));
+    }
     Err(format!(
-        "the corpus of dataset '{}' is not on this machine to be measured (dataset_type '{}', \
-         path {}) — and it was not fetched either, so there is no number to check the server \
-         against",
-        dataset.config.name, dataset_type, dataset.config.path,
+        "dataset '{}' has no corpus at '{}' on this machine (dataset_type '{}') and resolving it \
+         produced none, so there is no number to check the server against",
+        dataset.config.name, path, dataset_type,
     ))
 }
 
@@ -641,26 +662,31 @@ fn check_corpus_reuse_precondition(
     if args.skip_search {
         return Ok(None);
     }
+    // The other way a run measures nothing: `--skip-vector-index` on a dataset
+    // with no schema fields has no filter conditions to search for, so the
+    // search phase returns before `read_queries()`. Same rationale as
+    // `--skip-search` above, and checking it here also keeps the fetch below
+    // from downloading a corpus for a run that will publish nothing.
+    if args.skip_vector_index
+        && !dataset
+            .config
+            .schema
+            .as_ref()
+            .and_then(|s| s.as_object())
+            .map(|o| !o.is_empty())
+            .unwrap_or(false)
+    {
+        return Ok(None);
+    }
 
-    // Give the tool its own chance to make the corpus measurable BEFORE judging
-    // that it cannot be measured (#290 review). `read_queries()` opens with the
-    // same `get_path()` call in the search phase moments from now, which fetches
-    // a string-path dataset that is not on disk yet — so measuring first turned
-    // "not downloaded yet" into a hard error for every fetchable dataset on a
-    // fresh benchmark client, seconds before the tool would have fetched it.
+    // The SERVER side is probed FIRST — before the dataset is fetched — for the
+    // same reason `classify_reuse_precondition` tests it first: if it gives us
+    // nothing to compare against, fetching a corpus to measure buys nothing.
     //
-    // This adds no download the run was not already going to do: `--skip-search`
-    // returned above, so the search phase always follows, and it resolves the
-    // same path. The error is dropped on purpose — this is not the place that
-    // reports it, and `read_queries()` re-runs the identical resolution and
-    // fails properly if it must.
-    let _ = dataset.get_path();
-
-    // Kept as a Result: an Err here is fatal below (#290), so degrading it to
-    // "unknown" would be the very thing this check exists to prevent.
-    let expected = reuse_expected_rows(dataset);
-    let expected_rows: Option<u64> = expected.as_ref().ok().copied();
-
+    // This ordering is load-bearing, not tidiness. The fetch below can be
+    // hundreds of GB, and probing afterwards meant an unreachable or mis-ACL'd
+    // server — the case `--help` names — paid for the whole download before
+    // aborting, where master aborted having touched nothing.
     let actual = match engine.corpus_row_count() {
         Ok(v) => v,
         Err(e) => {
@@ -685,16 +711,55 @@ fn check_corpus_reuse_precondition(
         }
     };
 
+    // Only now, with a server-side number in hand that is worth comparing
+    // against, give the tool its own chance to make the corpus measurable before
+    // judging that it cannot be (#290 review). `read_queries()` opens with this
+    // same `get_path()` call, which fetches a string-path dataset that is not on
+    // disk — so measuring first turned "not downloaded yet" into a hard error
+    // for every fetchable dataset on a fresh benchmark client.
+    //
+    // Note what this does NOT claim: that the download is free. A run whose
+    // verdict is fatal (`Short`, `CorpusSizeUnknown`) now pays for the fetch
+    // before it aborts. That is the price of measuring rather than trusting, and
+    // it is bounded to the cases where a measurement could change the verdict.
+    // The error is dropped on purpose — this is not the place that reports it,
+    // and `read_queries()` re-runs the identical resolution and fails properly.
+    // The resolve error is KEPT, not dropped. When the fetch is what failed —
+    // a 404, a dead mirror — that status code is the whole answer, and it used
+    // to survive only as `Download attempt N/15 failed:` lines on stderr, with
+    // the final attempt's error printed nowhere at all.
+    let resolve_error: Option<String> = if actual.is_some() {
+        dataset.get_path().err()
+    } else {
+        None
+    };
+
+    // Kept as a Result: an Err here is fatal below (#290), so degrading it to
+    // "unknown" would be the very thing this check exists to prevent.
+    let expected = reuse_expected_rows(dataset).map_err(|why| match &resolve_error {
+        Some(e) => format!("{why}; resolving the dataset failed with: {e}"),
+        None => why,
+    });
+    let expected_rows: Option<u64> = expected.as_ref().ok().copied();
+
     let verdict = classify_reuse_precondition(expected, actual, engine.name());
     let approx_note = |approximate: bool| if approximate { "≈" } else { "" };
     let record = |waived: bool| {
-        json!({
+        let mut v = json!({
             "status": verdict.status(),
             "expected_rows": expected_rows,
             "actual_rows": actual.map(|c| c.rows),
             "actual_is_estimate": actual.map(|c| c.approximate).unwrap_or(false),
             "waived_by_allow_partial_corpus": waived,
-        })
+        });
+        // A waived `corpus_size_unknown` is a PUBLISHED result whose count was
+        // never checked. Without the reason, the file says the count was unknown
+        // but not why — and that is the artifact someone quotes months later.
+        // `probe_failed` has carried a `detail` since #238; this matches it.
+        if let ReusePrecondition::CorpusSizeUnknown(why) = &verdict {
+            v["detail"] = json!(why);
+        }
+        v
     };
 
     match &verdict {
@@ -723,9 +788,13 @@ fn check_corpus_reuse_precondition(
             // reported number. The difference is only that we cannot say by how
             // much (#290). `actual` is always Some in this arm — a missing
             // server-side count classifies as NoServerCount before we get here.
+            // The `None` arm is unreachable today: a missing server-side count
+            // classifies as `NoServerCount` above. It is a wording fallback
+            // rather than an `unwrap()` so that a future reordering degrades
+            // this message instead of panicking in the middle of a sweep.
             let held = actual
                 .map(|c| format!("{}{}", if c.approximate { "≈" } else { "" }, c.rows))
-                .unwrap_or_else(|| "?".to_string());
+                .unwrap_or_else(|| "an unreported number of".to_string());
             let msg = format!(
                 "--skip-upload: the reuse check for config '{}' has nothing to compare against — \
                  the expected row count for dataset '{}' could not be determined ({}). The server \
@@ -2426,7 +2495,7 @@ mod reuse_precondition_tests {
     use crate::config::DatasetConfig;
     use crate::dataset::Dataset;
     use crate::engine::CorpusCount;
-    use vector_db_benchmark::readers::write_npy_vectors;
+    use vector_db_benchmark::readers::{write_npy_vectors, write_sparse_matrix, SparseVector};
 
     /// A dataset rooted at an ABSOLUTE temp path, so `datasets_dir().join(abs)`
     /// resolves back to `abs` and no download is ever attempted.
@@ -2636,9 +2705,25 @@ mod reuse_precondition_tests {
         let ds = dataset_at(dir.path(), "tar", Some(400));
         let err = reuse_expected_rows(&ds)
             .expect_err("a corpus that is not on disk has no expected row count");
+        // The directory IS here — only the corpus file is gone — and `get_path()`
+        // returns early on an existing path, so this is precisely the case that
+        // a valid `link` will NOT repair. The message must say that rather than
+        // imply a download was tried (#290 review).
         assert!(
-            err.contains("is not on this machine to be measured") && err.contains("reuse-unit"),
-            "the failure must name the dataset and why: {err}"
+            err.contains("but its corpus file is not in it") && err.contains("reuse-unit"),
+            "the failure must name the dataset and the real remedy: {err}"
+        );
+        assert!(
+            err.contains("never re-downloaded"),
+            "it must warn that an existing directory is not re-fetched: {err}"
+        );
+        // The other shape: nothing at that path at all. Different message, and
+        // it must not claim a directory is sitting there.
+        let gone = dataset_at(&dir.path().join("does-not-exist"), "tar", Some(400));
+        let gone_err = reuse_expected_rows(&gone).expect_err("no corpus, no count");
+        assert!(
+            gone_err.contains("has no corpus at") && !gone_err.contains("is present at"),
+            "an absent dataset and a gutted one must not read alike: {gone_err}"
         );
         // Positive control: the SAME dataset, with the corpus present, measures.
         let vectors: Vec<Vec<f32>> = (0..7).map(|i| vec![i as f32, 0.0, 0.0]).collect();
@@ -2679,7 +2764,7 @@ mod reuse_precondition_tests {
         );
     }
 
-    // #290 review: `sparse`/`h5-multi` have no header to read, so datasets.json's
+    // #290 review: when the corpus cannot be measured here, datasets.json's
     // vector_count IS the expected count — and it must be usable WITHOUT every
     // corpus file being present locally. `corpus_completeness_target()`'s
     // file-presence gate exists to stop an UPLOAD being skipped (#188/#224);
@@ -2695,7 +2780,7 @@ mod reuse_precondition_tests {
         assert_eq!(
             reuse_expected_rows(&dataset_at(dir.path(), "sparse", Some(100_000))).unwrap(),
             100_000,
-            "the declared count is the only available answer for this layout"
+            "the declared count is the only available answer while data.csr is absent"
         );
 
         // Without a declared count there IS no answer — and the error must name
@@ -2707,8 +2792,80 @@ mod reuse_precondition_tests {
             "the error must name the field to add, not the files: {err}"
         );
         assert!(
-            !err.contains("not on this machine"),
+            !err.contains("no corpus at"),
             "an unmeasurable layout must not be reported as a missing corpus: {err}"
+        );
+    }
+
+    // #290 review, SHOULD-FIX 1: `sparse` is no longer TRUSTED. Once `data.csr`
+    // is on disk its 24-byte header is the authority, so a wrong `vector_count`
+    // can no longer classify a correct corpus as `Short` (false abort) or a
+    // short one as `Surplus` (warn, and publish the wrong number) — the failure
+    // this whole issue is about, reached through the datasets.json door.
+    #[test]
+    fn a_present_csr_corpus_is_measured_not_trusted() {
+        let dir = tempfile::tempdir().unwrap();
+        let rows: Vec<SparseVector> = (0..150)
+            .map(|i| SparseVector {
+                indices: vec![i % 7],
+                values: vec![1.0],
+            })
+            .collect();
+        write_sparse_matrix(dir.path().join("data.csr").to_str().unwrap(), &rows).unwrap();
+
+        // A declaration wildly higher than the corpus must NOT win.
+        assert_eq!(
+            reuse_expected_rows(&dataset_at(dir.path(), "sparse", Some(999_999))).unwrap(),
+            150,
+            "the measured corpus is the authority once data.csr is present"
+        );
+        // ... and neither must one lower than it, which is the direction that
+        // would have published a wrong number as `Surplus`.
+        assert_eq!(
+            reuse_expected_rows(&dataset_at(dir.path(), "sparse", Some(10))).unwrap(),
+            150
+        );
+        // Positive control: an agreeing declaration measures the same.
+        assert_eq!(
+            reuse_expected_rows(&dataset_at(dir.path(), "sparse", Some(150))).unwrap(),
+            150
+        );
+        // And with no declaration at all it is still measurable, so the
+        // "declare vector_count" error must NOT fire here.
+        assert_eq!(
+            reuse_expected_rows(&dataset_at(dir.path(), "sparse", None)).unwrap(),
+            150
+        );
+    }
+
+    // `queries.csr` is a matrix too. Counting it as the corpus would report 10
+    // rows for a 150-row dataset and reject every reuse of it.
+    #[test]
+    fn the_query_matrix_is_never_mistaken_for_the_corpus() {
+        let dir = tempfile::tempdir().unwrap();
+        let queries: Vec<SparseVector> = (0..10)
+            .map(|_| SparseVector {
+                indices: vec![1],
+                values: vec![1.0],
+            })
+            .collect();
+        write_sparse_matrix(dir.path().join("queries.csr").to_str().unwrap(), &queries).unwrap();
+        // Only queries.csr exists: unmeasurable, so the declaration stands.
+        assert_eq!(
+            reuse_expected_rows(&dataset_at(dir.path(), "sparse", Some(150))).unwrap(),
+            150
+        );
+        // Now add the real corpus; the answer must be the corpus, not the queries.
+        let rows: Vec<SparseVector> = (0..150)
+            .map(|_| SparseVector {
+                indices: vec![2],
+                values: vec![1.0],
+            })
+            .collect();
+        write_sparse_matrix(dir.path().join("data.csr").to_str().unwrap(), &rows).unwrap();
+        assert_eq!(
+            reuse_expected_rows(&dataset_at(dir.path(), "sparse", Some(150))).unwrap(),
+            150
         );
     }
 
@@ -2722,6 +2879,175 @@ mod reuse_precondition_tests {
                 expected: 0,
                 approximate: false
             }
+        );
+    }
+}
+
+/// Behavioural coverage for the `--skip-upload` reuse HANDLER, as opposed to the
+/// classifier (issue #290 review).
+///
+/// A reviewer's mutation campaign found the classifier well pinned but the
+/// handler bare: making the `NoServerCount` arm FATAL was killed by nothing —
+/// 12 unit and 8 integration tests all stayed green. That arm is the one place
+/// this PR deliberately lets #290's symptom through (five engines have no
+/// row-count probe), so the decision is worth locking down rather than leaving
+/// to the next person's judgement. Likewise, dropping
+/// `record_rejected_experiment` from the fatal arm would silently erase a
+/// rejected config from `summary.rejected_experiments` under
+/// `--exit-on-error false`.
+///
+/// These drive `check_corpus_reuse_precondition` directly through a stub engine,
+/// which is what lets a unit test force `corpus_row_count -> Ok(None)` — no
+/// live server can be asked to have an unimplemented probe.
+#[cfg(test)]
+mod reuse_handler_tests {
+    use super::*;
+    use crate::config::DatasetConfig;
+    use crate::dataset::Dataset;
+    use crate::engine::{CorpusCount, SearchResults, UploadStats};
+    use vector_db_benchmark::readers::write_npy_vectors;
+
+    /// Minimal `Engine` whose only interesting behaviour is the row-count probe.
+    /// Every other method is unreachable on this path and says so.
+    struct StubEngine {
+        name: String,
+        count: Result<Option<CorpusCount>, String>,
+        params: Vec<SearchParams>,
+    }
+
+    impl Engine for StubEngine {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn configure(&mut self, _d: &Dataset) -> Result<(), String> {
+            unreachable!("the reuse check never configures")
+        }
+        fn upload(&mut self, _d: &Dataset) -> Result<UploadStats, String> {
+            unreachable!("the reuse check never uploads")
+        }
+        fn search(
+            &mut self,
+            _d: &Dataset,
+            _p: &SearchParams,
+            _n: i64,
+        ) -> Result<SearchResults, String> {
+            unreachable!("the reuse check never searches")
+        }
+        fn delete(&mut self) -> Result<(), String> {
+            unreachable!("the reuse check never deletes")
+        }
+        fn search_params(&self) -> &[SearchParams] {
+            &self.params
+        }
+        fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
+            self.count.clone()
+        }
+    }
+
+    fn stub(name: &str, count: Result<Option<CorpusCount>, String>) -> StubEngine {
+        StubEngine {
+            name: name.to_string(),
+            count,
+            params: Vec::new(),
+        }
+    }
+
+    /// A dataset whose corpus really is on disk and really holds `rows` vectors,
+    /// so the dataset side of the comparison is genuinely available.
+    fn measurable_dataset(dir: &std::path::Path, rows: usize) -> Dataset {
+        let vectors: Vec<Vec<f32>> = (0..rows).map(|i| vec![i as f32, 0.0, 0.0]).collect();
+        write_npy_vectors(dir.join("vectors.npy").to_str().unwrap(), &vectors).unwrap();
+        Dataset::new(DatasetConfig {
+            name: "handler-unit".to_string(),
+            dataset_type: Some("tar".to_string()),
+            path: serde_json::Value::String(dir.to_str().unwrap().to_string()),
+            distance: Some("l2".to_string()),
+            vector_size: Some(3),
+            vector_count: Some(rows as i64),
+            link: None,
+            schema: None,
+            description: None,
+        })
+    }
+
+    fn args() -> Args {
+        use clap::Parser;
+        Args::parse_from(["vector-db-benchmark", "--skip-upload"])
+    }
+
+    /// The deliberate soft arm. An engine with no row-count probe must WARN and
+    /// continue, recording `unverified` — not abort. Making this fatal would
+    /// remove `--skip-upload` from Chroma, Milvus, Weaviate, Turbopuffer and
+    /// Vertex, which protects no number because neither side of the comparison
+    /// is available.
+    #[test]
+    fn no_server_side_count_warns_and_continues() {
+        let dir = tempfile::tempdir().unwrap();
+        let ds = measurable_dataset(dir.path(), 400);
+        let mut engine = stub("chroma-handler", Ok(None));
+
+        let record = check_corpus_reuse_precondition(&mut engine, &ds, &args())
+            .expect("an engine with no probe must not abort the run")
+            .expect("the verdict must still be recorded in the artifact");
+
+        assert_eq!(record["status"], "unverified");
+        assert_eq!(record["actual_rows"], serde_json::Value::Null);
+        assert_eq!(record["waived_by_allow_partial_corpus"], false);
+        // The dataset side WAS available; that must not have turned into an
+        // abort just because the server side was missing.
+        assert_eq!(record["expected_rows"], 400);
+    }
+
+    /// Positive control for the test above: the same handler, same stub, one
+    /// field different — a real count that comes up short — must abort. Without
+    /// this, `no_server_side_count_warns_and_continues` would still pass if the
+    /// handler never aborted at all.
+    #[test]
+    fn a_short_exact_count_still_aborts_and_is_recorded_as_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let ds = measurable_dataset(dir.path(), 400);
+        let mut engine = stub("redis-handler", Ok(Some(CorpusCount::exact(1))));
+
+        let err = check_corpus_reuse_precondition(&mut engine, &ds, &args())
+            .expect_err("a short exact count must abort");
+        assert!(
+            err.contains("the corpus you asked to reuse is incomplete"),
+            "{err}"
+        );
+
+        // A rejected config must reach the summary, or a sweep run with
+        // --exit-on-error false loses all record of what it skipped.
+        let rejected = crate::summary::rejected_experiments();
+        assert!(
+            rejected
+                .iter()
+                .any(|r| { r["engine"] == "redis-handler" && r["dataset"] == "handler-unit" }),
+            "the rejected experiment must be recorded for the summary: {rejected:?}"
+        );
+    }
+
+    /// `--skip-vector-index` on a schema-less dataset returns before
+    /// `read_queries()`, so the run measures nothing — the check must return
+    /// early rather than probe and fetch for a run that publishes nothing.
+    /// The stub's probe would `unreachable!()`... it cannot, so instead it is an
+    /// `Err` that would abort loudly if the early return were removed.
+    #[test]
+    fn a_run_that_will_not_search_is_not_checked_at_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let ds = measurable_dataset(dir.path(), 400);
+        let mut engine = stub("never-probed", Err("probe must not run".to_string()));
+
+        use clap::Parser;
+        let args = Args::parse_from([
+            "vector-db-benchmark",
+            "--skip-upload",
+            "--skip-vector-index",
+        ]);
+        let out = check_corpus_reuse_precondition(&mut engine, &ds, &args)
+            .expect("a run that searches nothing must not be rejected");
+        assert!(
+            out.is_none(),
+            "no verdict should be recorded for a run that measures nothing: {out:?}"
         );
     }
 }

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -424,9 +424,18 @@ pub enum ReusePrecondition {
         expected: u64,
         approximate: bool,
     },
-    /// Nothing to check against: the dataset's corpus size cannot be determined,
-    /// or no server-side count is implemented for this engine. Proceed with a note.
-    Unverifiable(String),
+    /// No server-side count came back for this engine (`corpus_row_count`
+    /// returned `Ok(None)`: unimplemented, or a reply that carried no count).
+    /// Proceed with a note — an engine we have not wired up must not become
+    /// unusable under `--skip-upload`.
+    NoServerCount(String),
+    /// The DATASET side of the comparison is missing: its expected row count
+    /// could not be determined at all. Fatal unless `--allow-partial-corpus`
+    /// (issue #290). This is the same outcome as `Short` with LESS information,
+    /// not a milder one: the server may hold the whole corpus, part of it, or
+    /// none of it, and recall is scored against ground truth for the FULL
+    /// corpus either way.
+    CorpusSizeUnknown(String),
     /// The server holds MORE rows than the dataset declares. Warn and continue:
     /// leftovers from a bigger corpus change the reported recall, but so does
     /// refusing to run, and unlike a short corpus this is often deliberate
@@ -454,7 +463,8 @@ impl ReusePrecondition {
     fn status(&self) -> &'static str {
         match self {
             ReusePrecondition::Ok { .. } => "verified",
-            ReusePrecondition::Unverifiable(_) => "unverified",
+            ReusePrecondition::NoServerCount(_) => "unverified",
+            ReusePrecondition::CorpusSizeUnknown(_) => "corpus_size_unknown",
             ReusePrecondition::Surplus { .. } => "surplus",
             ReusePrecondition::Short { .. } => "short",
         }
@@ -462,21 +472,24 @@ impl ReusePrecondition {
 }
 
 /// Classify a server-side corpus count against what the dataset declares.
+///
+/// `expected` is a `Result`, not an `Option`, so the REASON the dataset side is
+/// unavailable survives into the verdict instead of being flattened to "unknown"
+/// at the call site (issue #290).
 pub fn classify_reuse_precondition(
-    expected: Option<u64>,
+    expected: Result<u64, String>,
     actual: Option<CorpusCount>,
     engine_name: &str,
 ) -> ReusePrecondition {
-    let Some(expected) = expected else {
-        return ReusePrecondition::Unverifiable(
-            "the dataset's corpus size could not be determined".to_string(),
-        );
+    let expected = match expected {
+        Ok(v) => v,
+        Err(why) => return ReusePrecondition::CorpusSizeUnknown(why),
     };
     let Some(actual) = actual else {
         // Deliberately phrased as a gap in this tool, not a limitation of the
         // database: Chroma, Milvus and Weaviate all expose a count, we simply
         // have not wired one up yet.
-        return ReusePrecondition::Unverifiable(format!(
+        return ReusePrecondition::NoServerCount(format!(
             "no server-side row count is implemented here for the engine behind config \
              '{engine_name}' yet"
         ));
@@ -519,8 +532,16 @@ pub fn classify_reuse_precondition(
 /// it exists to catch (a `Recall: 0.0000` run, exit 0). The measurement is the
 /// fact; a conflicting declaration is a `datasets.json` bug worth warning about,
 /// not a reason to stop checking.
-fn reuse_expected_rows(dataset: &Dataset) -> Result<Option<u64>, String> {
-    if let Some(measured) = dataset.measured_vector_count()? {
+///
+/// Returns `Result<u64, _>` rather than `Result<Option<u64>, _>` (issue #290):
+/// "there is no count here" is not a success. The two ways it can fail — a read
+/// that blew up, and a layout/corpus that offers no count — carry different
+/// messages, where before both collapsed into one `None` at the call site.
+fn reuse_expected_rows(dataset: &Dataset) -> Result<u64, String> {
+    if let Some(measured) = dataset
+        .measured_vector_count()
+        .map_err(|e| format!("measuring the corpus on disk failed: {e}"))?
+    {
         if let Some(declared) = dataset
             .config
             .vector_count
@@ -536,11 +557,23 @@ fn reuse_expected_rows(dataset: &Dataset) -> Result<Option<u64>, String> {
                 );
             }
         }
-        return Ok(Some(measured));
+        return Ok(measured);
     }
     // Layouts with no cheap row count (sparse CSR, h5-multi) fall back to the
     // declared count, but only when their files are actually present.
-    dataset.corpus_completeness_target()
+    dataset
+        .corpus_completeness_target()
+        .map_err(|e| format!("determining the dataset's corpus size failed: {e}"))?
+        .ok_or_else(|| {
+            format!(
+                "the corpus of dataset '{}' could not be measured on disk (dataset_type '{}', \
+                 path {}), and datasets.json's vector_count is only accepted as a fallback for \
+                 the 'sparse' and 'h5-multi' layouts, whose files must all be present",
+                dataset.config.name,
+                dataset.config.dataset_type.as_deref().unwrap_or("<none>"),
+                dataset.config.path,
+            )
+        })
 }
 
 /// Verify the promise `--skip-upload` makes: that the corpus it is told to reuse
@@ -555,8 +588,15 @@ fn reuse_expected_rows(dataset: &Dataset) -> Result<Option<u64>, String> {
 /// LOWER half gives `mean_recall: 0.0`. A metric that is a coin flip on the
 /// deletion pattern cannot be the guard.
 ///
-/// Repo policy on what is fatal: a short corpus changes the reported number, so
-/// an exact count that comes up short is a hard error; everything softer warns.
+/// Repo policy on what is fatal: a condition that changes the reported number is
+/// a hard error; only things that affect indexing speed warn. So an exact count
+/// that comes up short is fatal, and so is being unable to determine the
+/// dataset's expected count at all (#290) — that is the same outcome with less
+/// information, not a milder one. `--allow-partial-corpus` waives both, and the
+/// waiver is stamped into the result file. What still only warns: a SURPLUS
+/// corpus, an ESTIMATED short count, and an engine that has no server-side row
+/// count wired up (`NoServerCount`) — refusing there would make `--skip-upload`
+/// unusable on those engines rather than protect a number.
 ///
 /// Returns the verdict so it can be stamped into every result file this
 /// experiment writes.
@@ -570,16 +610,10 @@ fn check_corpus_reuse_precondition(
         return Ok(None);
     }
 
-    let expected = match reuse_expected_rows(dataset) {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!(
-                "\tNote: could not determine the dataset's corpus size ({e}); \
-                 --skip-upload reuse left unverified"
-            );
-            None
-        }
-    };
+    // Kept as a Result: an Err here is fatal below (#290), so degrading it to
+    // "unknown" would be the very thing this check exists to prevent.
+    let expected = reuse_expected_rows(dataset);
+    let expected_rows: Option<u64> = expected.as_ref().ok().copied();
 
     let actual = match engine.corpus_row_count() {
         Ok(v) => v,
@@ -610,7 +644,7 @@ fn check_corpus_reuse_precondition(
     let record = |waived: bool| {
         json!({
             "status": verdict.status(),
-            "expected_rows": expected,
+            "expected_rows": expected_rows,
             "actual_rows": actual.map(|c| c.rows),
             "actual_is_estimate": actual.map(|c| c.approximate).unwrap_or(false),
             "waived_by_allow_partial_corpus": waived,
@@ -631,12 +665,43 @@ fn check_corpus_reuse_precondition(
             );
             Ok(Some(record(false)))
         }
-        ReusePrecondition::Unverifiable(why) => {
+        ReusePrecondition::NoServerCount(why) => {
             println!(
                 "Experiment stage: Reuse check — SKIPPED ({why}); \
                  --skip-upload is running against an unverified corpus"
             );
             Ok(Some(record(false)))
+        }
+        ReusePrecondition::CorpusSizeUnknown(why) => {
+            // Same policy as Short, for the same reason: this changes the
+            // reported number. The difference is only that we cannot say by how
+            // much (#290).
+            let held = match actual {
+                Some(c) => format!("{}{} rows", if c.approximate { "≈" } else { "" }, c.rows),
+                None => "not readable either".to_string(),
+            };
+            let msg = format!(
+                "--skip-upload: the reuse check for config '{}' has nothing to compare against — \
+                 the expected row count for dataset '{}' could not be determined ({}). The server \
+                 side of the comparison came back as {}. Unverified is not the same as intact: \
+                 recall/precision are scored against ground truth for the FULL corpus, so if the \
+                 corpus behind this config is empty or partial, continuing publishes a wrong \
+                 number (an empty corpus scores recall 0.0 with zero failed queries) under a \
+                 config name that claims otherwise. Make the dataset's corpus measurable on this \
+                 machine — the count is read from the corpus file itself — or drop --skip-upload \
+                 to upload it. --allow-partial-corpus measures whatever the server holds without \
+                 checking; the waiver is recorded in the result file.",
+                engine.name(),
+                dataset.config.name,
+                why,
+                held,
+            );
+            if args.allow_partial_corpus {
+                eprintln!("WARNING: {msg}");
+                return Ok(Some(record(true)));
+            }
+            crate::summary::record_rejected_experiment(engine.name(), &dataset.config.name, &msg);
+            Err(msg)
         }
         ReusePrecondition::Surplus {
             actual,
@@ -2309,15 +2374,38 @@ mod tests {
 
 #[cfg(test)]
 mod reuse_precondition_tests {
-    use super::{classify_reuse_precondition, ReusePrecondition};
+    use super::{classify_reuse_precondition, reuse_expected_rows, ReusePrecondition};
+    use crate::config::DatasetConfig;
+    use crate::dataset::Dataset;
     use crate::engine::CorpusCount;
+    use vector_db_benchmark::readers::write_npy_vectors;
+
+    /// A dataset rooted at an ABSOLUTE temp path, so `datasets_dir().join(abs)`
+    /// resolves back to `abs` and no download is ever attempted.
+    fn dataset_at(
+        path: &std::path::Path,
+        dataset_type: &str,
+        vector_count: Option<i64>,
+    ) -> Dataset {
+        Dataset::new(DatasetConfig {
+            name: "reuse-unit".to_string(),
+            dataset_type: Some(dataset_type.to_string()),
+            path: serde_json::Value::String(path.to_str().unwrap().to_string()),
+            distance: Some("l2".to_string()),
+            vector_size: Some(3),
+            vector_count,
+            link: None,
+            schema: None,
+            description: None,
+        })
+    }
 
     // A corpus shorter than the dataset declares is the case that publishes a
     // wrong recall under a config name claiming otherwise (issue #238).
     #[test]
     fn short_corpus_is_short() {
         assert_eq!(
-            classify_reuse_precondition(Some(400), Some(CorpusCount::exact(200)), "redis-x"),
+            classify_reuse_precondition(Ok(400), Some(CorpusCount::exact(200)), "redis-x"),
             ReusePrecondition::Short {
                 actual: 200,
                 expected: 400,
@@ -2331,7 +2419,7 @@ mod reuse_precondition_tests {
     #[test]
     fn missing_corpus_is_short_not_ok() {
         assert_eq!(
-            classify_reuse_precondition(Some(400), Some(CorpusCount::exact(0)), "redis-x"),
+            classify_reuse_precondition(Ok(400), Some(CorpusCount::exact(0)), "redis-x"),
             ReusePrecondition::Short {
                 actual: 0,
                 expected: 400,
@@ -2343,7 +2431,7 @@ mod reuse_precondition_tests {
     #[test]
     fn exact_match_is_ok() {
         assert_eq!(
-            classify_reuse_precondition(Some(400), Some(CorpusCount::exact(400)), "redis-x"),
+            classify_reuse_precondition(Ok(400), Some(CorpusCount::exact(400)), "redis-x"),
             ReusePrecondition::Ok {
                 actual: 400,
                 expected: 400,
@@ -2357,7 +2445,7 @@ mod reuse_precondition_tests {
     #[test]
     fn surplus_is_classified_as_surplus() {
         assert_eq!(
-            classify_reuse_precondition(Some(400), Some(CorpusCount::exact(401)), "redis-x"),
+            classify_reuse_precondition(Ok(400), Some(CorpusCount::exact(401)), "redis-x"),
             ReusePrecondition::Surplus {
                 actual: 401,
                 expected: 400,
@@ -2372,7 +2460,7 @@ mod reuse_precondition_tests {
     #[test]
     fn approximate_flag_survives_classification() {
         assert_eq!(
-            classify_reuse_precondition(Some(400), Some(CorpusCount::estimated(200)), "pg-x"),
+            classify_reuse_precondition(Ok(400), Some(CorpusCount::estimated(200)), "pg-x"),
             ReusePrecondition::Short {
                 actual: 200,
                 expected: 400,
@@ -2380,7 +2468,7 @@ mod reuse_precondition_tests {
             }
         );
         assert_eq!(
-            classify_reuse_precondition(Some(400), Some(CorpusCount::estimated(400)), "pg-x"),
+            classify_reuse_precondition(Ok(400), Some(CorpusCount::estimated(400)), "pg-x"),
             ReusePrecondition::Ok {
                 actual: 400,
                 expected: 400,
@@ -2389,17 +2477,14 @@ mod reuse_precondition_tests {
         );
     }
 
-    // Nothing to compare against must never be silently reported as "Ok" — the
-    // runner has to say the reuse went unverified.
+    // An engine with no server-side row count wired up is the SOFT arm: the
+    // runner says the reuse went unverified and proceeds, because refusing would
+    // make --skip-upload unusable on that engine rather than protect a number.
     #[test]
-    fn unknown_expected_or_actual_is_unverifiable() {
-        assert!(matches!(
-            classify_reuse_precondition(None, Some(CorpusCount::exact(400)), "redis-x"),
-            ReusePrecondition::Unverifiable(_)
-        ));
-        let why = match classify_reuse_precondition(Some(400), None, "chroma-y") {
-            ReusePrecondition::Unverifiable(w) => w,
-            other => panic!("expected Unverifiable, got {other:?}"),
+    fn missing_server_side_count_is_the_soft_arm() {
+        let why = match classify_reuse_precondition(Ok(400), None, "chroma-y") {
+            ReusePrecondition::NoServerCount(w) => w,
+            other => panic!("expected NoServerCount, got {other:?}"),
         };
         assert!(
             why.contains("chroma-y"),
@@ -2413,11 +2498,82 @@ mod reuse_precondition_tests {
         );
     }
 
+    // Issue #290: an unavailable EXPECTED count is its own verdict, distinct
+    // from the engine-side gap above, and it carries the reason through instead
+    // of collapsing to a bare "unknown". The handler makes it fatal; keeping the
+    // variant separate is what lets it.
+    #[test]
+    fn unknown_expected_count_is_its_own_verdict_and_keeps_the_reason() {
+        let why = match classify_reuse_precondition(
+            Err("measuring the corpus on disk failed: bad npy magic".to_string()),
+            Some(CorpusCount::exact(400)),
+            "redis-x",
+        ) {
+            ReusePrecondition::CorpusSizeUnknown(w) => w,
+            other => panic!("expected CorpusSizeUnknown, got {other:?}"),
+        };
+        assert_eq!(
+            why, "measuring the corpus on disk failed: bad npy magic",
+            "the reason must survive into the verdict, not be flattened to 'unknown'"
+        );
+        // Positive control on the same input shape: a KNOWN expected count that
+        // matches must still classify as Ok, so this cannot pass by rejecting
+        // everything.
+        assert_eq!(
+            classify_reuse_precondition(Ok(400), Some(CorpusCount::exact(400)), "redis-x"),
+            ReusePrecondition::Ok {
+                actual: 400,
+                expected: 400,
+                approximate: false
+            }
+        );
+    }
+
+    // Issue #290, the widest real path to that verdict: a MEASURABLE layout
+    // whose corpus file is not on this machine. `tests.jsonl` (queries + ground
+    // truth) is still there, so the run would otherwise proceed and search — the
+    // scenario --skip-upload exists for. Pre-fix this was `Ok(None)`.
+    #[test]
+    fn absent_corpus_file_yields_an_error_not_a_silent_none() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("tests.jsonl"), "{}\n").unwrap();
+        let ds = dataset_at(dir.path(), "tar", Some(400));
+        let err = reuse_expected_rows(&ds)
+            .expect_err("a corpus that is not on disk has no expected row count");
+        assert!(
+            err.contains("could not be measured on disk") && err.contains("reuse-unit"),
+            "the failure must name the dataset and why: {err}"
+        );
+        // Positive control: the SAME dataset, with the corpus present, measures.
+        let vectors: Vec<Vec<f32>> = (0..7).map(|i| vec![i as f32, 0.0, 0.0]).collect();
+        write_npy_vectors(dir.path().join("vectors.npy").to_str().unwrap(), &vectors).unwrap();
+        assert_eq!(
+            reuse_expected_rows(&dataset_at(dir.path(), "tar", Some(7))).unwrap(),
+            7
+        );
+    }
+
+    // The other #290 path: `measured_vector_count()` returning Err. Before, the
+    // call site swallowed it to None and the guard went inert for that run.
+    #[test]
+    fn a_failed_measurement_propagates_instead_of_being_swallowed() {
+        let dir = tempfile::tempdir().unwrap();
+        // A vectors.npy that exists but is not a valid npy file: the header read
+        // fails, which is the transient-read-failure shape of this bug.
+        std::fs::write(dir.path().join("vectors.npy"), b"not an npy file at all").unwrap();
+        let ds = dataset_at(dir.path(), "tar", Some(400));
+        let err = reuse_expected_rows(&ds).expect_err("a failed header read must not become None");
+        assert!(
+            err.contains("measuring the corpus on disk failed"),
+            "a read failure and 'this layout has no cheap count' must not read alike: {err}"
+        );
+    }
+
     // Zero expected rows cannot make a zero-row server look short.
     #[test]
     fn zero_expected_never_fires() {
         assert_eq!(
-            classify_reuse_precondition(Some(0), Some(CorpusCount::exact(0)), "redis-x"),
+            classify_reuse_precondition(Ok(0), Some(CorpusCount::exact(0)), "redis-x"),
             ReusePrecondition::Ok {
                 actual: 0,
                 expected: 0,

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -2553,10 +2553,16 @@ mod reuse_precondition_tests {
         );
     }
 
-    // The other #290 path: `measured_vector_count()` returning Err. Before, the
-    // call site swallowed it to None and the guard went inert for that run.
+    // The other #290 path: `measured_vector_count()` returning Err.
+    //
+    // Scope, stated so it is not overclaimed: this function ALREADY returned Err
+    // here before the fix — the swallow was in `check_corpus_reuse_precondition`,
+    // which turned that Err into `None`. So all this test pins is that the two
+    // failure conditions now read differently to the operator. The end-to-end
+    // coverage for the swallow itself is phase (d) of
+    // `test_binary_redis_skip_upload_unverifiable_corpus_is_fatal`.
     #[test]
-    fn a_failed_measurement_propagates_instead_of_being_swallowed() {
+    fn a_failed_measurement_reads_as_a_failure_not_as_a_missing_count() {
         let dir = tempfile::tempdir().unwrap();
         // A vectors.npy that exists but is not a valid npy file: the header read
         // fails, which is the transient-read-failure shape of this bug.

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -616,12 +616,29 @@ fn reuse_expected_rows(dataset: &Dataset) -> Result<u64, String> {
     // re-fetched, however valid its link — saying "could not be fetched" there
     // would describe an attempt that was never made.
     if dataset.corpus_path_exists() {
+        // The remedy is gated on there actually BEING something to re-fetch.
+        // 8 of the 57 shipped datasets have no `link` — the locally generated
+        // ones, `random-100`, and laion — and for those "delete the directory"
+        // is not merely useless but destructive: it also removes `tests.jsonl`
+        // and `payloads.jsonl`, which nothing can restore. Advising it would
+        // repeat the mistake this branch exists to fix (a message describing an
+        // attempt that cannot be made), with data loss attached.
+        let remedy = if dataset.config.link.is_some() {
+            format!(
+                "restore the corpus file — or delete '{path}' to make the next run fetch it \
+                 fresh from the dataset's link"
+            )
+        } else {
+            "restore the corpus file. This dataset has no download link, so deleting the \
+             directory would NOT re-fetch it — and would destroy the query and payload files \
+             sitting beside the missing corpus"
+                .to_string()
+        };
         return Err(format!(
             "dataset '{}' is present at '{}' but its corpus file is not in it (dataset_type \
              '{}'), so there is no number to check the server against. A dataset whose path \
-             already exists is never re-downloaded, so restore the corpus file — or delete '{}' \
-             to make the next run fetch it fresh",
-            dataset.config.name, path, dataset_type, path,
+             already exists is never re-downloaded, so {}",
+            dataset.config.name, path, dataset_type, remedy,
         ));
     }
     Err(format!(
@@ -722,8 +739,6 @@ fn check_corpus_reuse_precondition(
     // verdict is fatal (`Short`, `CorpusSizeUnknown`) now pays for the fetch
     // before it aborts. That is the price of measuring rather than trusting, and
     // it is bounded to the cases where a measurement could change the verdict.
-    // The error is dropped on purpose — this is not the place that reports it,
-    // and `read_queries()` re-runs the identical resolution and fails properly.
     // The resolve error is KEPT, not dropped. When the fetch is what failed —
     // a 404, a dead mirror — that status code is the whole answer, and it used
     // to survive only as `Download attempt N/15 failed:` lines on stderr, with
@@ -2716,6 +2731,28 @@ mod reuse_precondition_tests {
         assert!(
             err.contains("never re-downloaded"),
             "it must warn that an existing directory is not re-fetched: {err}"
+        );
+        // `dataset_at` builds a LINK-LESS dataset, like 8 of the 57 shipped ones
+        // (the generated fixtures, random-100, laion). "Delete the directory" is
+        // not just useless for those, it destroys tests.jsonl/payloads.jsonl
+        // that nothing can restore — so it must not be offered here.
+        assert!(
+            !err.contains("delete"),
+            "a link-less dataset must never be told to delete its directory: {err}"
+        );
+        assert!(
+            err.contains("no download link"),
+            "it must say why deleting would not help: {err}"
+        );
+        // Positive control: the SAME state WITH a link does get the delete-and-
+        // refetch remedy, so the branch above is a real distinction and not a
+        // blanket removal.
+        let mut linked_cfg = dataset_at(dir.path(), "tar", Some(400));
+        linked_cfg.config.link = Some("https://example.invalid/ds.tgz".to_string());
+        let linked_err = reuse_expected_rows(&linked_cfg).expect_err("still unmeasurable");
+        assert!(
+            linked_err.contains("delete") && linked_err.contains("fetch it fresh"),
+            "a fetchable dataset should still be told it can be re-fetched: {linked_err}"
         );
         // The other shape: nothing at that path at all. Different message, and
         // it must not claim a directory is sitting there.

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -16,7 +16,8 @@ pub use jsonl_reader::{read_jsonl_queries, read_jsonl_vectors};
 pub use metadata::{parse_metadata_from_json, MetadataItem, MetadataValue};
 pub use npy_reader::{npy_row_count, read_npy_vectors, write_npy_vectors};
 pub use sparse_reader::{
-    read_gt_neighbours, read_sparse_matrix, write_gt_neighbours, write_sparse_matrix, SparseVector,
+    csr_row_count, read_gt_neighbours, read_sparse_matrix, write_gt_neighbours,
+    write_sparse_matrix, SparseVector,
 };
 
 #[cfg(test)]

--- a/src/readers/sparse_reader.rs
+++ b/src/readers/sparse_reader.rs
@@ -72,6 +72,45 @@ fn read_u32_array<T>(
         .collect())
 }
 
+/// Number of rows a CSR file declares, read from its 24-byte header WITHOUT
+/// parsing the matrix.
+///
+/// The sibling of [`crate::readers::npy_row_count`], and for the same reason: it
+/// makes the corpus — not `datasets.json` — the authority on how many vectors
+/// exist (#224). Until this existed, `sparse` was the one shipped layout with no
+/// cheap row count, so the `--skip-upload` reuse check had to TRUST the declared
+/// `vector_count`; a wrong declaration then classified a correct corpus as
+/// `Short` (false abort) or a genuinely short one as `Surplus` (warn, and publish
+/// the wrong number) — the exact failure class #290 exists to close, reached
+/// through the datasets.json door.
+///
+/// Cost is a 24-byte read, so this is safe to call on a multi-GB `data.csr`.
+/// Validation is deliberately minimal and matches what the header alone can
+/// support: the first `i64` must be non-negative, and the file must be at least
+/// as long as the three-`i64` header. Everything structural (index_pointer
+/// monotonicity, nnz agreement) is [`read_sparse_matrix`]'s job — a count read
+/// must not have to parse the matrix to answer.
+pub fn csr_row_count(path: &str) -> Result<u64, String> {
+    let file = File::open(Path::new(path)).map_err(|e| format!("open {}: {}", path, e))?;
+    let file_len = file.metadata().map(|m| m.len()).unwrap_or(0);
+    if file_len < 24 {
+        return Err(format!(
+            "{}: not a readable CSR file ({} bytes, header needs 24)",
+            path, file_len
+        ));
+    }
+    let mut r = BufReader::new(file);
+    let sizes = read_i64_le(&mut r, 3, file_len)?;
+    let n_row = sizes[0];
+    if n_row < 0 {
+        return Err(format!(
+            "{}: invalid CSR header (n_row {} is negative)",
+            path, n_row
+        ));
+    }
+    Ok(n_row as u64)
+}
+
 /// Parse a CSR file into a list of sparse vectors.
 pub fn read_sparse_matrix(path: &str) -> Result<Vec<SparseVector>, String> {
     let file = File::open(Path::new(path)).map_err(|e| format!("open {}: {}", path, e))?;
@@ -348,6 +387,44 @@ mod tests {
         f.write_all(bytes).unwrap();
         f.flush().unwrap();
         f
+    }
+
+    /// `csr_row_count` reads n_row from the 24-byte header and must agree with
+    /// what `read_sparse_matrix` actually yields — the whole point is that it is
+    /// a cheap substitute for parsing, not a second opinion (#290 review).
+    #[test]
+    fn csr_row_count_matches_a_full_parse() {
+        for n in [0usize, 1, 150] {
+            let rows: Vec<SparseVector> = (0..n)
+                .map(|i| SparseVector {
+                    indices: vec![i as u32 % 5],
+                    values: vec![0.5],
+                })
+                .collect();
+            let f = tempfile::NamedTempFile::new().unwrap();
+            let path = f.path().to_str().unwrap().to_string();
+            write_sparse_matrix(&path, &rows).unwrap();
+            assert_eq!(csr_row_count(&path).unwrap(), n as u64, "n = {n}");
+            assert_eq!(read_sparse_matrix(&path).unwrap().len(), n, "n = {n}");
+        }
+    }
+
+    /// A count read must not be fooled by a file too short to hold a header, and
+    /// must not report a negative n_row as an enormous unsigned one. Both would
+    /// feed a bogus "expected rows" straight into the --skip-upload verdict.
+    #[test]
+    fn csr_row_count_rejects_a_truncated_or_negative_header() {
+        let short = write_tmp(&[0u8; 23]);
+        let err = csr_row_count(short.path().to_str().unwrap()).unwrap_err();
+        assert!(err.contains("not a readable CSR file"), "{err}");
+
+        let mut b = Vec::new();
+        b.extend_from_slice(&(-5i64).to_le_bytes()); // n_row
+        b.extend_from_slice(&1i64.to_le_bytes());
+        b.extend_from_slice(&0i64.to_le_bytes());
+        let neg = write_tmp(&b);
+        let err = csr_row_count(neg.path().to_str().unwrap()).unwrap_err();
+        assert!(err.contains("negative"), "{err}");
     }
 
     /// Header n_row so large that `(n_row + 1) * 8` overflows usize.

--- a/src/readers/sparse_reader.rs
+++ b/src/readers/sparse_reader.rs
@@ -389,11 +389,53 @@ mod tests {
         f
     }
 
-    /// `csr_row_count` reads n_row from the 24-byte header and must agree with
-    /// what `read_sparse_matrix` actually yields — the whole point is that it is
-    /// a cheap substitute for parsing, not a second opinion (#290 review).
+    /// The count must come out of LITERAL little-endian bytes, not out of
+    /// whatever `write_sparse_matrix` happens to emit (#290 review).
+    ///
+    /// Without this, `csr_row_count`, `read_sparse_matrix` and the fixture
+    /// writer all agree by construction: a COHERENT endianness flip
+    /// (`from_le_bytes` + `to_le_bytes` → `_be_`) left the whole suite green,
+    /// because every party to the comparison flipped together. The CSR format is
+    /// little-endian by definition — it is what qdrant/vector-db-benchmark's
+    /// `sparse_reader.py` writes — so a byte fixture is the only thing that pins
+    /// it. `results.gt` already has this treatment in
+    /// `gt_decodes_a_literal_little_endian_fixture`; with both, that flip now
+    /// fails two tests instead of none.
+    ///
+    /// `n_row = 150` is the real `synthetic-sparse-300` count, and decodes
+    /// big-endian to 0x9600000000000000 — wildly wrong rather than subtly so.
     #[test]
-    fn csr_row_count_matches_a_full_parse() {
+    fn csr_row_count_decodes_a_literal_little_endian_fixture() {
+        #[rustfmt::skip]
+        let bytes: &[u8] = &[
+            // n_row = 150
+            0x96, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            // n_col = 300 — two non-zero bytes, so a swap shows here too if the
+            // header fields are ever read in a different order
+            0x2c, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            // n_non_zero = 1500
+            0xdc, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let f = write_tmp(bytes);
+        assert_eq!(
+            csr_row_count(f.path().to_str().unwrap()).unwrap(),
+            150,
+            "n_row must decode little-endian"
+        );
+    }
+
+    /// `csr_row_count` must agree with what `read_sparse_matrix` yields on a
+    /// WELL-FORMED file — it is a cheap substitute for parsing, not a second
+    /// opinion (#290 review).
+    ///
+    /// Scope, so the name does not overstate: they agree on well-formed input
+    /// only. A valid header over a truncated body gives `Ok(n)` here and `Err`
+    /// there, by design — a count read must not have to parse the matrix to
+    /// answer. The header is itself a declaration, just one stored inside the
+    /// corpus rather than in `datasets.json`; what the change buys is that the
+    /// declaration now travels WITH the file it describes.
+    #[test]
+    fn csr_row_count_agrees_with_a_full_parse_on_well_formed_input() {
         for n in [0usize, 1, 150] {
             let rows: Vec<SparseVector> = (0..n)
                 .map(|i| SparseVector {

--- a/src/synthetic.rs
+++ b/src/synthetic.rs
@@ -54,6 +54,19 @@ pub struct SparseData {
     pub neighbours: Vec<Vec<i64>>,
 }
 
+/// Corpus size of the shipped `synthetic-sparse-300` dataset.
+///
+/// Single source of truth, shared by `generate-dataset` (which writes the
+/// corpus) and the `datasets.json` guard in `config.rs` (which checks the
+/// declared `vector_count` against it). CI has no corpus on disk, so without
+/// this constant nothing could police that number from `datasets.json` alone —
+/// and the dataset's NAME says 300, which is its DIMENSION, so the wrong value
+/// is the easy mistake to make. It was in fact proposed during review.
+pub const SYNTHETIC_SPARSE_ROWS: usize = 150;
+
+/// Sparse dimensionality of `synthetic-sparse-300` — the `300` in its name.
+pub const SYNTHETIC_SPARSE_DIM: usize = 300;
+
 /// Generate a deterministic random sparse dataset and its dot-product
 /// (descending) ground truth. Sparse similarity is MIPS — larger dot = more
 /// similar — so the neighbours are sorted DESCENDING by dot product.

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -3437,7 +3437,7 @@ fn test_binary_redis_skip_upload_unverifiable_corpus_is_fatal() {
     assert!(
         intact_out.contains("has nothing to compare against")
             && intact_out.contains("config 'cfg290unver'")
-            && intact_out.contains("could not be measured on disk"),
+            && intact_out.contains("is not on this machine to be measured"),
         "the error must name the missing side of the comparison.\n{intact_out}"
     );
     assert!(
@@ -3539,6 +3539,218 @@ fn test_binary_redis_skip_upload_unverifiable_corpus_is_fatal() {
         "the rejected run must not publish a result file after a failed measurement"
     );
 
+    flush_db(&mut conn);
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+/// Issue #290 review, BLOCKER 1: the reuse check must not reject a dataset the
+/// tool is about to fetch for itself.
+///
+/// The check runs before the search phase, and the search phase's very first act
+/// is `read_queries()` → `get_path()`, which downloads a dataset that is not on
+/// disk yet. 49 of the 57 shipped datasets carry a `link`. Measuring before that
+/// fetch made "not downloaded yet" indistinguishable from "not obtainable", so
+/// the first `--skip-upload` run on a fresh benchmark client — a machine that
+/// loaded the server from somewhere else, which is the flag's central use case —
+/// was rejected seconds before the tool would have fetched the corpus. With
+/// `--exit-on-error` defaulting to true, one such dataset kills a whole sweep.
+///
+/// This test serves the dataset as a `.tgz` from a `TcpListener` on localhost —
+/// no external network — and deletes it from disk, leaving the server corpus
+/// complete.
+///
+/// The load-bearing assertion is `corpus_reuse.status == "verified"` with
+/// `expected_rows == 400`. That is stronger than "the run succeeded": it is only
+/// reachable if the corpus was fetched BEFORE the count was measured. It is RED
+/// on both trees for different reasons — master `cff7e3a` succeeds but records
+/// `"unverified"` with `expected_rows: null` (the search phase downloaded the
+/// corpus *after* the check), and `ce51f65` aborts outright.
+///
+/// The final phase is the control that keeps the fetch-first step from simply
+/// disabling the guard: same corpus-absent state with the `link` removed, so
+/// nothing can fetch it, must still be a hard error.
+#[test]
+fn test_binary_redis_skip_upload_fetches_the_dataset_before_judging_it() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "cfg290fetch", "engine": "redis",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "cfg290fetch-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let port = test_port().to_string();
+    let envs: [(&str, &str); 1] = [("REDIS_PORT", port.as_str())];
+    let results_dir = proj.root.join("results");
+    let ds_dir = proj.root.join("datasets").join("cfg290fetch-test");
+    let datasets_json = proj.root.join("datasets").join("datasets.json");
+
+    // Phase 1: build the corpus the reuse run is told to reuse.
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg290fetch",
+            "cfg290fetch-test",
+            "localhost",
+            &envs,
+            &["--keep-data", "--skip-search"],
+        ),
+        "phase 1 (upload) failed"
+    );
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:cfg290fetch"),
+        common::N_DOCS as i64,
+        "phase 1 must leave a complete corpus"
+    );
+    delete_search_result_files(&results_dir);
+
+    // Pack the dataset directory into a .tgz, exactly the layout `extract_tgz`
+    // unpacks into `datasets/<name>/`.
+    let tgz: Vec<u8> = {
+        let mut buf = Vec::new();
+        {
+            let enc = flate2::write::GzEncoder::new(&mut buf, flate2::Compression::fast());
+            let mut ar = tar::Builder::new(enc);
+            ar.append_dir_all("", &ds_dir).expect("tar the dataset");
+            ar.into_inner()
+                .expect("finish tar")
+                .finish()
+                .expect("finish gzip");
+        }
+        buf
+    };
+
+    // Serve it from localhost. One thread, answers every request with the same
+    // body; the binary makes exactly one GET, but a loop keeps a stray probe
+    // from wedging the download's 15-attempt retry.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local http server");
+    let http_port = listener.local_addr().unwrap().port();
+    let body = tgz.clone();
+    let server = thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut s) = stream else { break };
+            use std::io::{Read, Write};
+            let mut scratch = [0u8; 2048];
+            let _ = s.read(&mut scratch); // request line + headers; content ignored
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            if s.write_all(head.as_bytes()).is_err() || s.write_all(&body).is_err() {
+                break;
+            }
+            let _ = s.flush();
+        }
+    });
+
+    let write_link = |link: Option<&str>| {
+        let mut v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&datasets_json).unwrap()).unwrap();
+        let entry = &mut v.as_array_mut().unwrap()[0];
+        match link {
+            Some(l) => {
+                entry["link"] = serde_json::json!(l);
+            }
+            None => {
+                entry.as_object_mut().unwrap().remove("link");
+            }
+        }
+        fs::write(&datasets_json, serde_json::to_string_pretty(&v).unwrap()).unwrap();
+    };
+    write_link(Some(&format!(
+        "http://127.0.0.1:{http_port}/cfg290fetch.tgz"
+    )));
+
+    // The dataset is gone from this machine. The server corpus is untouched.
+    fs::remove_dir_all(&ds_dir).expect("remove the dataset from disk");
+    assert!(
+        !ds_dir.exists(),
+        "the dataset must be absent before the run"
+    );
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:cfg290fetch"),
+        common::N_DOCS as i64,
+        "the server-side corpus must still be complete"
+    );
+
+    let bin = binary_path();
+    let run = || {
+        let mut cmd = Command::new(&bin);
+        cmd.args([
+            "--engines",
+            "cfg290fetch",
+            "--datasets",
+            "cfg290fetch-test",
+            "--host",
+            "localhost",
+            "--skip-if-exists",
+            "false",
+            "--skip-upload",
+            "--keep-data",
+        ]);
+        cmd.env("REDIS_PORT", &port)
+            .current_dir(&proj.root)
+            .output()
+            .expect("run vector-db-benchmark")
+    };
+
+    let out = run();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        out.status.success(),
+        "a dataset that is merely not downloaded yet must not be a hard error \
+         (#290 review, BLOCKER 1).\n{combined}"
+    );
+    assert!(
+        ds_dir.join("vectors.npy").exists(),
+        "the run must have fetched the corpus.\n{combined}"
+    );
+    let reuse = common::read_params_obj(&proj.root, "cfg290fetch")["corpus_reuse"].clone();
+    assert_eq!(
+        reuse["status"], "verified",
+        "the fetch must happen BEFORE the count is measured — 'unverified' here \
+         means the corpus arrived too late to be checked: {reuse}"
+    );
+    assert_eq!(reuse["expected_rows"], common::N_DOCS as u64);
+    assert_eq!(reuse["actual_rows"], common::N_DOCS as u64);
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:cfg290fetch"),
+        common::N_DOCS as i64,
+        "the reuse check must never modify the corpus"
+    );
+
+    // CONTROL: fetching first must not have disabled the guard. Same absent
+    // corpus, but now nothing can fetch it — that is still a hard error.
+    delete_search_result_files(&results_dir);
+    fs::remove_dir_all(&ds_dir).expect("remove the dataset again");
+    write_link(None);
+    let out2 = run();
+    let combined2 = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out2.stdout),
+        String::from_utf8_lossy(&out2.stderr)
+    );
+    assert!(
+        !out2.status.success(),
+        "a corpus that is neither present nor fetchable must still abort.\n{combined2}"
+    );
+    assert!(
+        combined2.contains("is not on this machine to be measured"),
+        "the error must name the corpus, not the layout.\n{combined2}"
+    );
+
+    drop(server); // the listener closes with the test process
     flush_db(&mut conn);
     fs::remove_dir_all(&proj.root).ok();
 }

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -3262,3 +3262,238 @@ fn test_binary_redis_skip_upload_without_keep_data_preserves_corpus() {
     flush_db(&mut conn);
     fs::remove_dir_all(&proj.root).ok();
 }
+
+// ---------------------------------------------------------------------------
+// Issue #290 — `--skip-upload` must not run against a corpus it cannot VERIFY
+// ---------------------------------------------------------------------------
+
+/// A `--skip-upload` run whose dataset offers no expected row count must abort,
+/// not proceed with a printed note (issue #290).
+///
+/// Before this fix the guard compared an `Option<u64>` expected count against
+/// the server-side count, and `None` short-circuited to a printed "Reuse check —
+/// SKIPPED" and `Ok`. `None` is reachable without any user error: the count is
+/// measured from the corpus FILE, and `--skip-upload` exists precisely for the
+/// case where the corpus lives on the server and not on this machine.
+///
+/// This test reaches that state the way the tool's own doc comment describes it
+/// — "one whose big `vectors.npy` was deleted to reclaim disk while
+/// `tests.jsonl` stayed behind so queries still work" — by deleting
+/// `vectors.npy` from the fixture. Queries and ground truth are in
+/// `tests.jsonl`, so the run still searches and still publishes.
+///
+/// What the assertions rest on: the server-side row count read back with
+/// `FT.INFO` (`ft_info_num_docs`), before and after each run. Recall is asserted
+/// once, at the very end, only to show what the waiver publishes — it is NOT the
+/// detector, and could not be: on a truncated corpus recall is a coin flip on
+/// which rows went.
+///
+/// Structure: a POSITIVE CONTROL first (everything present → the run must
+/// succeed and record `verified`), then the guard with the server corpus INTACT
+/// (proving it fires on unverifiability itself, not on missing data), then with
+/// the server corpus EMPTY (the published-recall-0.0 case from the issue), then
+/// the `--allow-partial-corpus` waiver.
+///
+/// RED on unfixed master `cff7e3a`: both guarded runs exit 0 and write a search
+/// result file; the empty-corpus one publishes `mean_recall` 0.0 with
+/// `corpus_reuse.status` `"unverified"`.
+#[test]
+fn test_binary_redis_skip_upload_unverifiable_corpus_is_fatal() {
+    wait_for_redis();
+    let mut conn = get_test_connection();
+    flush_db(&mut conn);
+
+    let dim = 8;
+    let configs = serde_json::json!([{
+        "name": "cfg290unver", "engine": "redis",
+        "search_params": [{"parallel": 1, "search_params": {"ef": 64}}],
+        "upload_params": {"parallel": 1, "batch_size": 100}
+    }]);
+    let proj = common::write_match_any_project(
+        "cfg290unver-test",
+        &serde_json::to_string(&configs).unwrap(),
+        dim,
+    );
+    let port = test_port().to_string();
+    let envs: [(&str, &str); 1] = [("REDIS_PORT", port.as_str())];
+    let results_dir = proj.root.join("results");
+    let vectors_npy = proj
+        .root
+        .join("datasets")
+        .join("cfg290unver-test")
+        .join("vectors.npy");
+
+    // Phase 1: build the corpus the later runs are told to reuse.
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg290unver",
+            "cfg290unver-test",
+            "localhost",
+            &envs,
+            &["--keep-data", "--skip-search"],
+        ),
+        "phase 1 (upload) failed"
+    );
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:cfg290unver"),
+        common::N_DOCS as i64,
+        "phase 1 must leave a complete corpus"
+    );
+    delete_search_result_files(&results_dir);
+
+    let bin = binary_path();
+    let run = |extra: &[&str]| {
+        let mut cmd = Command::new(&bin);
+        cmd.args([
+            "--engines",
+            "cfg290unver",
+            "--datasets",
+            "cfg290unver-test",
+            "--host",
+            "localhost",
+            "--skip-if-exists",
+            "false",
+            "--skip-upload",
+            "--keep-data",
+        ]);
+        cmd.args(extra);
+        cmd.env("REDIS_PORT", &port)
+            .current_dir(&proj.root)
+            .output()
+            .expect("run vector-db-benchmark")
+    };
+    let combined = |out: &std::process::Output| {
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        )
+    };
+    let wrote_search_result = || {
+        fs::read_dir(&results_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains("-search-"))
+    };
+
+    // POSITIVE CONTROL. Corpus file present, server corpus complete: the guard
+    // must let this through, or the test could pass by rejecting everything.
+    let control = run(&[]);
+    assert!(
+        control.status.success(),
+        "--skip-upload over a corpus that IS verifiable and complete must succeed.\n{}",
+        combined(&control)
+    );
+    let reuse = common::read_params_obj(&proj.root, "cfg290unver")["corpus_reuse"].clone();
+    assert_eq!(reuse["status"], "verified", "control verdict: {reuse}");
+    assert_eq!(reuse["expected_rows"], common::N_DOCS as u64);
+    assert_eq!(reuse["actual_rows"], common::N_DOCS as u64);
+    delete_search_result_files(&results_dir);
+
+    // Take the corpus FILE away. tests.jsonl (queries + ground truth) and
+    // payloads.jsonl stay, so nothing else about the run changes: it can still
+    // search, and the dataset directory still exists so no download is
+    // attempted. Only the expected row count is now unobtainable.
+    fs::remove_file(&vectors_npy).expect("remove vectors.npy");
+
+    // (a) Server corpus INTACT. The number this run would publish is in fact
+    // correct — and the tool has no way to know that. Asserting the FT.INFO
+    // count here is what proves the abort is about unverifiability and not
+    // about missing data.
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:cfg290unver"),
+        common::N_DOCS as i64,
+        "the server-side corpus must still be complete at this point"
+    );
+    let intact = run(&[]);
+    let intact_out = combined(&intact);
+    assert!(
+        !intact.status.success(),
+        "--skip-upload must abort when the dataset's expected row count cannot be \
+         determined (issue #290), but the run succeeded.\n{intact_out}"
+    );
+    assert!(
+        intact_out.contains("has nothing to compare against")
+            && intact_out.contains("config 'cfg290unver'")
+            && intact_out.contains("could not be measured on disk"),
+        "the error must name the missing side of the comparison.\n{intact_out}"
+    );
+    assert!(
+        !wrote_search_result(),
+        "a rejected --skip-upload run must not leave a search result file behind"
+    );
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:cfg290unver"),
+        common::N_DOCS as i64,
+        "the reuse check must never modify the corpus"
+    );
+
+    // (b) Server corpus EMPTY — the case from the issue. Index kept so the probe
+    // still succeeds and reports an exact 0; dropping it would instead exercise
+    // the (already fatal) probe-failure branch.
+    for id in 0..common::N_DOCS {
+        let _: () = redis::cmd("UNLINK")
+            .arg(format!("cfg290unver:{id}"))
+            .query(&mut conn)
+            .unwrap();
+    }
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:cfg290unver"),
+        0,
+        "server-side ground truth for this phase: the corpus is gone"
+    );
+    let empty = run(&[]);
+    let empty_out = combined(&empty);
+    assert!(
+        !empty.status.success(),
+        "--skip-upload over an EMPTY corpus it cannot verify must abort.\n{empty_out}"
+    );
+    assert!(
+        !wrote_search_result(),
+        "the rejected run must not publish a result file for an empty corpus"
+    );
+
+    // (c) The waiver. It must work, must warn, and must be recorded.
+    let waived = run(&["--allow-partial-corpus"]);
+    assert!(
+        waived.status.success(),
+        "--allow-partial-corpus must downgrade the guard to a warning.\n{}",
+        combined(&waived)
+    );
+    assert!(
+        String::from_utf8_lossy(&waived.stderr).contains("WARNING: --skip-upload"),
+        "the override must still warn.\n{}",
+        combined(&waived)
+    );
+    let reuse = common::read_params_obj(&proj.root, "cfg290unver")["corpus_reuse"].clone();
+    assert_eq!(
+        reuse["status"], "corpus_size_unknown",
+        "the waived verdict must be distinguishable from an engine-side \
+         'unverified' in the artifact: {reuse}"
+    );
+    assert_eq!(reuse["expected_rows"], serde_json::Value::Null);
+    assert_eq!(reuse["actual_rows"], 0);
+    assert_eq!(reuse["waived_by_allow_partial_corpus"], true);
+    assert_eq!(
+        ft_info_num_docs(&mut conn, "idx:cfg290unver"),
+        0,
+        "the reuse check must never modify the corpus, waived or not"
+    );
+
+    // Illustrative only, and deliberately last: this is the number the default
+    // path used to publish with exit 0. It is not the detector.
+    assert_eq!(
+        common::read_recall(&proj.root, "cfg290unver"),
+        0.0,
+        "an empty corpus scores recall 0.0 — the number #290 is about"
+    );
+    assert_eq!(
+        common::read_results_obj(&proj.root, "cfg290unver")["failed_queries"],
+        0,
+        "and it scores it with no failed queries, which is why nothing else catches it"
+    );
+
+    flush_db(&mut conn);
+    fs::remove_dir_all(&proj.root).ok();
+}

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -3315,7 +3315,7 @@ fn test_binary_redis_skip_upload_without_keep_data_preserves_corpus() {
 /// swallowed-`Err` half of #290 — `reuse_expected_rows` already returned `Err`
 /// for it on master; it was the caller that turned that into "cannot verify".
 ///
-/// RED on unfixed master `cff7e3a`: every guarded run here exits 0 and writes a
+/// RED on unfixed master `7ed81eb`: every guarded run here exits 0 and writes a
 /// search result file; the empty-corpus one publishes `mean_recall` 0.0 with
 /// `corpus_reuse.status` `"unverified"` and `failed_queries` 0.
 #[test]
@@ -3437,8 +3437,14 @@ fn test_binary_redis_skip_upload_unverifiable_corpus_is_fatal() {
     assert!(
         intact_out.contains("has nothing to compare against")
             && intact_out.contains("config 'cfg290unver'")
-            && intact_out.contains("is not on this machine to be measured"),
-        "the error must name the missing side of the comparison.\n{intact_out}"
+            // The dataset DIRECTORY is still here — only vectors.npy is gone —
+            // and `get_path()` returns early on an existing path, so nothing was
+            // fetched and nothing could be. The message must say that, not imply
+            // a download was attempted (#290 review).
+            && intact_out.contains("but its corpus file is not in it")
+            && intact_out.contains("never re-downloaded"),
+        "the error must name the missing side of the comparison, and the real \
+         remedy for a directory that exists without its corpus.\n{intact_out}"
     );
     assert!(
         !wrote_search_result(),
@@ -3496,6 +3502,15 @@ fn test_binary_redis_skip_upload_unverifiable_corpus_is_fatal() {
     assert_eq!(reuse["expected_rows"], serde_json::Value::Null);
     assert_eq!(reuse["actual_rows"], 0);
     assert_eq!(reuse["waived_by_allow_partial_corpus"], true);
+    // A waived run is a PUBLISHED result whose count was never checked, so the
+    // reason has to travel in the file — `probe_failed` has carried `detail`
+    // since #238 and this arm now matches it (#290 review).
+    assert!(
+        reuse["detail"]
+            .as_str()
+            .is_some_and(|d| d.contains("but its corpus file is not in it")),
+        "the waived artifact must record WHY the count was unknown: {reuse}"
+    );
     assert_eq!(
         ft_info_num_docs(&mut conn, "idx:cfg290unver"),
         0,
@@ -3562,13 +3577,20 @@ fn test_binary_redis_skip_upload_unverifiable_corpus_is_fatal() {
 /// The load-bearing assertion is `corpus_reuse.status == "verified"` with
 /// `expected_rows == 400`. That is stronger than "the run succeeded": it is only
 /// reachable if the corpus was fetched BEFORE the count was measured. It is RED
-/// on both trees for different reasons — master `cff7e3a` succeeds but records
+/// on both trees for different reasons — master `7ed81eb` succeeds but records
 /// `"unverified"` with `expected_rows: null` (the search phase downloaded the
 /// corpus *after* the check), and `ce51f65` aborts outright.
 ///
 /// The final phase is the control that keeps the fetch-first step from simply
 /// disabling the guard: same corpus-absent state with the `link` removed, so
-/// nothing can fetch it, must still be a hard error.
+/// nothing can resolve it, must still be a hard error.
+///
+/// That control asserts WHERE the run stopped, not just that it stopped. Exit
+/// code and the message text are both satisfied by a neutered guard, because the
+/// search phase's own `get_path()` fails on an unresolvable dataset and prints
+/// the same reason as a warning — a reviewer demonstrated exactly that mutation
+/// passing an earlier version of this test. The discriminating assertions are
+/// the absence of `Experiment stage: Search` and of `Dataset path not found`.
 #[test]
 fn test_binary_redis_skip_upload_fetches_the_dataset_before_judging_it() {
     wait_for_redis();
@@ -3680,6 +3702,12 @@ fn test_binary_redis_skip_upload_fetches_the_dataset_before_judging_it() {
         "the server-side corpus must still be complete"
     );
 
+    let wrote_search_result = || {
+        fs::read_dir(&results_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains("-search-"))
+    };
     let bin = binary_path();
     let run = || {
         let mut cmd = Command::new(&bin);
@@ -3743,11 +3771,33 @@ fn test_binary_redis_skip_upload_fetches_the_dataset_before_judging_it() {
     );
     assert!(
         !out2.status.success(),
-        "a corpus that is neither present nor fetchable must still abort.\n{combined2}"
+        "a corpus that is not on this machine and cannot be resolved must still abort.\n{combined2}"
     );
     assert!(
-        combined2.contains("is not on this machine to be measured"),
+        combined2.contains("has no corpus at"),
         "the error must name the corpus, not the layout.\n{combined2}"
+    );
+    // The assertions above are NOT enough on their own, and saying so is the
+    // point of this comment. A neutered guard — `CorpusSizeUnknown` downgraded
+    // to warn-and-continue — still exits non-zero here, because the search
+    // phase's own `get_path()` cannot resolve the dataset either, and still
+    // prints the reason as a warning. Both would pass while the guard did
+    // nothing. What separates them is WHERE the run stopped: the guard aborts
+    // before the search phase begins, so neither the stage banner nor the
+    // reader's own failure may appear.
+    assert!(
+        !combined2.contains("Experiment stage: Search"),
+        "the reuse check must reject this BEFORE the search phase — reaching it \
+         means the guard did not fire and something else failed the run.\n{combined2}"
+    );
+    assert!(
+        !combined2.contains("WARNING: --skip-upload"),
+        "the guard must REJECT here, not warn: a warning means the arm was \
+         downgraded and the run died downstream instead.\n{combined2}"
+    );
+    assert!(
+        !wrote_search_result(),
+        "the rejected run must not leave a search result file behind"
     );
 
     drop(server); // the listener closes with the test process

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -3590,7 +3590,8 @@ fn test_binary_redis_skip_upload_unverifiable_corpus_is_fatal() {
 /// search phase's own `get_path()` fails on an unresolvable dataset and prints
 /// the same reason as a warning — a reviewer demonstrated exactly that mutation
 /// passing an earlier version of this test. The discriminating assertions are
-/// the absence of `Experiment stage: Search` and of `Dataset path not found`.
+/// the absence of `Experiment stage: Search` (a rejected run never reaches the
+/// search phase) and of `WARNING: --skip-upload` (a fatal arm never warns).
 #[test]
 fn test_binary_redis_skip_upload_fetches_the_dataset_before_judging_it() {
     wait_for_redis();

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -3292,11 +3292,14 @@ fn test_binary_redis_skip_upload_without_keep_data_preserves_corpus() {
 /// succeed and record `verified`), then the guard with the server corpus INTACT
 /// (proving it fires on unverifiability itself, not on missing data), then with
 /// the server corpus EMPTY (the published-recall-0.0 case from the issue), then
-/// the `--allow-partial-corpus` waiver.
+/// the `--allow-partial-corpus` waiver, then the second `None` path: a corpus
+/// file whose header cannot be READ. That last phase is the one that covers the
+/// swallowed-`Err` half of #290 — `reuse_expected_rows` already returned `Err`
+/// for it on master; it was the caller that turned that into "cannot verify".
 ///
-/// RED on unfixed master `cff7e3a`: both guarded runs exit 0 and write a search
-/// result file; the empty-corpus one publishes `mean_recall` 0.0 with
-/// `corpus_reuse.status` `"unverified"`.
+/// RED on unfixed master `cff7e3a`: every guarded run here exits 0 and writes a
+/// search result file; the empty-corpus one publishes `mean_recall` 0.0 with
+/// `corpus_reuse.status` `"unverified"` and `failed_queries` 0.
 #[test]
 fn test_binary_redis_skip_upload_unverifiable_corpus_is_fatal() {
     wait_for_redis();
@@ -3481,8 +3484,8 @@ fn test_binary_redis_skip_upload_unverifiable_corpus_is_fatal() {
         "the reuse check must never modify the corpus, waived or not"
     );
 
-    // Illustrative only, and deliberately last: this is the number the default
-    // path used to publish with exit 0. It is not the detector.
+    // Illustrative only: this is the number the default path used to publish
+    // with exit 0. It is NOT the detector — see the doc comment.
     assert_eq!(
         common::read_recall(&proj.root, "cfg290unver"),
         0.0,
@@ -3492,6 +3495,30 @@ fn test_binary_redis_skip_upload_unverifiable_corpus_is_fatal() {
         common::read_results_obj(&proj.root, "cfg290unver")["failed_queries"],
         0,
         "and it scores it with no failed queries, which is why nothing else catches it"
+    );
+
+    // (d) The OTHER #290 path, and the widest one: the corpus file IS present
+    // but its header cannot be read. `reuse_expected_rows` already returned Err
+    // here before this fix — it was the CALL SITE that degraded that Err to
+    // `None`, leaving the guard inert for the run. So this phase, not the unit
+    // tests, is what covers the swallowed-Err half of the issue.
+    delete_search_result_files(&results_dir);
+    fs::write(&vectors_npy, b"not an npy file at all").expect("write junk vectors.npy");
+    let junk = run(&[]);
+    let junk_out = combined(&junk);
+    assert!(
+        !junk.status.success(),
+        "a failed corpus measurement must abort the run, not be swallowed into \
+         'cannot verify' (issue #290).\n{junk_out}"
+    );
+    assert!(
+        junk_out.contains("measuring the corpus on disk failed"),
+        "the error must say the measurement FAILED, not that the layout has no \
+         count — they are different conditions.\n{junk_out}"
+    );
+    assert!(
+        !wrote_search_result(),
+        "the rejected run must not publish a result file after a failed measurement"
     );
 
     flush_db(&mut conn);


### PR DESCRIPTION
## The defect

`--skip-upload`'s reuse guard hard-errors on a SHORT corpus but degraded to a printed note and `Ok` whenever it could not determine the dataset's expected row count. Measured on master (redis 8.8.0, 400-doc fixture, corpus file deleted, server corpus emptied behind the tool's back; throwaway harness, printed verbatim):

```
exit_status            = exit status: 0
params.corpus_reuse    = {"status":"unverified","expected_rows":null,"actual_rows":0,"actual_is_estimate":false,"waived_by_allow_partial_corpus":false}
results.mean_recall    = 0.0
results.failed_queries = 0
results.rps            = 1726.4764135698283
```

The same config over its intact corpus, same fixture and machine, printed `→ QPS: 838.7, Recall: 1.0000, Precision@returned: 1.0000, MRR: 1.0000, NDCG: 1.0000 (best of reps)`. One unrepeated pair on a toy fixture — the direction, not a benchmark claim. (A reviewer reproduced the direction independently at 1.79×.)

## What this PR does

`ReusePrecondition::Unverifiable` is split, and the plumbing that collapsed distinct conditions into one `None` is gone.

| variant | reached when | verdict | `status` |
|---|---|---|---|
| `CorpusSizeUnknown` | server count available, dataset's expected count is not | **fatal**, waivable | `corpus_size_unknown` (+ `detail`) |
| `NoServerCount` | no server-side count read back, whatever the dataset side says | warn and continue | `unverified` (unchanged) |

`reuse_expected_rows` returns `Result<u64, String>`; `classify_reuse_precondition` takes `Result<u64, String>`; the call site no longer swallows the `Err`. The issue's option 3 (post-search assertion) was not taken: it fires after the measurement it should prevent, and only catches the all-empty case.

**Ordering, which is load-bearing.** The server side is classified first, and — since round 3 — *probed* first, before any download. Both for the same reason: with no server-side count there is nothing to compare in either direction.

## Review rounds

Six reviewers. Every blocker is fixed; the corrections below are recorded rather than quietly folded in.

### Round 2 — BLOCKER 1: the check rejected datasets the tool was about to fetch

49 of 57 shipped datasets carry a `link`, and the search phase's first act is `read_queries()` → `get_path()`. Measuring before that made the **first `--skip-upload` run on a fresh benchmark client** — the flag's central use case — a hard error, with `--exit-on-error` defaulting to true. Fixed by resolving the dataset in the check. RED on master `7ed81eb`, verbatim:

```
thread '…' panicked at tests/integration_redis.rs:3458:5:
assertion `left == right` failed: the fetch must happen BEFORE the count is measured — 'unverified' here means the corpus arrived too late to be checked: {"status":"unverified","expected_rows":null,"actual_rows":400,"actual_is_estimate":false,"waived_by_allow_partial_corpus":false}
  left: String("unverified")
 right: "verified"
```

Master "passes" this case but records `unverified`; the branch records `verified`. That is a case the guard could not previously check at all.

### Round 2 — BLOCKER 2, and a wrong value I declined

`corpus_completeness_target()` returns `Ok(None)` for two unrelated reasons; only one is #290. Making both fatal broke `synthetic-sparse-300`, whose files are exactly where the code expects and whose real defect was a missing `vector_count`.

**I did not take the suggested `"vector_count": 300`.** The `300` is the **dimension**. The corpus holds **150** rows (`generate_dataset.rs:114`; header read back as `data.csr header (n_row, n_col, nnz) = (150, 300, 1500)`). Declaring 300 would have turned a correct corpus into a fatal `Short` — this issue's own failure class. Two later reviewers confirmed 300 would have shipped green under the guard as it then stood.

### Round 3 — BLOCKER: "no download the run was not already going to do" was false

I asserted that in the PR body, a commit message **and** a shipped code comment. It is wrong twice over, and reviewers measured both:

- `--skip-vector-index` on a schema-less dataset returns **before** `read_queries()`. A run could download an entire corpus and publish nothing.
- The fetch ran **before** the probe, so a dead server paid for the whole download first:

```
master 7ed81eb : http_gets=0  corpus_on_disk=false
branch 514084a : http_gets=1  corpus_on_disk=true
both: Error: --skip-upload: could not read the server-side corpus size ... (Connection refused)
```

On `gist-960` (3.6 GB) that is gigabytes before "Connection refused". Fixed by probing first and resolving only when a count came back, plus an early return for the schema-less `--skip-vector-index` case (same rationale as `--skip-search`: nothing measured, nothing to misreport). **The justification is deleted, not reworded.** What is *not* claimed: that the fetch is free — a fatal verdict still pays for it, bounded to cases where a measurement could change the verdict.

### Round 3 — `sparse` is now measured, not trusted

The deepest finding: after my rework, `reuse_expected_rows` trusted `datasets.json` **unconditionally** for `sparse`/`h5-multi`. Wrong-high → false fatal; wrong-low → `Surplus`, warn, **publish a wrong number**. The second is exactly what this PR exists to close, reintroduced through the datasets.json door.

Fixed the way this repo's own comment has proposed since #224: `csr_row_count` reads `n_row` out of `data.csr`'s 24-byte header. With the corpus present the measurement wins, so the `datasets.json` declaration can no longer steer the verdict. Stated precisely: the CSR header is itself a declaration, just one stored inside the corpus rather than in a config file — what this buys is that the number now travels **with** the file it describes, and a header that lies loudly (a garbage `n_row`) fails as `Short` rather than passing silently. `h5-multi` is the one layout still trusted — summing 100 part headers is not an option — so it is pinned from `datasets.json` instead.

Both pins verified by mutation, needing no corpus and no network:

```
dataset 'synthetic-sparse-300' declares vector_count 999 but generate-dataset writes 150 rows (SYNTHETIC_SPARSE_ROWS); note 300 is its DIMENSION, not its row count
dataset 'laion-img-emb-768d-1Billion-cosine' declares vector_count 12345 but its 100 parts span 1000000000 rows
```

The generator's corpus size is now a shared constant (`SYNTHETIC_SPARSE_ROWS`), so `datasets.json` is checked against the number actually written rather than against a comment.

### Round 3 — messages that described things that never happened

- `get_path()` returns early when the path exists, so a dataset **directory** present without its corpus file is never re-fetched, however valid its link. The old error said the corpus "was not fetched either" — describing an attempt never made, for the exact scenario the README calls realistic. There are now two messages; the present-but-gutted one names the real remedy (restore the file, or delete the directory to force a fresh fetch). `--help` and the self-contradicting README bullet are corrected.
- The resolve error was dropped, so a 404 survived only as 14 of 15 `Download attempt N/15 failed:` lines with the final error printed nowhere. It is now threaded into the verdict's reason.
- `corpus_size_unknown` now carries `detail`, matching `probe_failed`. A waived run is a **published** number whose count was never checked; the reason has to travel in the file.

### Round 3 — the control was decoration

Two reviewers independently showed a neutered guard passing the fetch test's control: `!success` is satisfied because the run dies downstream in `read_queries()`, and the message assertion by the warning the neutered arm still prints. It now asserts **where** the run stopped — no `Experiment stage: Search`, no `WARNING: --skip-upload`. Re-running the reviewers' M1 mutation now fails **both** skip-upload tests instead of one.

### Round 3 — handler coverage

A mutation campaign found the classifier well pinned and the handler bare: making `NoServerCount` fatal was killed by nothing. Three tests now drive `check_corpus_reuse_precondition` through a stub engine — the only way to force `corpus_row_count → Ok(None)`. Each was verified to kill what it claims and nothing else:

| mutation | tests killed |
|---|---|
| `NoServerCount` arm made fatal | `no_server_side_count_warns_and_continues` (the other 2 stub tests ok) |
| `record_rejected_experiment` dropped | `a_short_exact_count_still_aborts_and_is_recorded_as_rejected` (other 2 ok) |
| sparse measurement removed | **two**: `a_present_csr_corpus_is_measured_not_trusted` and `engine::redis::tests::unmeasurable_layouts_fall_back_only_when_their_files_exist` |
| `CorpusSizeUnknown` neutered to warn-and-continue | both skip-upload integration tests |
| coherent big-endian flip (`from_le_bytes`+`to_le_bytes`) | `csr_row_count_decodes_a_literal_little_endian_fixture` and `gt_decodes_a_literal_little_endian_fixture` |

Corrections to how I described this: the sparse mutation kills **two** tests, not "exactly one and no other"; the third row above is not a stub-engine test (the third stub test is `a_run_that_will_not_search_is_not_checked_at_all`, which a reviewer mutation-tested separately and which holds); and the endianness row is new in round 4 — before it, that flip left the whole suite green.

### Round 4 — a remedy that destroys data, and unpinned endianness

**8 of the 57 shipped datasets have no `link`** — laion, `random-100`, `random-100-euclidean`, `random-768-25-tenants` and the four generated `synthetic-*` fixtures, which is also the shape `write_match_any_project` produces for this PR's own tests. The gutted-directory message advised deleting the directory to force a re-fetch, with no `link` check: for those 8 that would not re-fetch anything and *would* destroy the `tests.jsonl` / `payloads.jsonl` beside the missing corpus. Same class round 3 closed (advice describing an attempt that cannot be made), one level down, with data loss attached. Now gated on `config.link.is_some()`, pinned in both directions.

A shipped comment also refuted itself — `experiment.rs` carried "The error is dropped on purpose … fails properly" directly above "The resolve error is KEPT, not dropped", both introduced in `b50a2d1`. Deleted.

**Endianness was unpinned.** `csr_row_count_matches_a_full_parse` compared two functions that both go through `read_i64_le`, against a fixture written by `write_sparse_matrix` in the same module — so a coherent big-endian flip (7 `from_le_bytes` + 48 `to_le_bytes` sites) left the whole suite green. CSR is little-endian by definition (it is what `sparse_reader.py` writes), so a literal-byte fixture is the only thing that pins it, mirroring what this file already does for `results.gt`. That flip now fails two tests. The old test name also overstated: on a valid header over a truncated body the two disagree *by design*, so it is now `..._agrees_with_a_full_parse_on_well_formed_input`.

## Corrections to my own earlier claims

1. `a72e2ba` claimed the unit tests show a failed header read erroring "instead of `Ok(None)`". Wrong: master already returned `Err`; the swallow was one level up. Corrected in `ce51f65`.
2. That commit also said each unit test had a positive control. Two did not. Fixed rather than reworded; **all** `reuse_precondition_tests` now have one.
3. I cited a repo policy ("only things that affect indexing speed warn") that is written down nowhere and is false of three things that warn. Withdrawn; master's narrower sentence restored (not verbatim — I dropped "Repo policy on").
4. **`integration_redis` master baseline: 39, not 38.** Three reviewers derived this independently; 38 is `cff7e3a`, the pre-merge base. My delta is **+2**, not +3. My own transcripts already implied it ("39 filtered out"). Two test doc-comments still naming `cff7e3a` as master are refreshed to `7ed81eb`.
5. "No download the run was not already going to do" — false, see above. Deleted from body, comment and (by this commit message) the record.
6. `generate_dataset.rs:113` → it is line **114**.
7. "Each mutation fails exactly one test and no other" — false; the sparse one kills two. And the handler table listed a non-stub test as its third row. Both corrected above.
8. "No declaration can mislead the verdict" was loose. The CSR header is a declaration too. Reworded.
9. **Scope spillover, flagged rather than found by me:** `measured_vector_count()` is shared, so `sparse` is now measured by `corpus_completeness_target()` as well, which `redis.rs::upload()` `?`-propagates under `shared_corpus`. A `msmarco-sparse-*` corpus whose real `n_row` exceeded a round declared count would now hard-error the *upload*, not just the reuse check. Nothing is affected today — no shipped config sets `shared_corpus`, and `read_vectors()` rejects `"sparse"` outright — but I had framed this change as `--skip-upload`-only and it is not.

### Process note

While measuring the endianness mutation I ran `git checkout -- src/readers/sparse_reader.rs` to revert it. That is forbidden in this repo for exactly this reason, and it silently discarded the new fixture along with the mutation. The suite was green without it, so nothing failed; I caught it by re-grepping for the test name. Re-applied and re-verified. Recording it because a green suite is not evidence that an edit landed.

## What is NOT covered — explicitly

- **No test runs `--skip-upload` against a real `sparse` or `h5-multi` dataset.** The CSR measurement and the declared-count fallback are covered by unit tests over synthetic fixtures; the `laion` consequence is reasoned from `datasets.json`, not measured end to end.
- **A dataset directory present without its corpus file is still not re-fetched.** I chose to correct the message rather than add an auto-refetch, which would mean overwriting a partially-present dataset directory. Stated as a limit, not a fix.
- **`h5-multi` remains trusted at runtime.** The span pin checks its declaration from `datasets.json`; nothing measures the parts.
- **A wrong `vector_count` on a machine without the corpus** still mis-verifies for the fallback layouts. There is nothing to measure against there.
- The `≈` estimate rendering in the new fatal message is formatted but never asserted.
- **Only Redis was tested live** for the new behaviour; qdrant and vectorsets suites are regression cover only.
- **Concurrency (pre-existing, out of scope):** `extract_tgz` calls `create_dir_all` before unpacking into the shared `datasets/<name>/`, so a concurrent process can see a half-written tree. That used to give a soft `unverified`. It now gives a fatal `corpus_size_unknown` whose `detail` begins `measuring the corpus on disk failed` — a reviewer measured a 12-byte `data.csr` going from exit 0 `verified` on master to exit 1 rejected here. Correct in kind (a half-written corpus is not a corpus), but it is a behaviour change on a race this PR did not introduce and does not fix.
- The reviewer-suggested gates `--lib effective_config` and `--lib every_measuring_flag` **match no test in this tree** (`0 tests`; `grep` finds neither name). Not run, and no green implied.

## Behaviour change for users

A `--skip-upload` run whose corpus is not on the machine and cannot be resolved, or whose unmeasurable layout declares no `vector_count`, now fails where it previously published. A dataset merely not downloaded yet is fetched and verified. An unreachable server aborts before any download. Engines with no row-count probe are unaffected. `--skip-search`, and `--skip-vector-index` on a schema-less dataset, are unaffected.

## Gates

All on `6988976` (merges master `7ed81eb`). Own worktree, own `CARGO_TARGET_DIR`, own containers (`c290d-redis` 6501, `c290d-qdrant` 6502/6503 — never 6399).

| command | result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo test --lib --bins` | `129` + `0`×3 + `2` + `788` = **919** (master `7ed81eb`: 126+2+777 = **905**, **+14**) |
| `cargo test --test overhead_invariants` | `running 9 tests` → 9 passed |
| `cargo test --test integration_redis -- --test-threads=1` | `running 41 tests` → 41 passed (master **39** → **+2**) |
| `cargo test --test integration_vectorsets -- --test-threads=1` | `running 13 tests` → 13 passed |
| `cargo test --test integration_qdrant -- --test-threads=1` | `running 27 tests` → 27 passed |

`--test-threads=1` is quoted because it is load-bearing: these tests call `flush_db()`. The master baseline was measured in a separate detached worktree at `7ed81eb` after `touch src/lib.rs src/bin/vector_db_benchmark/main.rs`. No `#[test]` was removed; the one renamed test had its assertion strengthened from `matches!` to an exact `assert_eq!`.

Closes #290.

