### PR TITLE
test(harness): destructive suites refuse to FLUSHALL a server they do not own (#292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,10 @@ jobs:
       run: cargo test --test overhead_invariants --release
 
     - name: Run test-harness invariants (no container)
-      # INV-P1/P2/P3 (#292): each integration suite's port has exactly one source
-      # of truth, and every FLUSHALL-issuing suite claims its instance from
-      # inside `test_port()` so it cannot destroy a server it does not own.
+      # INV-P1..P6 (#292): each suite has exactly one source of truth for its
+      # port and it matches docker-compose.test.yml; every server-wiping suite
+      # claims its instance from inside `test_port()`; the claim decision fails
+      # closed; and no shared helper under tests/common/ can wipe a server.
       run: cargo test --test harness_invariants --release
 
   integration-redis:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,12 @@ jobs:
       # had never run in CI. INV-4/INV-4b (#214) join them here.
       run: cargo test --test overhead_invariants --release
 
+    - name: Run test-harness invariants (no container)
+      # INV-P1/P2/P3 (#292): each integration suite's port has exactly one source
+      # of truth, and every FLUSHALL-issuing suite claims its instance from
+      # inside `test_port()` so it cannot destroy a server it does not own.
+      run: cargo test --test harness_invariants --release
+
   integration-redis:
     name: Integration tests (Redis)
     runs-on: ubuntu-latest

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2165,28 +2165,48 @@ fn display_id(id: &str) -> &str {
     }
 }
 
-/// Sum `keys=` across every `dbN:` line of an `INFO keyspace` section.
+/// Sum `keys=` across every `dbN:` line of an `INFO keyspace` section, or `None`
+/// when the section cannot be trusted.
 ///
-/// Redis omits empty databases entirely, so an empty section legitimately means
-/// zero keys. Field ORDER and the extra fields differ per engine — verified live
-/// on redis:8.8.0 (`db0:keys=1,expires=0,avg_ttl=0,subexpiry=0`),
-/// valkey-bundle (`...,keys_with_volatile_items=0`), dragonfly df-v1.40.1
-/// (`db0:keys=1,expires=0,hits=0,misses=0,hit_ratio=0.00,avg_ttl=-1`) and
-/// kividb v1.0.2-full (`db0:keys=1,expires=0,avg_ttl=0`) — so parse by name.
-pub fn sum_keyspace_keys(info: &str) -> i64 {
-    info.lines()
-        .filter_map(|line| {
-            let line = line.trim();
-            if !line.starts_with("db") {
-                return None;
-            }
-            let (_db, fields) = line.split_once(':')?;
-            fields
-                .split(',')
-                .find_map(|kv| kv.trim().strip_prefix("keys="))
-                .and_then(|v| v.trim().parse::<i64>().ok())
-        })
-        .sum()
+/// Redis omits empty databases entirely, so a section that has the `# Keyspace`
+/// header and no `dbN:` lines legitimately means zero keys. What must NOT read as
+/// zero is a reply that never was a keyspace section, or a `dbN:` line whose
+/// `keys=` is missing, unparseable or negative — the earlier `-> i64` version
+/// collapsed all of those to `0`, i.e. to `Fresh`, which is this guard's own bug
+/// class one notch in. `None` becomes [`Probe::Inconclusive`], which refuses.
+///
+/// Field ORDER and the extra fields differ per engine — verified live on
+/// redis:8.8.0 (`db0:keys=1,expires=0,avg_ttl=0,subexpiry=0`), valkey-bundle
+/// (`...,keys_with_volatile_items=0`), dragonfly df-v1.40.1
+/// (`db0:keys=1,expires=0,hits=0,misses=0,hit_ratio=0.00,avg_ttl=-1`) and kividb
+/// v1.0.2-full (`db0:keys=1,expires=0,avg_ttl=0`) — so parse by name. All four
+/// emit the `# Keyspace` header (measured).
+pub fn sum_keyspace_keys(info: &str) -> Option<i64> {
+    if !info
+        .lines()
+        .any(|l| l.trim().eq_ignore_ascii_case("# keyspace"))
+    {
+        return None;
+    }
+    let mut total: i64 = 0;
+    for line in info.lines() {
+        let line = line.trim();
+        if !line.starts_with("db") {
+            continue;
+        }
+        let (_db, fields) = line.split_once(':')?;
+        let keys: i64 = fields
+            .split(',')
+            .find_map(|kv| kv.trim().strip_prefix("keys="))?
+            .trim()
+            .parse()
+            .ok()?;
+        if keys < 0 {
+            return None;
+        }
+        total = total.checked_add(keys)?;
+    }
+    Some(total)
 }
 
 /// Pull `field:` out of an `INFO` section body.
@@ -2262,6 +2282,12 @@ fn probe_server(host: &str, port: u16, wait: std::time::Duration) -> Probe {
 
     // A server replaying its RDB/AOF answers INFO but reports a keyspace that is
     // still filling, so "0 keys" would be a lie.
+    //
+    // Best-effort by design: an engine whose `INFO persistence` errors, or that
+    // omits `loading` entirely (kividb v1.0.2-full does — measured), simply gets
+    // no loading check. Making a missing section fatal would refuse those engines
+    // outright, and a server so locked down that INFO fails is caught two lines
+    // below by `INFO keyspace` anyway.
     if let Ok(persistence) = redis::cmd("INFO")
         .arg("persistence")
         .query::<String>(&mut conn)
@@ -2286,7 +2312,13 @@ fn probe_server(host: &str, port: u16, wait: std::time::Duration) -> Probe {
             ));
         }
     };
-    let keys = sum_keyspace_keys(&keyspace);
+    let Some(keys) = sum_keyspace_keys(&keyspace) else {
+        return Probe::Inconclusive(format!(
+            "could not parse the `INFO keyspace` reply from {host}:{port} (no `# Keyspace` \
+             header, or a `dbN:` line without a usable `keys=`), so the number of keys at \
+             risk is unknown; the reply was: {keyspace:?}"
+        ));
+    };
 
     let index_count = match redis::cmd("FT._LIST").query::<Vec<String>>(&mut conn) {
         Ok(v) => v.len(),
@@ -2321,8 +2353,30 @@ fn claim_file(target: &str, host: &str, port: u16) -> Option<std::path::PathBuf>
 
 /// Claim `host:port` for a destructive suite, or panic with the refusal message.
 ///
-/// Called once per test process from the suite's `test_port()`.
+/// Called from the suite's `test_port()`. The WORK happens once per process; the
+/// panic is replayed cheaply for every later test.
+///
+/// That split matters. The suites memoize the port with
+/// `OnceLock::get_or_init`, and `get_or_init` does NOT memoize an initializer
+/// that panics — so putting the panic inside it made every one of the 44 tests
+/// re-run the whole 30 s reachability loop. Measured against a dead port, two
+/// tests took 60.14 s instead of 20.13 s; the full suite would have taken ~22
+/// minutes to report "server not available". Here the memoized value is the
+/// VERDICT (`None` = allowed, `Some(msg)` = refuse) and the panic happens
+/// outside the initializer, so only the first test pays.
+static CLAIM_OUTCOME: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+
 pub fn claim_resp_instance(target: &str, port_env: &str, host: &str, port: u16) {
+    if let Some(msg) = CLAIM_OUTCOME.get_or_init(|| claim_outcome(target, port_env, host, port)) {
+        panic!("{msg}");
+    }
+}
+
+/// The decision, as a value. Never panics, so [`CLAIM_OUTCOME`] memoizes it.
+///
+/// One `OnceLock` per process is enough because a test binary is one suite
+/// against one server: `target`/`host`/`port` are identical on every call.
+fn claim_outcome(target: &str, port_env: &str, host: &str, port: u16) -> Option<String> {
     let forced = std::env::var(ALLOW_DIRTY_ENV)
         .map(|v| !v.is_empty() && v != "0")
         .unwrap_or(false);
@@ -2367,7 +2421,7 @@ pub fn claim_resp_instance(target: &str, port_env: &str, host: &str, port: u16) 
     });
 
     match verdict {
-        Claim::Refuse(msg) => panic!("{msg}"),
+        Claim::Refuse(msg) => Some(msg),
         Claim::Fresh | Claim::Reused => {
             if let Probe::Reachable { server_id, .. } = &probe {
                 if let Some(p) = path {
@@ -2377,6 +2431,7 @@ pub fn claim_resp_instance(target: &str, port_env: &str, host: &str, port: u16) 
                     let _ = fs::write(&p, server_id);
                 }
             }
+            None
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1991,9 +1991,10 @@ pub struct ClaimInputs<'a> {
     /// Server identity this target directory recorded the last time it claimed
     /// `host:port`, if any.
     pub prior_claim: Option<&'a str>,
-    /// Server identity now: `run_id` from `INFO server`. Empty when the server
-    /// does not report one — an empty identity NEVER matches a prior claim, so
-    /// such a server can only be used when it is empty or the check is waived.
+    /// Server identity now (see [`server_identity`]). Empty when the server
+    /// reports neither `run_id` nor `master_replid` — an empty identity NEVER
+    /// matches a prior claim, so such a server can only be used when it is empty
+    /// or the check is waived.
     pub server_id: &'a str,
     /// Operator set [`ALLOW_DIRTY_ENV`].
     pub forced: bool,
@@ -2053,18 +2054,37 @@ fn claim_file(target: &str, host: &str, port: u16) -> Option<std::path::PathBuf>
     )
 }
 
-/// `run_id` from `INFO server`, or an empty string when the server does not
-/// report one.
-fn server_run_id(conn: &mut redis::Connection) -> String {
-    let info: String = redis::cmd("INFO")
-        .arg("server")
-        .query(conn)
-        .unwrap_or_default();
+/// Pull `field:` out of an `INFO` section body.
+pub fn info_field(info: &str, field: &str) -> String {
+    let prefix = format!("{field}:");
     info.lines()
-        .find_map(|l| l.trim().strip_prefix("run_id:"))
+        .find_map(|l| l.trim().strip_prefix(prefix.as_str()))
         .unwrap_or("")
         .trim()
         .to_string()
+}
+
+/// A per-instance random identity for the server, so a claim recorded against
+/// one server is not honoured for a different one that later took the port.
+///
+/// `run_id` from `INFO server` where available (Redis, Valkey, KiviDB), falling
+/// back to `master_replid` from `INFO replication` (Dragonfly df-v1.40.1 reports
+/// no `run_id`; both were checked live). Empty when neither is present — an
+/// empty identity never matches a prior claim.
+fn server_identity(conn: &mut redis::Connection) -> String {
+    let server: String = redis::cmd("INFO")
+        .arg("server")
+        .query(conn)
+        .unwrap_or_default();
+    let run_id = info_field(&server, "run_id");
+    if !run_id.is_empty() {
+        return run_id;
+    }
+    let repl: String = redis::cmd("INFO")
+        .arg("replication")
+        .query(conn)
+        .unwrap_or_default();
+    info_field(&repl, "master_replid")
 }
 
 /// Claim `host:port` for a destructive suite, or panic with the refusal message.
@@ -2086,7 +2106,7 @@ pub fn claim_resp_instance(target: &str, port_env: &str, host: &str, port: u16) 
         .query::<Vec<String>>(&mut conn)
         .map(|v| v.len())
         .unwrap_or(0);
-    let server_id = server_run_id(&mut conn);
+    let server_id = server_identity(&mut conn);
 
     let path = claim_file(target, host, port);
     let prior = path

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2263,8 +2263,16 @@ fn server_identity(conn: &mut redis::Connection) -> String {
 }
 
 /// Probe the server. EVERY failure path yields [`Probe::Inconclusive`], which
-/// [`claim_verdict`] refuses on.
-fn probe_server(host: &str, port: u16, wait: std::time::Duration) -> Probe {
+/// [`claim_verdict`] refuses on. `Probe::Reachable` is constructed at exactly
+/// one place: the final statement, after `INFO keyspace` AND `FT._LIST` both
+/// returned `Ok`.
+///
+/// `pub` and `wait`-parameterised so `tests/harness_invariants.rs` can assert the
+/// unreachable case directly against a closed port with a zero wait. Without
+/// that, the whole producer side was untested: a mutant returning
+/// `Reachable { keys: 0, index_count: 0 }` for an unreachable server — the exact
+/// regression INV-P4's docstring cites — passed every invariant.
+pub fn probe_server(host: &str, port: u16, wait: std::time::Duration) -> Probe {
     let url = format!("redis://{host}:{port}/");
     let Ok(client) = redis::Client::open(url.as_str()) else {
         return Probe::Inconclusive(format!("could not parse the connection URL {url}"));

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1936,3 +1936,189 @@ pub fn read_results_obj(root: &Path, engine: &str) -> serde_json::Value {
     let v: serde_json::Value = serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
     v["results"].clone()
 }
+
+// ---------------------------------------------------------------------------
+// Destructive-suite instance ownership (issue #292)
+// ---------------------------------------------------------------------------
+//
+// Four integration suites (`integration_redis`, `integration_valkey`,
+// `integration_dragonfly`, `integration_kividb`) share one `flush_db()` shape:
+// drop every index `FT._LIST` reports, then `FLUSHALL`. That destroys the WHOLE
+// server, and each suite's default port is a shared container from
+// `tests/docker-compose.test.yml`. Two incidents were caused by a port override
+// that looked applied but was not, so the run silently destroyed a server it did
+// not own.
+//
+// The guard below makes the destructive suites refuse to touch a server that
+// already holds state this harness did not create. It is deliberately placed
+// behind the suites' `test_port()`, because EVERY path that reaches the server
+// — direct `redis::Client` connections and the `REDIS_PORT`-style env vars
+// handed to spawned benchmark binaries alike — resolves its port there.
+
+/// Env var an operator sets to waive [`claim_resp_instance`]'s ownership check.
+pub const ALLOW_DIRTY_ENV: &str = "VDBB_TEST_ALLOW_DIRTY";
+
+/// Verdict of the ownership check a FLUSHALL-issuing suite runs before it
+/// touches a server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Claim {
+    /// Server held no keys and no indexes, so this process takes it over.
+    Fresh,
+    /// Server is non-empty, but either the operator waived the check or the
+    /// server's identity matches the claim this target directory recorded, so
+    /// the state is this harness's own leftovers.
+    Reused,
+    /// Server holds state this harness never created. Carries the message to
+    /// show the operator.
+    Refuse(String),
+}
+
+/// Everything [`claim_verdict`] depends on, so the decision is unit-testable
+/// with no live server.
+#[derive(Debug, Clone)]
+pub struct ClaimInputs<'a> {
+    /// Cargo test target, e.g. `"integration_redis"`. Used in the message.
+    pub target: &'a str,
+    /// Env var that selects this suite's port, e.g. `"REDIS_TEST_PORT"`.
+    pub port_env: &'a str,
+    pub host: &'a str,
+    pub port: u16,
+    /// `DBSIZE` reported by the target server.
+    pub dbsize: i64,
+    /// Number of entries `FT._LIST` returned (0 when the command is
+    /// unsupported or errored).
+    pub index_count: usize,
+    /// Server identity this target directory recorded the last time it claimed
+    /// `host:port`, if any.
+    pub prior_claim: Option<&'a str>,
+    /// Server identity now: `run_id` from `INFO server`. Empty when the server
+    /// does not report one — an empty identity NEVER matches a prior claim, so
+    /// such a server can only be used when it is empty or the check is waived.
+    pub server_id: &'a str,
+    /// Operator set [`ALLOW_DIRTY_ENV`].
+    pub forced: bool,
+}
+
+/// Decide whether a destructive suite may run against the server described by
+/// `i`. Pure: no I/O, no env reads.
+pub fn claim_verdict(i: &ClaimInputs<'_>) -> Claim {
+    if i.forced {
+        return Claim::Reused;
+    }
+    if i.dbsize <= 0 && i.index_count == 0 {
+        return Claim::Fresh;
+    }
+    if !i.server_id.is_empty() && i.prior_claim == Some(i.server_id) {
+        return Claim::Reused;
+    }
+    Claim::Refuse(format!(
+        "\n\n\
+         REFUSING TO RUN `{target}` AGAINST {host}:{port}\n\
+         \n\
+         That server already holds {dbsize} key(s) and {indexes} search index(es) that this\n\
+         test harness did not create. Every test in `{target}` calls `flush_db()`, which\n\
+         drops every index `FT._LIST` reports and then issues `FLUSHALL` — running here\n\
+         would destroy all of it.\n\
+         \n\
+         Point the suite at a container of your own:\n\
+         \n\
+         \x20   docker run -d --rm -p <your-port>:6379 --name <your-name> <image>\n\
+         \x20   {port_env}=<your-port> cargo test --test {target} -- --test-threads=1\n\
+         \n\
+         `{port_env}` is the ONLY supported way to move the suite. Editing the port literal\n\
+         in tests/{target}.rs is rejected by tests/harness_invariants.rs.\n\
+         \n\
+         If that data really is disposable, re-run with {allow}=1 to waive this check.\n",
+        target = i.target,
+        host = i.host,
+        port = i.port,
+        dbsize = i.dbsize,
+        indexes = i.index_count,
+        port_env = i.port_env,
+        allow = ALLOW_DIRTY_ENV,
+    ))
+}
+
+/// Path of the file recording which server identity this target directory last
+/// claimed for `host:port`. Lives beside the test binaries (derived from
+/// `current_exe()`: `<target>/<profile>/deps/<bin>` -> `<target>`), so a session
+/// running with its own `CARGO_TARGET_DIR` has its own claims.
+fn claim_file(target: &str, host: &str, port: u16) -> Option<std::path::PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let target_dir = exe.parent()?.parent()?.parent()?;
+    Some(
+        target_dir
+            .join("vdbb-test-claims")
+            .join(format!("{target}-{host}-{port}.claim")),
+    )
+}
+
+/// `run_id` from `INFO server`, or an empty string when the server does not
+/// report one.
+fn server_run_id(conn: &mut redis::Connection) -> String {
+    let info: String = redis::cmd("INFO")
+        .arg("server")
+        .query(conn)
+        .unwrap_or_default();
+    info.lines()
+        .find_map(|l| l.trim().strip_prefix("run_id:"))
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+/// Claim `host:port` for a destructive suite, or panic with the refusal message.
+///
+/// Called once per test process from the suite's `test_port()`. A server that
+/// cannot be reached is left alone: connecting is the suite's own
+/// `wait_for_*()` job, and an unreachable server cannot be damaged.
+pub fn claim_resp_instance(target: &str, port_env: &str, host: &str, port: u16) {
+    let url = format!("redis://{host}:{port}/");
+    let Ok(client) = redis::Client::open(url.as_str()) else {
+        return;
+    };
+    let Ok(mut conn) = client.get_connection_with_timeout(std::time::Duration::from_secs(2)) else {
+        return;
+    };
+
+    let dbsize: i64 = redis::cmd("DBSIZE").query(&mut conn).unwrap_or(0);
+    let index_count = redis::cmd("FT._LIST")
+        .query::<Vec<String>>(&mut conn)
+        .map(|v| v.len())
+        .unwrap_or(0);
+    let server_id = server_run_id(&mut conn);
+
+    let path = claim_file(target, host, port);
+    let prior = path
+        .as_ref()
+        .and_then(|p| fs::read_to_string(p).ok())
+        .map(|s| s.trim().to_string());
+
+    let forced = std::env::var(ALLOW_DIRTY_ENV)
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false);
+
+    let verdict = claim_verdict(&ClaimInputs {
+        target,
+        port_env,
+        host,
+        port,
+        dbsize,
+        index_count,
+        prior_claim: prior.as_deref(),
+        server_id: &server_id,
+        forced,
+    });
+
+    match verdict {
+        Claim::Refuse(msg) => panic!("{msg}"),
+        Claim::Fresh | Claim::Reused => {
+            if let Some(p) = path {
+                if let Some(dir) = p.parent() {
+                    let _ = fs::create_dir_all(dir);
+                }
+                let _ = fs::write(&p, &server_id);
+            }
+        }
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2026,6 +2026,13 @@ pub struct ClaimInputs<'a> {
     pub prior_claim: Option<&'a str>,
     /// Where that claim is stored, for the message.
     pub claim_path: &'a str,
+    /// Port this engine's server listens on INSIDE its container, so the
+    /// `docker run -p …` line in the refusal is runnable. NOT always 6379 —
+    /// kividb listens on 6380 (`tests/docker-compose.test.yml` maps
+    /// `6386:6380`), and an operator who followed a hardcoded `:6379` would get
+    /// a container the suite cannot reach and then a second refusal from this
+    /// very guard.
+    pub container_port: u16,
     /// Operator set [`ALLOW_DIRTY_ENV`].
     pub forced: bool,
 }
@@ -2035,14 +2042,17 @@ fn refusal_footer(i: &ClaimInputs<'_>) -> String {
     format!(
         "Point the suite at a container of your own:\n\
          \n\
-         \x20   docker run -d --rm -p <your-port>:6379 --name <your-name> <image>\n\
+         \x20   docker run -d --rm -p <your-port>:{container} --name <your-name> <image>\n\
          \x20   {port_env}=<your-port> cargo test --test {target} -- --test-threads=1\n\
          \n\
-         `{port_env}` is the ONLY supported way to move the suite. Editing the port literal\n\
-         in tests/{target}.rs is rejected by tests/harness_invariants.rs.\n\
+         `{port_env}` is the supported way to move the suite. Do not edit the port in\n\
+         tests/{target}.rs instead: tests/harness_invariants.rs pins that default to the\n\
+         `{target}` mapping in tests/docker-compose.test.yml, so an edit fails the build,\n\
+         and it would move the default for everyone rather than just for you.\n\
          \n\
          If the server really is yours and its contents are disposable, re-run with\n\
          {allow}=1 to waive this check.\n",
+        container = i.container_port,
         port_env = i.port_env,
         target = i.target,
         allow = ALLOW_DIRTY_ENV,
@@ -2358,16 +2368,25 @@ fn claim_file(target: &str, host: &str, port: u16) -> Option<std::path::PathBuf>
 ///
 /// That split matters. The suites memoize the port with
 /// `OnceLock::get_or_init`, and `get_or_init` does NOT memoize an initializer
-/// that panics — so putting the panic inside it made every one of the 44 tests
-/// re-run the whole 30 s reachability loop. Measured against a dead port, two
-/// tests took 60.14 s instead of 20.13 s; the full suite would have taken ~22
-/// minutes to report "server not available". Here the memoized value is the
-/// VERDICT (`None` = allowed, `Some(msg)` = refuse) and the panic happens
-/// outside the initializer, so only the first test pays.
+/// that panics — so putting the panic inside it made EVERY test re-run the whole
+/// 30 s reachability loop. Measured against a dead port, the same two tests took
+/// 60.21 s with the panic inside the initializer and 30.07 s with it outside; the
+/// 44-test suite would have needed ~22 min (44 x 30 s) to report "server not
+/// available" and now finishes in 30.17 s. Here the memoized value is the VERDICT
+/// (`None` = allowed, `Some(msg)` = refuse) and the panic happens outside the
+/// initializer, so only the first test pays the loop.
 static CLAIM_OUTCOME: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
 
-pub fn claim_resp_instance(target: &str, port_env: &str, host: &str, port: u16) {
-    if let Some(msg) = CLAIM_OUTCOME.get_or_init(|| claim_outcome(target, port_env, host, port)) {
+pub fn claim_resp_instance(
+    target: &str,
+    port_env: &str,
+    host: &str,
+    port: u16,
+    container_port: u16,
+) {
+    if let Some(msg) =
+        CLAIM_OUTCOME.get_or_init(|| claim_outcome(target, port_env, host, port, container_port))
+    {
         panic!("{msg}");
     }
 }
@@ -2376,7 +2395,13 @@ pub fn claim_resp_instance(target: &str, port_env: &str, host: &str, port: u16) 
 ///
 /// One `OnceLock` per process is enough because a test binary is one suite
 /// against one server: `target`/`host`/`port` are identical on every call.
-fn claim_outcome(target: &str, port_env: &str, host: &str, port: u16) -> Option<String> {
+fn claim_outcome(
+    target: &str,
+    port_env: &str,
+    host: &str,
+    port: u16,
+    container_port: u16,
+) -> Option<String> {
     let forced = std::env::var(ALLOW_DIRTY_ENV)
         .map(|v| !v.is_empty() && v != "0")
         .unwrap_or(false);
@@ -2417,6 +2442,7 @@ fn claim_outcome(target: &str, port_env: &str, host: &str, port: u16) -> Option<
         probe: &probe,
         prior_claim: prior.as_deref(),
         claim_path: &path_display,
+        container_port,
         forced,
     });
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1944,32 +1944,68 @@ pub fn read_results_obj(root: &Path, engine: &str) -> serde_json::Value {
 // Four integration suites (`integration_redis`, `integration_valkey`,
 // `integration_dragonfly`, `integration_kividb`) share one `flush_db()` shape:
 // drop every index `FT._LIST` reports, then `FLUSHALL`. That destroys the WHOLE
-// server, and each suite's default port is a shared container from
-// `tests/docker-compose.test.yml`. Two incidents were caused by a port override
-// that looked applied but was not, so the run silently destroyed a server it did
-// not own.
+// server — every database, not just db 0 — and each suite's default port is a
+// shared container from `tests/docker-compose.test.yml`. Two incidents were
+// caused by a port override that looked applied but was not, so the run silently
+// destroyed a server it did not own.
 //
-// The guard below makes the destructive suites refuse to touch a server that
-// already holds state this harness did not create. It is deliberately placed
-// behind the suites' `test_port()`, because EVERY path that reaches the server
-// — direct `redis::Client` connections and the `REDIS_PORT`-style env vars
-// handed to spawned benchmark binaries alike — resolves its port there.
+// The guard below makes the destructive suites refuse to touch a server unless
+// they can POSITIVELY establish it is safe. It is deliberately placed behind the
+// suites' `test_port()`, because EVERY path that reaches the server — direct
+// `redis::Client` connections and the `REDIS_PORT`-style env vars handed to
+// spawned benchmark binaries alike — resolves its port there.
+//
+// Design rule, learned the hard way: **every way the probe can fail must refuse.**
+// The first version coerced an unreachable server, a denied command and an
+// unsupported command all to "0 keys", i.e. to `Fresh`, which fails OPEN in the
+// one function whose job is to refuse.
 
-/// Env var an operator sets to waive [`claim_resp_instance`]'s ownership check.
+/// Env var an operator sets to waive the ownership check.
 pub const ALLOW_DIRTY_ENV: &str = "VDBB_TEST_ALLOW_DIRTY";
+
+/// How long [`claim_resp_instance`] waits for the server to become reachable.
+///
+/// Must be >= the longest `wait_for_*()` deadline in the guarded suites (30 s in
+/// `integration_valkey` / `_dragonfly` / `_kividb`, 10 s in `integration_redis`).
+/// If it were shorter, the documented "bring the container up, then run the
+/// suite" workflow would race past the guard: the probe would give up, the
+/// suite's own wait would succeed, and — because the claim runs once per process
+/// behind a `OnceLock` — it would never be retried.
+const CLAIM_REACHABLE_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Per-attempt connect timeout inside that window.
+const CLAIM_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// What the pre-flight probe managed to learn about the target server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Probe {
+    /// The server answered every question the guard asked.
+    Reachable {
+        /// Keys summed over ALL databases (`INFO keyspace`), not just db 0.
+        /// `DBSIZE` was wrong here: it counts one database while `FLUSHALL`
+        /// destroys all of them, so keys parked in db 1+ read as "empty".
+        keys: i64,
+        /// Number of entries `FT._LIST` returned.
+        index_count: usize,
+        /// Per-start server identity; see [`server_identity`]. May be empty.
+        server_id: String,
+    },
+    /// The guard could not establish that the server is safe to destroy —
+    /// unreachable, still loading, or a probe command that errored. Carries a
+    /// short reason for the message.
+    Inconclusive(String),
+}
 
 /// Verdict of the ownership check a FLUSHALL-issuing suite runs before it
 /// touches a server.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Claim {
-    /// Server held no keys and no indexes, so this process takes it over.
+    /// Server holds nothing, so this process takes it over.
     Fresh,
     /// Server is non-empty, but either the operator waived the check or the
-    /// server's identity matches the claim this target directory recorded, so
-    /// the state is this harness's own leftovers.
+    /// server's identity matches the claim this target directory recorded.
     Reused,
-    /// Server holds state this harness never created. Carries the message to
-    /// show the operator.
+    /// Not established as safe. Carries the message to show the operator.
     Refuse(String),
 }
 
@@ -1977,51 +2013,27 @@ pub enum Claim {
 /// with no live server.
 #[derive(Debug, Clone)]
 pub struct ClaimInputs<'a> {
-    /// Cargo test target, e.g. `"integration_redis"`. Used in the message.
+    /// Cargo test target, e.g. `"integration_redis"`.
     pub target: &'a str,
     /// Env var that selects this suite's port, e.g. `"REDIS_TEST_PORT"`.
     pub port_env: &'a str,
     pub host: &'a str,
     pub port: u16,
-    /// `DBSIZE` reported by the target server.
-    pub dbsize: i64,
-    /// Number of entries `FT._LIST` returned (0 when the command is
-    /// unsupported or errored).
-    pub index_count: usize,
+    /// What the probe learned.
+    pub probe: &'a Probe,
     /// Server identity this target directory recorded the last time it claimed
     /// `host:port`, if any.
     pub prior_claim: Option<&'a str>,
-    /// Server identity now (see [`server_identity`]). Empty when the server
-    /// reports neither `run_id` nor `master_replid` — an empty identity NEVER
-    /// matches a prior claim, so such a server can only be used when it is empty
-    /// or the check is waived.
-    pub server_id: &'a str,
+    /// Where that claim is stored, for the message.
+    pub claim_path: &'a str,
     /// Operator set [`ALLOW_DIRTY_ENV`].
     pub forced: bool,
 }
 
-/// Decide whether a destructive suite may run against the server described by
-/// `i`. Pure: no I/O, no env reads.
-pub fn claim_verdict(i: &ClaimInputs<'_>) -> Claim {
-    if i.forced {
-        return Claim::Reused;
-    }
-    if i.dbsize <= 0 && i.index_count == 0 {
-        return Claim::Fresh;
-    }
-    if !i.server_id.is_empty() && i.prior_claim == Some(i.server_id) {
-        return Claim::Reused;
-    }
-    Claim::Refuse(format!(
-        "\n\n\
-         REFUSING TO RUN `{target}` AGAINST {host}:{port}\n\
-         \n\
-         That server already holds {dbsize} key(s) and {indexes} search index(es) that this\n\
-         test harness did not create. Every test in `{target}` calls `flush_db()`, which\n\
-         drops every index `FT._LIST` reports and then issues `FLUSHALL` — running here\n\
-         would destroy all of it.\n\
-         \n\
-         Point the suite at a container of your own:\n\
+/// Advice appended to every refusal.
+fn refusal_footer(i: &ClaimInputs<'_>) -> String {
+    format!(
+        "Point the suite at a container of your own:\n\
          \n\
          \x20   docker run -d --rm -p <your-port>:6379 --name <your-name> <image>\n\
          \x20   {port_env}=<your-port> cargo test --test {target} -- --test-threads=1\n\
@@ -2029,29 +2041,152 @@ pub fn claim_verdict(i: &ClaimInputs<'_>) -> Claim {
          `{port_env}` is the ONLY supported way to move the suite. Editing the port literal\n\
          in tests/{target}.rs is rejected by tests/harness_invariants.rs.\n\
          \n\
-         If that data really is disposable, re-run with {allow}=1 to waive this check.\n",
+         If the server really is yours and its contents are disposable, re-run with\n\
+         {allow}=1 to waive this check.\n",
+        port_env = i.port_env,
+        target = i.target,
+        allow = ALLOW_DIRTY_ENV,
+    )
+}
+
+/// Decide whether a destructive suite may run against the server described by
+/// `i`. Pure: no I/O, no env reads, no clock.
+pub fn claim_verdict(i: &ClaimInputs<'_>) -> Claim {
+    if i.forced {
+        return Claim::Reused;
+    }
+
+    let (keys, index_count, server_id) = match i.probe {
+        Probe::Inconclusive(why) => {
+            return Claim::Refuse(format!(
+                "\n\n\
+                 REFUSING TO RUN `{target}` AGAINST {host}:{port}\n\
+                 \n\
+                 The safety check could not establish that this server is safe to destroy:\n\
+                 \x20   {why}\n\
+                 \n\
+                 Every test in `{target}` calls `flush_db()`, which drops every index\n\
+                 `FT._LIST` reports and then issues `FLUSHALL` — destroying EVERY database on\n\
+                 the server. The check refuses rather than guess, because guessing wrong is\n\
+                 unrecoverable.\n\
+                 \n\
+                 {footer}",
+                target = i.target,
+                host = i.host,
+                port = i.port,
+                why = why,
+                footer = refusal_footer(i),
+            ));
+        }
+        Probe::Reachable {
+            keys,
+            index_count,
+            server_id,
+        } => (*keys, *index_count, server_id.as_str()),
+    };
+
+    if keys <= 0 && index_count == 0 {
+        return Claim::Fresh;
+    }
+    if !server_id.is_empty() && i.prior_claim == Some(server_id) {
+        return Claim::Reused;
+    }
+
+    // Non-empty and unclaimed. Say WHY, because the two cases need opposite
+    // actions from the operator.
+    let diagnosis = match i.prior_claim {
+        None => format!(
+            "This target directory has NO claim recorded for {host}:{port}.\n\
+             \x20   (looked in {claim_path})\n\
+             \n\
+             Either the server is not yours, or your claim was removed — `cargo clean`, a\n\
+             fresh CARGO_TARGET_DIR, a new worktree, or `--target <triple>` (which relocates\n\
+             the claim under <target>/<triple>/) all lose it. A previous run that was killed\n\
+             mid-suite also leaves the server populated with no claim.",
+            host = i.host,
+            port = i.port,
+            claim_path = i.claim_path,
+        ),
+        Some(prior) if server_id.is_empty() => format!(
+            "A claim IS recorded for {host}:{port} ({claim_path}, instance {prior}), but this\n\
+             server reports neither `run_id` nor `master_replid`, so nothing can be matched\n\
+             against it. An unidentifiable server is never auto-authorised.",
+            host = i.host,
+            port = i.port,
+            claim_path = i.claim_path,
+            prior = display_id(prior),
+        ),
+        Some(prior) => format!(
+            "A claim IS recorded for {host}:{port} ({claim_path}), but it does not match:\n\
+             \x20   claimed instance: {prior}\n\
+             \x20   instance now:     {now}\n\
+             \n\
+             The server was restarted or replaced. NOTE: `docker restart` of your OWN\n\
+             container changes both `run_id` and `master_replid` while an RDB-persisted\n\
+             dataset survives — so if this is your container, this refusal is a false alarm.\n\
+             Delete {claim_path} (or set {allow}=1) and re-run.",
+            host = i.host,
+            port = i.port,
+            claim_path = i.claim_path,
+            prior = display_id(prior),
+            now = display_id(server_id),
+            allow = ALLOW_DIRTY_ENV,
+        ),
+    };
+
+    Claim::Refuse(format!(
+        "\n\n\
+         REFUSING TO RUN `{target}` AGAINST {host}:{port}\n\
+         \n\
+         That server holds {keys} key(s) across all databases and {indexes} search index(es)\n\
+         that this target directory has no claim for. Every test in `{target}` calls\n\
+         `flush_db()`, which drops every index `FT._LIST` reports and then issues `FLUSHALL`\n\
+         — destroying EVERY database on the server, not just db 0.\n\
+         \n\
+         {diagnosis}\n\
+         \n\
+         {footer}",
         target = i.target,
         host = i.host,
         port = i.port,
-        dbsize = i.dbsize,
-        indexes = i.index_count,
-        port_env = i.port_env,
-        allow = ALLOW_DIRTY_ENV,
+        keys = keys,
+        indexes = index_count,
+        diagnosis = diagnosis,
+        footer = refusal_footer(i),
     ))
 }
 
-/// Path of the file recording which server identity this target directory last
-/// claimed for `host:port`. Lives beside the test binaries (derived from
-/// `current_exe()`: `<target>/<profile>/deps/<bin>` -> `<target>`), so a session
-/// running with its own `CARGO_TARGET_DIR` has its own claims.
-fn claim_file(target: &str, host: &str, port: u16) -> Option<std::path::PathBuf> {
-    let exe = std::env::current_exe().ok()?;
-    let target_dir = exe.parent()?.parent()?.parent()?;
-    Some(
-        target_dir
-            .join("vdbb-test-claims")
-            .join(format!("{target}-{host}-{port}.claim")),
-    )
+/// Render a possibly-empty instance id for a message.
+fn display_id(id: &str) -> &str {
+    if id.is_empty() {
+        "<none reported>"
+    } else {
+        id
+    }
+}
+
+/// Sum `keys=` across every `dbN:` line of an `INFO keyspace` section.
+///
+/// Redis omits empty databases entirely, so an empty section legitimately means
+/// zero keys. Field ORDER and the extra fields differ per engine — verified live
+/// on redis:8.8.0 (`db0:keys=1,expires=0,avg_ttl=0,subexpiry=0`),
+/// valkey-bundle (`...,keys_with_volatile_items=0`), dragonfly df-v1.40.1
+/// (`db0:keys=1,expires=0,hits=0,misses=0,hit_ratio=0.00,avg_ttl=-1`) and
+/// kividb v1.0.2-full (`db0:keys=1,expires=0,avg_ttl=0`) — so parse by name.
+pub fn sum_keyspace_keys(info: &str) -> i64 {
+    info.lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if !line.starts_with("db") {
+                return None;
+            }
+            let (_db, fields) = line.split_once(':')?;
+            fields
+                .split(',')
+                .find_map(|kv| kv.trim().strip_prefix("keys="))
+                .and_then(|v| v.trim().parse::<i64>().ok())
+        })
+        .sum()
 }
 
 /// Pull `field:` out of an `INFO` section body.
@@ -2064,13 +2199,23 @@ pub fn info_field(info: &str, field: &str) -> String {
         .to_string()
 }
 
-/// A per-instance random identity for the server, so a claim recorded against
-/// one server is not honoured for a different one that later took the port.
+/// A per-START identity for the server, so a claim recorded against one server
+/// is not honoured for a different one that later took the port.
 ///
-/// `run_id` from `INFO server` where available (Redis, Valkey, KiviDB), falling
-/// back to `master_replid` from `INFO replication` (Dragonfly df-v1.40.1 reports
-/// no `run_id`; both were checked live). Empty when neither is present — an
-/// empty identity never matches a prior claim.
+/// `run_id` from `INFO server` where available (redis:8.8.0, valkey-bundle,
+/// kividb v1.0.2-full), falling back to `master_replid` from `INFO replication`
+/// (dragonfly df-v1.40.1 reports no `run_id`; all four checked live). Empty when
+/// neither is present — an empty identity never matches a prior claim.
+///
+/// LIMITS, both measured:
+///   * `master_replid` identifies a REPLICATION GROUP, not an instance: a
+///     Dragonfly replica reports the same value as its primary. A claim recorded
+///     against a primary would therefore also authorise a replica of it that
+///     later occupied the same host:port.
+///   * Both values are re-generated on restart, so `docker restart` of your own
+///     container invalidates its claim even though an RDB-persisted dataset
+///     survives. That direction is safe (it refuses), and the refusal message
+///     names it explicitly.
 fn server_identity(conn: &mut redis::Connection) -> String {
     let server: String = redis::cmd("INFO")
         .arg("server")
@@ -2087,57 +2232,150 @@ fn server_identity(conn: &mut redis::Connection) -> String {
     info_field(&repl, "master_replid")
 }
 
-/// Claim `host:port` for a destructive suite, or panic with the refusal message.
-///
-/// Called once per test process from the suite's `test_port()`. A server that
-/// cannot be reached is left alone: connecting is the suite's own
-/// `wait_for_*()` job, and an unreachable server cannot be damaged.
-pub fn claim_resp_instance(target: &str, port_env: &str, host: &str, port: u16) {
+/// Probe the server. EVERY failure path yields [`Probe::Inconclusive`], which
+/// [`claim_verdict`] refuses on.
+fn probe_server(host: &str, port: u16, wait: std::time::Duration) -> Probe {
     let url = format!("redis://{host}:{port}/");
     let Ok(client) = redis::Client::open(url.as_str()) else {
-        return;
-    };
-    let Ok(mut conn) = client.get_connection_with_timeout(std::time::Duration::from_secs(2)) else {
-        return;
+        return Probe::Inconclusive(format!("could not parse the connection URL {url}"));
     };
 
-    let dbsize: i64 = redis::cmd("DBSIZE").query(&mut conn).unwrap_or(0);
-    let index_count = redis::cmd("FT._LIST")
-        .query::<Vec<String>>(&mut conn)
-        .map(|v| v.len())
-        .unwrap_or(0);
-    let server_id = server_identity(&mut conn);
+    // Wait for the server the same way the suite's own `wait_for_*()` does. A
+    // container that is still starting must NOT skip the check: that was the
+    // whole bug — the probe gave up, the suite's 10-30 s wait then succeeded,
+    // and the `OnceLock` meant the claim was never retried.
+    let deadline = std::time::Instant::now() + wait;
+    let mut conn = loop {
+        match client.get_connection_with_timeout(CLAIM_CONNECT_TIMEOUT) {
+            Ok(c) => break c,
+            Err(e) => {
+                if std::time::Instant::now() >= deadline {
+                    return Probe::Inconclusive(format!(
+                        "could not reach {host}:{port} within {}s ({e})",
+                        wait.as_secs()
+                    ));
+                }
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    };
+
+    // A server replaying its RDB/AOF answers INFO but reports a keyspace that is
+    // still filling, so "0 keys" would be a lie.
+    if let Ok(persistence) = redis::cmd("INFO")
+        .arg("persistence")
+        .query::<String>(&mut conn)
+    {
+        if info_field(&persistence, "loading") == "1" {
+            return Probe::Inconclusive(format!(
+                "{host}:{port} is still loading its dataset (INFO persistence reports \
+                 loading:1), so its keyspace cannot be trusted yet"
+            ));
+        }
+    }
+
+    let keyspace = match redis::cmd("INFO")
+        .arg("keyspace")
+        .query::<String>(&mut conn)
+    {
+        Ok(s) => s,
+        Err(e) => {
+            return Probe::Inconclusive(format!(
+                "`INFO keyspace` failed on {host}:{port} ({e}), so the number of keys at \
+                 risk is unknown"
+            ));
+        }
+    };
+    let keys = sum_keyspace_keys(&keyspace);
+
+    let index_count = match redis::cmd("FT._LIST").query::<Vec<String>>(&mut conn) {
+        Ok(v) => v.len(),
+        Err(e) => {
+            return Probe::Inconclusive(format!(
+                "`FT._LIST` failed on {host}:{port} ({e}); `flush_db()` drops every index it \
+                 reports, so the indexes at risk are unknown"
+            ));
+        }
+    };
+
+    Probe::Reachable {
+        keys,
+        index_count,
+        server_id: server_identity(&mut conn),
+    }
+}
+
+/// Path of the file recording which server identity this target directory last
+/// claimed for `host:port`. Lives beside the test binaries (derived from
+/// `current_exe()`: `<target>/<profile>/deps/<bin>` -> `<target>`), so a session
+/// running with its own `CARGO_TARGET_DIR` has its own claims.
+fn claim_file(target: &str, host: &str, port: u16) -> Option<std::path::PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let target_dir = exe.parent()?.parent()?.parent()?;
+    Some(
+        target_dir
+            .join("vdbb-test-claims")
+            .join(format!("{target}-{host}-{port}.claim")),
+    )
+}
+
+/// Claim `host:port` for a destructive suite, or panic with the refusal message.
+///
+/// Called once per test process from the suite's `test_port()`.
+pub fn claim_resp_instance(target: &str, port_env: &str, host: &str, port: u16) {
+    let forced = std::env::var(ALLOW_DIRTY_ENV)
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false);
+    if forced {
+        // Never silent: a stale `export` in a shell rc would otherwise disable
+        // the guard permanently with no signal at all.
+        //
+        // Written straight to the process's stderr handle, NOT via `eprintln!`:
+        // libtest redirects the print macros into its per-test capture buffer and
+        // only replays it for FAILING tests, so an `eprintln!` here is invisible
+        // in exactly the case that matters — a passing run whose guard is off.
+        use std::io::Write as _;
+        let _ = writeln!(
+            std::io::stderr(),
+            "WARNING: {ALLOW_DIRTY_ENV} is set, so `{target}` will NOT verify that it owns \
+             {host}:{port} before `flush_db()` drops every FT._LIST index and FLUSHALLs the \
+             server. Unset {ALLOW_DIRTY_ENV} to restore the #292 safety check."
+        );
+    }
+
+    let probe = probe_server(host, port, CLAIM_REACHABLE_WAIT);
 
     let path = claim_file(target, host, port);
+    let path_display = path
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<claim path unavailable>".to_string());
     let prior = path
         .as_ref()
         .and_then(|p| fs::read_to_string(p).ok())
         .map(|s| s.trim().to_string());
-
-    let forced = std::env::var(ALLOW_DIRTY_ENV)
-        .map(|v| !v.is_empty() && v != "0")
-        .unwrap_or(false);
 
     let verdict = claim_verdict(&ClaimInputs {
         target,
         port_env,
         host,
         port,
-        dbsize,
-        index_count,
+        probe: &probe,
         prior_claim: prior.as_deref(),
-        server_id: &server_id,
+        claim_path: &path_display,
         forced,
     });
 
     match verdict {
         Claim::Refuse(msg) => panic!("{msg}"),
         Claim::Fresh | Claim::Reused => {
-            if let Some(p) = path {
-                if let Some(dir) = p.parent() {
-                    let _ = fs::create_dir_all(dir);
+            if let Probe::Reachable { server_id, .. } = &probe {
+                if let Some(p) = path {
+                    if let Some(dir) = p.parent() {
+                        let _ = fs::create_dir_all(dir);
+                    }
+                    let _ = fs::write(&p, server_id);
                 }
-                let _ = fs::write(&p, &server_id);
             }
         }
     }

--- a/tests/harness_invariants.rs
+++ b/tests/harness_invariants.rs
@@ -18,7 +18,7 @@
 //!   2. A `docker run -p 6399:6379` failed because the shared container already
 //!      held the port, so the writes landed in the shared server instead.
 //!
-//! Six invariants are locked in:
+//! Seven invariants are locked in:
 //!
 //!   INV-P1  A suite's default port appears exactly ONCE in its executable
 //!           source: the `.unwrap_or(<port>)` inside `fn test_port()`. Any other
@@ -52,6 +52,10 @@
 //!           a SECOND literal; only this rejects EDITING the single one — the
 //!           bypass incident 1 used, and the one the refusal message promises is
 //!           rejected.
+//!
+//!   INV-P7  The set of test targets under tests/ is pinned, so a wiping suite
+//!           named outside the `integration_*.rs` pattern cannot slip past the
+//!           INV-P3 scan unclassified.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -193,16 +197,20 @@ fn bare_port_hits(src: &str, port: u16, allowed_line: usize) -> Vec<(usize, Stri
 /// `FLUSHDB` counts: it wipes db 0 of a shared server, and it is the verb an
 /// author reaches for precisely because it sounds safer.
 fn wipes_whole_server(src: &str) -> bool {
+    // `\` counts as a quote boundary so an ESCAPED literal — `\"FLUSHALL\"`, the
+    // natural Rust spelling of a Lua payload or a printed message — is caught.
+    // Without it the "either quote style" claim was false.
+    let is_quote = |c: char| c == '"' || c == '\'' || c == '\\';
     let upper = src.to_ascii_uppercase();
     for verb in ["FLUSHALL", "FLUSHDB"] {
         let mut from = 0;
         while let Some(rel) = upper[from..].find(verb) {
             let at = from + rel;
-            let quoted_before = matches!(upper[..at].chars().next_back(), Some('"') | Some('\''));
-            let quoted_after = matches!(
-                upper[at + verb.len()..].chars().next(),
-                Some('"') | Some('\'')
-            );
+            let quoted_before = upper[..at].chars().next_back().is_some_and(is_quote);
+            let quoted_after = upper[at + verb.len()..]
+                .chars()
+                .next()
+                .is_some_and(is_quote);
             if quoted_before && quoted_after {
                 return true;
             }
@@ -278,6 +286,117 @@ fn port_env_var(body: &str) -> Option<String> {
 fn squeeze(s: &str) -> String {
     let no_ws: String = s.chars().filter(|c| !c.is_whitespace()).collect();
     no_ws.replace(",)", ")")
+}
+
+/// Remove `//` and `/* */` comments, leaving string literals intact so
+/// `"redis://host"` survives.
+///
+/// INV-P2 used to match against RAW source, so **commenting the claim call out**
+/// — one `/` character — left all invariants green while the suite went on to
+/// `FLUSHALL` a server it had not claimed. `bare_port_hits` had skipped comment
+/// lines since the first round; INV-P2 was the same file, one dimension short.
+fn strip_comments(src: &str) -> String {
+    let chars: Vec<char> = src.chars().collect();
+    let mut out = String::with_capacity(src.len());
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '"' {
+            out.push(c);
+            i += 1;
+            while i < chars.len() {
+                if chars[i] == '\\' && i + 1 < chars.len() {
+                    out.push(chars[i]);
+                    out.push(chars[i + 1]);
+                    i += 2;
+                    continue;
+                }
+                out.push(chars[i]);
+                i += 1;
+                if chars[i - 1] == '"' {
+                    break;
+                }
+            }
+            continue;
+        }
+        if c == '/' && chars.get(i + 1) == Some(&'/') {
+            while i < chars.len() && chars[i] != '\n' {
+                i += 1;
+            }
+            continue;
+        }
+        if c == '/' && chars.get(i + 1) == Some(&'*') {
+            i += 2;
+            while i + 1 < chars.len() && !(chars[i] == '*' && chars[i + 1] == '/') {
+                i += 1;
+            }
+            i = (i + 2).min(chars.len());
+            continue;
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
+}
+
+/// The one shape a wiping suite's `fn test_port()` is allowed to have.
+///
+/// INV-P2 asserts the WHOLE body equals this, not merely that it contains the
+/// claim call. Containment could be satisfied while the call was disabled —
+/// commented out, wrapped in `if false { .. }`, or parked inside
+/// `stringify!(..)`. Equality means any extra or missing token fails, so the
+/// choke point cannot be neutered without the build going red. It also makes the
+/// rustfmt tolerance in `squeeze` load-bearing: an identity `squeeze` no longer
+/// matches.
+fn expected_test_port_body(suite: &str, env: &str, default: u16, container: u16) -> String {
+    format!(
+        "fn test_port() -> u16 {{
+            static PORT: std::sync::OnceLock<u16> = std::sync::OnceLock::new();
+            *PORT.get_or_init(|| {{
+                let port = std::env::var(\"{env}\")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or({default});
+                common::claim_resp_instance(\"{suite}\", \"{env}\", TEST_HOST, port, {container});
+                port
+            }})"
+    )
+}
+
+/// Every `.rs` file under `tests/common/`, at ANY depth.
+///
+/// `read_dir` reads one level, so INV-P5 — round 3's headline fix — was evaded in
+/// its own idiom by putting the wipe helper in `tests/common/wipe/mod.rs`.
+fn common_sources() -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(path);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(&tests_dir().join("common"), &mut out);
+    out.sort();
+    out
+}
+
+/// Body of a top-level `fn <name>(..)` in `tests/common/mod.rs`, comments kept.
+fn common_fn_body(name: &str) -> String {
+    let src = fs::read_to_string(tests_dir().join("common").join("mod.rs")).unwrap();
+    let marker = format!("fn {name}(");
+    let start = src
+        .find(&marker)
+        .unwrap_or_else(|| panic!("tests/common/mod.rs must define `fn {name}`"));
+    let rest = &src[start..];
+    let end = rest.find("\n}").unwrap_or(rest.len());
+    rest[..end].to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -526,6 +645,12 @@ fn inv_p3_scanner_is_case_insensitive() {
             "lua",
             "redis::cmd(\"EVAL\").arg(\"redis.call('flushall')\").query(c)",
         ),
+        // Escaped double quotes — the natural Rust spelling, and the one that
+        // beat the "either quote style" matcher.
+        (
+            "escaped",
+            "redis::cmd(\"EVAL\").arg(\"return redis.call(\\\"FLUSHALL\\\")\").query(c)",
+        ),
     ] {
         assert!(
             wipes_whole_server(src),
@@ -542,15 +667,9 @@ fn inv_p5_shared_helpers_must_not_wipe_a_server() {
     // suite a server-wiping path that INV-P2/P3 cannot see — and that refactor is
     // the LIKELY one, since the premise of this whole guard is that four suites
     // share one `flush_db()` shape.
-    let dir = tests_dir().join("common");
-    let mut scanned = 0usize;
-    for entry in fs::read_dir(&dir).expect("tests/common must be readable") {
-        let path = entry.unwrap().path();
-        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
-            continue;
-        }
-        scanned += 1;
-        let src = fs::read_to_string(&path).unwrap();
+    let sources = common_sources();
+    for path in &sources {
+        let src = fs::read_to_string(path).unwrap();
         assert!(
             !wipes_whole_server(&src),
             "{}: shared test helpers must not issue FLUSHALL/FLUSHDB. Every suite \
@@ -560,7 +679,99 @@ fn inv_p5_shared_helpers_must_not_wipe_a_server() {
             path.display(),
         );
     }
-    assert!(scanned > 0, "found no .rs files under {}", dir.display());
+    // Pin the file set, not just `> 0`. The first version used `read_dir`, which
+    // reads ONE level, so a helper at `tests/common/wipe/mod.rs` evaded the check
+    // entirely — this invariant re-evaded in its own idiom. `common_sources()`
+    // now recurses, and pinning the names means a new shared file has to be
+    // acknowledged here rather than silently joining (or dodging) the scan.
+    let names: BTreeSet<String> = sources
+        .iter()
+        .map(|p| {
+            p.strip_prefix(tests_dir().join("common"))
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    let expected: BTreeSet<String> = ["mod.rs"].iter().map(|s| s.to_string()).collect();
+    assert_eq!(
+        names, expected,
+        "the set of shared helper files under tests/common/ changed; add it here \
+         so the wipe scan provably covers it"
+    );
+}
+
+#[test]
+fn inv_p5_scanner_recurses() {
+    // Positive control for the walker: the evasion was depth, not content, so
+    // the fix has to be demonstrated on depth.
+    let nested = tests_dir().join("common").join("mod.rs");
+    assert!(
+        common_sources().contains(&nested),
+        "the walker must find tests/common/mod.rs: {:?}",
+        common_sources()
+    );
+    // ..and it must be a real walk, not a hardcoded list: point it at a tree it
+    // has never seen and it must find the nested file.
+    let tmp = std::env::temp_dir().join(format!("vdbb-p5-{}", std::process::id()));
+    let deep = tmp.join("a").join("b");
+    fs::create_dir_all(&deep).unwrap();
+    fs::write(deep.join("wipe.rs"), "redis::cmd(\"FLUSHALL\")").unwrap();
+    fs::write(tmp.join("top.rs"), "fn x() {}").unwrap();
+    let mut found: Vec<String> = Vec::new();
+    fn walk(dir: &Path, out: &mut Vec<String>) {
+        for e in fs::read_dir(dir).unwrap().filter_map(|e| e.ok()) {
+            let p = e.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().and_then(|x| x.to_str()) == Some("rs") {
+                out.push(p.file_name().unwrap().to_string_lossy().into_owned());
+            }
+        }
+    }
+    walk(&tmp, &mut found);
+    found.sort();
+    fs::remove_dir_all(&tmp).ok();
+    assert_eq!(found, vec!["top.rs".to_string(), "wipe.rs".to_string()]);
+}
+
+#[test]
+fn inv_p7_the_scanned_test_target_set_is_pinned() {
+    // The wipe scan only sees `tests/integration_*.rs`, so a wiping suite named
+    // `tests/zz_wipe_smoke.rs` would never be classified at all. Pinning the
+    // target list means a new one must be acknowledged here.
+    let mut found: Vec<String> = fs::read_dir(tests_dir())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("rs"))
+        .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+        .collect();
+    found.sort();
+    let expected = vec![
+        "harness_invariants.rs",
+        "integration_chroma.rs",
+        "integration_cli.rs",
+        "integration_dragonfly.rs",
+        "integration_elasticsearch.rs",
+        "integration_kividb.rs",
+        "integration_milvus.rs",
+        "integration_mongodb.rs",
+        "integration_opensearch.rs",
+        "integration_pgvector.rs",
+        "integration_qdrant.rs",
+        "integration_redis.rs",
+        "integration_valkey.rs",
+        "integration_vectorsets.rs",
+        "integration_vertex.rs",
+        "integration_weaviate.rs",
+        "overhead_invariants.rs",
+    ];
+    assert_eq!(
+        found, expected,
+        "the set of test targets changed. A new one that wipes a server must be \
+         named `integration_*.rs` so the INV-P3 scan sees it, and listed here."
+    );
 }
 
 #[test]
@@ -592,12 +803,16 @@ fn inv_p2_wiping_suites_claim_their_instance_in_test_port() {
         });
         let env = port_env_var(body)
             .unwrap_or_else(|| panic!("{}: `fn test_port()` must read an env var", path.display()));
-        // Check the ARGUMENTS, not merely that some call exists: a copy-paste
-        // passing another suite's target name or env var would otherwise pass,
-        // recording the claim under the wrong key and naming the wrong override
-        // in the refusal message. The container port is checked against compose
-        // for the same reason — the refusal prints a `docker run -p X:<it>` line,
-        // and kividb's is 6380, not 6379.
+        // Compare the WHOLE body, comments stripped, against the one allowed
+        // shape. Containment was not enough: commenting the claim line out left
+        // every invariant green while the suite went on to wipe an unclaimed
+        // server, and `if false { .. }` / `stringify!(..)` do the same. Equality
+        // also pins the arguments — a copy-paste carrying another suite's target
+        // name or env var would record the claim under the wrong key and name
+        // the wrong override in the refusal — and the container port, which the
+        // refusal prints in its `docker run -p X:<it>` line (kividb's is 6380).
+        let (_line, default) = default_port(&src)
+            .unwrap_or_else(|| panic!("{}: no `test_port()` fallback", path.display()));
         let service = SUITE_COMPOSE_SERVICE
             .iter()
             .find(|(s, _)| *s == suite)
@@ -605,16 +820,64 @@ fn inv_p2_wiping_suites_claim_their_instance_in_test_port() {
             .unwrap_or_else(|| panic!("{suite} must be listed in SUITE_COMPOSE_SERVICE"));
         let (_host_port, container_port) = compose_ports(service)
             .unwrap_or_else(|| panic!("no published port for compose service {service}"));
-        let expected = format!(
-            "common::claim_resp_instance(\"{suite}\", \"{env}\", TEST_HOST, port, {container_port});"
-        );
-        assert!(
-            squeeze(body).contains(&squeeze(&expected)),
-            "{}: `fn test_port()` must call exactly\n    {expected}\n\
-             (the choke point every path to the server goes through). Body was:\n{body}",
+        let expected = expected_test_port_body(&suite, &env, default, container_port);
+        assert_eq!(
+            squeeze(&strip_comments(body)),
+            squeeze(&expected),
+            "{}: `fn test_port()` must be EXACTLY this shape (whitespace and \
+             comments aside) — it is the choke point every path to the server \
+             goes through, so nothing may be added, removed or disabled:\n\
+             {expected}\n\nfound:\n{body}",
             path.display(),
         );
     }
+}
+
+#[test]
+fn inv_p2_rejects_a_commented_out_or_disabled_claim() {
+    // The evasions equality closes, each proved to wipe a real server while the
+    // containment check stayed green.
+    let (suite, env, default, container) =
+        ("integration_redis", "REDIS_TEST_PORT", 6399u16, 6379u16);
+    let good = expected_test_port_body(suite, env, default, container);
+    assert_eq!(
+        squeeze(&strip_comments(&good)),
+        squeeze(&expected_test_port_body(suite, env, default, container)),
+        "positive control: the canonical body must match itself"
+    );
+    for (name, mutant) in [
+        ("commented out", good.replace("common::claim", "// common::claim")),
+        (
+            "wrapped in if false",
+            good.replace(
+                "common::claim_resp_instance(",
+                "if false { common::claim_resp_instance(",
+            ) + " }",
+        ),
+        (
+            "parked in stringify!",
+            good.replace("common::claim_resp_instance(", "stringify!(common::claim_resp_instance("),
+        ),
+        ("deleted", good.replace("common::claim_resp_instance(\"integration_redis\", \"REDIS_TEST_PORT\", TEST_HOST, port, 6379);", "")),
+    ] {
+        assert_ne!(
+            squeeze(&strip_comments(&mutant)),
+            squeeze(&good),
+            "a {name} claim must not satisfy INV-P2"
+        );
+    }
+}
+
+#[test]
+fn comment_stripper_keeps_string_literals() {
+    // Negative control: without this the stripper would eat the `//` in every
+    // `redis://` URL and INV-P2 would compare mangled text against mangled text.
+    let src = "let url = format!(\"redis://{}:{}/\", h, p); // trailing\n/* block */ let x = 1;";
+    let out = strip_comments(src);
+    assert!(out.contains("\"redis://{}:{}/\""), "{out}");
+    assert!(!out.contains("trailing"), "{out}");
+    assert!(!out.contains("block"), "{out}");
+    assert!(out.contains("let x = 1;"), "{out}");
 }
 
 #[test]
@@ -712,6 +975,142 @@ fn inv_p4_an_unreachable_server_is_not_treated_as_empty() {
         claim_verdict(&inputs(&probe, None)),
         Claim::Fresh,
         "an unreachable server must never be classified Fresh"
+    );
+}
+
+#[test]
+fn inv_p4_probe_server_reports_a_closed_port_as_inconclusive() {
+    // INV-P4 only ever exercised `claim_verdict`, the CONSUMER. Everything
+    // between it and the wire was untested, so a `probe_server` returning
+    // `Reachable { keys: 0, index_count: 0 }` for an unreachable server — the
+    // exact regression INV-P4's docstring cites — passed every invariant. A
+    // zero wait keeps this a pure, fast test.
+    let port = closed_port();
+    let probe = common::probe_server("127.0.0.1", port, std::time::Duration::ZERO);
+    assert!(
+        matches!(probe, Probe::Inconclusive(_)),
+        "a closed port must probe as Inconclusive, got {probe:?}"
+    );
+    // ..and it must flow through to a refusal, not merely be Inconclusive.
+    assert!(matches!(
+        claim_verdict(&inputs(&probe, None)),
+        Claim::Refuse(_)
+    ));
+}
+
+/// A TCP port with nothing listening: bind one, read the number, drop it.
+fn closed_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+#[test]
+fn inv_p4_the_producer_side_keeps_its_shape() {
+    // Source pins for the three mutations that make the guard INERT and that no
+    // integration suite can catch — a permissive mutation makes every suite pass
+    // harder, not fail.
+    let probe = common_fn_body("probe_server");
+    let inconclusive = probe.matches("Probe::Inconclusive(").count();
+    let reachable = probe.matches("Probe::Reachable {").count();
+    assert!(
+        inconclusive >= 5,
+        "`probe_server` must refuse on every failure path (unreachable, loading, \
+         INFO keyspace error, unparseable keyspace, FT._LIST error); found only \
+         {inconclusive} `Probe::Inconclusive(` sites"
+    );
+    assert_eq!(
+        reachable, 1,
+        "`Probe::Reachable` must be constructed at exactly one place in \
+         `probe_server`, so it cannot be reached before both probes succeeded"
+    );
+    let last_reachable = probe.rfind("Probe::Reachable {").unwrap();
+    let last_inconclusive = probe.rfind("Probe::Inconclusive(").unwrap();
+    assert!(
+        last_reachable > last_inconclusive,
+        "the single `Probe::Reachable` must be the FINAL statement, after every \
+         inconclusive early return"
+    );
+
+    // The refusal must actually stop the test.
+    let claim = common_fn_body("claim_resp_instance");
+    assert!(
+        claim.contains("panic!(\"{msg}\")"),
+        "`claim_resp_instance` must panic on a refusal; swallowing it makes the \
+         whole guard inert. Body was:\n{claim}"
+    );
+
+    // The waiver must default to OFF: `unwrap_or(true)` would disable the guard
+    // for everyone while every suite kept passing.
+    let outcome = common_fn_body("claim_outcome");
+    assert!(
+        outcome.contains("std::env::var(ALLOW_DIRTY_ENV)") && outcome.contains(".unwrap_or(false)"),
+        "the waiver must be opt-IN — an absent {ALLOW_DIRTY_ENV} has to mean the \
+         guard is ON. Body was:\n{outcome}"
+    );
+}
+
+#[test]
+fn inv_p4_claim_wait_covers_every_suite_wait_for() {
+    // A documented relation with no guard until now: if the claim gave up sooner
+    // than a suite's own `wait_for_*()`, the startup race that caused BLOCKER 1
+    // would reopen — the probe would quit, the suite's wait would succeed, and
+    // the `OnceLock` would never retry.
+    let common_src = fs::read_to_string(tests_dir().join("common").join("mod.rs")).unwrap();
+    let claim_wait: u64 = common_src
+        .lines()
+        .find_map(|l| {
+            l.contains("const CLAIM_REACHABLE_WAIT")
+                .then(|| {
+                    l.split("from_secs(")
+                        .nth(1)?
+                        .split(')')
+                        .next()?
+                        .parse()
+                        .ok()
+                })
+                .flatten()
+        })
+        .expect("CLAIM_REACHABLE_WAIT must be a literal `from_secs(N)`");
+    let mut worst = 0u64;
+    for (suite, _) in SUITE_COMPOSE_SERVICE {
+        let src = fs::read_to_string(tests_dir().join(format!("{suite}.rs"))).unwrap();
+        for line in strip_comments(&src).lines() {
+            if !line.contains("Instant::now() + Duration::from_secs(") {
+                continue;
+            }
+            if let Some(n) = line
+                .split("from_secs(")
+                .nth(1)
+                .and_then(|r| r.split(')').next())
+                .and_then(|n| n.parse::<u64>().ok())
+            {
+                worst = worst.max(n);
+            }
+        }
+    }
+    assert!(
+        worst > 0,
+        "found no `wait_for_*()` deadline to compare against"
+    );
+    assert!(
+        claim_wait >= worst,
+        "CLAIM_REACHABLE_WAIT ({claim_wait}s) must be >= the longest \
+         `wait_for_*()` deadline in the guarded suites ({worst}s), or a slow \
+         container start races past the claim"
+    );
+}
+
+#[test]
+fn claim_verdict_refuses_indexes_even_with_no_keys() {
+    // The index half of the emptiness test was unpinned: `Fresh` whenever
+    // `keys == 0` would have passed everything, even though `flush_db()` drops
+    // every index `FT._LIST` reports and the refusal counts them.
+    let p = reachable(0, 1, "abc");
+    assert!(
+        matches!(claim_verdict(&inputs(&p, None)), Claim::Refuse(_)),
+        "a server with no keys but a live search index must still be refused"
     );
 }
 

--- a/tests/harness_invariants.rs
+++ b/tests/harness_invariants.rs
@@ -18,7 +18,7 @@
 //!   2. A `docker run -p 6399:6379` failed because the shared container already
 //!      held the port, so the writes landed in the shared server instead.
 //!
-//! Three invariants are locked in:
+//! Four invariants are locked in:
 //!
 //!   INV-P1  A suite's default port appears exactly ONCE in its executable
 //!           source: the `.unwrap_or(<port>)` inside `fn test_port()`. Any other
@@ -26,14 +26,21 @@
 //!           handed to a spawned binary — is a second source of truth that an
 //!           env override cannot move. Comments may mention the port freely.
 //!
-//!   INV-P2  Every suite that issues `FLUSHALL` claims its instance from inside
-//!           `fn test_port()`, via `common::claim_resp_instance`. `test_port()`
-//!           is the choke point every path to the server goes through, so a
-//!           claim there cannot be bypassed by a helper that forgets to call it.
+//!   INV-P2  Every suite that wipes a whole server claims its instance from
+//!           inside `fn test_port()`, via `common::claim_resp_instance`, passing
+//!           ITS OWN target name and ITS OWN port env var. `test_port()` is the
+//!           choke point every path to the server goes through, so a claim there
+//!           cannot be bypassed by a helper that forgets to call it.
 //!
-//!   INV-P3  The FLUSHALL scan is not vacuous: the set of suites it discovers is
+//!   INV-P3  The wipe scan is not vacuous: the set of suites it discovers is
 //!           pinned, so deleting the guard from a suite fails INV-P2 rather than
 //!           quietly shrinking the set INV-P2 checks.
+//!
+//!   INV-P4  The ownership decision fails CLOSED. Every way the probe can fail
+//!           must produce a refusal, never a `Fresh`. The first version of this
+//!           guard coerced an unreachable server, a denied `DBSIZE` and an
+//!           unsupported command all to "0 keys" — i.e. to `Fresh` — which fails
+//!           open in the one function whose job is to refuse.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -41,7 +48,9 @@ use std::path::{Path, PathBuf};
 
 mod common;
 
-use common::{claim_verdict, info_field, Claim, ClaimInputs, ALLOW_DIRTY_ENV};
+use common::{
+    claim_verdict, info_field, sum_keyspace_keys, Claim, ClaimInputs, Probe, ALLOW_DIRTY_ENV,
+};
 
 // ---------------------------------------------------------------------------
 // Source scanning helpers (pure — unit-tested against synthetic input below)
@@ -77,23 +86,26 @@ fn test_port_body(src: &str) -> Option<&str> {
 }
 
 /// The default port a suite falls back to, and the 0-based index of the line it
-/// is written on. `None` when the file has no `fn test_port()` fallback.
+/// is written on. Recognises `.unwrap_or(<port>)` and `.unwrap_or_else(|| <port>)`.
+/// `None` when the file has no such fallback.
 fn default_port(src: &str) -> Option<(usize, u16)> {
     let body = test_port_body(src)?;
-    let at = body.find(".unwrap_or(")?;
-    let digits: String = body[at + ".unwrap_or(".len()..]
+    let (at, skip) = [".unwrap_or_else(|| ", ".unwrap_or_else(||", ".unwrap_or("]
+        .iter()
+        .find_map(|pat| body.find(pat).map(|at| (at, pat.len())))?;
+    let digits: String = body[at + skip..]
         .chars()
+        .skip_while(|c| *c == ' ')
         .take_while(|c| c.is_ascii_digit())
         .collect();
     let port: u16 = digits.parse().ok()?;
-    // Absolute line index of that `.unwrap_or(` within the whole file.
     let abs = src.find("fn test_port() -> u16 {")? + at;
     let line = src[..abs].lines().count() - 1;
     Some((line, port))
 }
 
-/// True when `hay[at..at + needle_len]` is a standalone number (not a digit of a
-/// longer one).
+/// True when `hay[at..at + len]` is a standalone number (not a digit of a longer
+/// one).
 fn is_standalone_number(hay: &str, at: usize, len: usize) -> bool {
     let before_ok = hay[..at]
         .chars()
@@ -108,8 +120,6 @@ fn is_standalone_number(hay: &str, at: usize, len: usize) -> bool {
 
 /// Code lines (comment lines excluded) that write `port` as a bare literal,
 /// other than the single declaration line `allowed_line`.
-///
-/// Returns `(1-based line number, line text)` pairs.
 fn bare_port_hits(src: &str, port: u16, allowed_line: usize) -> Vec<(usize, String)> {
     let needle = port.to_string();
     let mut hits = Vec::new();
@@ -117,8 +127,7 @@ fn bare_port_hits(src: &str, port: u16, allowed_line: usize) -> Vec<(usize, Stri
         if idx == allowed_line {
             continue;
         }
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("//") {
+        if line.trim_start().starts_with("//") {
             continue;
         }
         let mut from = 0;
@@ -134,22 +143,40 @@ fn bare_port_hits(src: &str, port: u16, allowed_line: usize) -> Vec<(usize, Stri
     hits
 }
 
-/// Suites whose source issues `FLUSHALL`, by test-target name.
-fn flushall_suites() -> BTreeSet<String> {
+/// True when this source sends a command that wipes a whole server.
+///
+/// Matches the QUOTED COMMAND NAME anywhere in the file rather than one exact
+/// call spelling. The first version matched the literal `cmd("FLUSHALL")`, and a
+/// synthetic wiping suite evaded it three ways — `cmd("FLUSHDB")`, a rustfmt-
+/// wrapped `cmd(\n    "FLUSHALL",\n)`, and `Cmd::new().arg("FLUSHALL")` — each of
+/// which passed every invariant with no claim call at all.
+///
+/// `FLUSHDB` counts: it wipes db 0 of a shared server, and it is the verb an
+/// author reaches for precisely because it sounds safer.
+fn wipes_whole_server(src: &str) -> bool {
+    src.contains("\"FLUSHALL\"") || src.contains("\"FLUSHDB\"")
+}
+
+/// Test-target names of the suites that wipe a server.
+fn wiping_suites() -> BTreeSet<String> {
     integration_sources()
         .into_iter()
-        .filter(|p| {
-            fs::read_to_string(p)
-                .unwrap_or_default()
-                .contains("cmd(\"FLUSHALL\")")
-        })
-        .map(|p| {
-            p.file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or_default()
-                .to_string()
-        })
+        .filter(|p| wipes_whole_server(&fs::read_to_string(p).unwrap_or_default()))
+        .map(|p| p.file_stem().unwrap().to_str().unwrap().to_string())
         .collect()
+}
+
+/// The env var a `test_port()` body reads, e.g. `REDIS_TEST_PORT`.
+fn port_env_var(body: &str) -> Option<String> {
+    let at = body.find("std::env::var(\"")? + "std::env::var(\"".len();
+    let rest = &body[at..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Collapse runs of whitespace so a match survives rustfmt rewrapping.
+fn squeeze(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 // ---------------------------------------------------------------------------
@@ -193,7 +220,7 @@ fn inv_p1_suite_ports_have_a_single_source_of_truth() {
         assert!(
             checked.contains(required),
             "{required} must resolve its port through a `fn test_port() -> u16` \
-             with a `.unwrap_or(<port>)` fallback so this scan can see it; \
+             with an `.unwrap_or(<port>)` fallback so this scan can see it; \
              scanned {checked:?}"
         );
     }
@@ -215,17 +242,12 @@ fn test_port() -> u16 {
     let (line, port) = default_port(src).expect("fallback must be found");
     assert_eq!(port, 6399);
     let hits = bare_port_hits(src, port, line);
-    assert_eq!(
-        hits.len(),
-        1,
-        "scanner must flag the `const TEST_PORT` line, got {hits:?}"
-    );
+    assert_eq!(hits.len(), 1, "got {hits:?}");
     assert!(hits[0].1.contains("const TEST_PORT"));
 }
 
 #[test]
 fn inv_p1_scanner_flags_a_literal_handed_to_a_spawned_binary() {
-    // Positive control #2: the other spelling of a second source of truth.
     let src = "\
 fn test_port() -> u16 {
     std::env::var(\"REDIS_TEST_PORT\")
@@ -244,9 +266,28 @@ fn run() {
 }
 
 #[test]
+fn inv_p1_scanner_reads_the_unwrap_or_else_spelling_too() {
+    // The scanner used to require the literal `.unwrap_or(`, so a suite written
+    // with `.unwrap_or_else(|| 6399)` was skipped ENTIRELY — no port checked at
+    // all, which is the silent-skip shape this whole file exists to prevent.
+    let src = "\
+const TEST_PORT: u16 = 6399;
+fn test_port() -> u16 {
+    std::env::var(\"REDIS_TEST_PORT\")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| 6399)
+}
+";
+    let (line, port) = default_port(src).expect("unwrap_or_else fallback must be found");
+    assert_eq!(port, 6399);
+    assert_eq!(bare_port_hits(src, port, line).len(), 1);
+}
+
+#[test]
 fn inv_p1_scanner_accepts_comment_mentions_and_longer_numbers() {
     // Negative control: without it, a guard that rejects everything would pass
-    // the two positive controls above.
+    // the positive controls above.
     let src = "\
 //! Requires redis running on port 6399.
 //! Run with: REDIS_TEST_PORT=6399 cargo test --test integration_redis
@@ -269,12 +310,12 @@ fn unrelated() -> u32 {
 }
 
 // ---------------------------------------------------------------------------
-// INV-P2 / INV-P3 — destructive suites claim the instance they run against
+// INV-P2 / INV-P3 — server-wiping suites claim the instance they run against
 // ---------------------------------------------------------------------------
 
 #[test]
-fn inv_p3_flushall_suite_set_is_pinned() {
-    let found = flushall_suites();
+fn inv_p3_wiping_suite_set_is_pinned() {
+    let found = wiping_suites();
     let expected: BTreeSet<String> = [
         "integration_dragonfly",
         "integration_kividb",
@@ -286,142 +327,319 @@ fn inv_p3_flushall_suite_set_is_pinned() {
     .collect();
     assert_eq!(
         found, expected,
-        "the set of suites issuing FLUSHALL changed. A NEW one must call \
+        "the set of suites issuing FLUSHALL/FLUSHDB changed. A NEW one must call \
          `common::claim_resp_instance` from its `fn test_port()` (see issue #292) \
-         and be added here; a REMOVED one means its FLUSHALL is gone."
+         and be added here; a REMOVED one means its wipe is gone."
     );
 }
 
 #[test]
-fn inv_p2_flushall_suites_claim_their_instance_in_test_port() {
-    let suites = flushall_suites();
-    assert!(!suites.is_empty(), "FLUSHALL scan found nothing");
+fn inv_p3_scanner_catches_every_spelling_that_evaded_it() {
+    // Positive controls: each of these wiped a server while passing the old
+    // `cmd("FLUSHALL")` substring scan.
+    for (name, src) in [
+        ("plain", "redis::cmd(\"FLUSHALL\").query(c)"),
+        ("flushdb", "redis::cmd(\"FLUSHDB\").query(c)"),
+        ("wrapped", "redis::cmd(\n    \"FLUSHALL\",\n)\n.query(c)"),
+        ("builder", "redis::Cmd::new().arg(\"FLUSHALL\").query(c)"),
+    ] {
+        assert!(
+            wipes_whole_server(src),
+            "spelling {name:?} must be detected as a whole-server wipe"
+        );
+    }
+}
+
+#[test]
+fn inv_p3_scanner_ignores_prose_mentions() {
+    // Negative control. `integration_vectorsets.rs` and `integration_valkey.rs`
+    // both discuss FLUSHALL in comments; only a quoted command name counts, so
+    // vectorsets stays OUT of the pinned set and INV-P3 keeps its meaning.
+    let src = "\
+// FLUSHALL — the suite shares one server with the other tests, so it must not
+// FLUSHDB either.
+fn noop() {}
+";
+    assert!(!wipes_whole_server(src));
+}
+
+#[test]
+fn inv_p2_wiping_suites_claim_their_instance_in_test_port() {
+    let suites = wiping_suites();
+    assert!(!suites.is_empty(), "wipe scan found nothing");
     for suite in suites {
         let path = tests_dir().join(format!("{suite}.rs"));
         let src = fs::read_to_string(&path).unwrap();
         let body = test_port_body(&src).unwrap_or_else(|| {
             panic!(
-                "{}: a FLUSHALL suite must resolve its port through \
+                "{}: a server-wiping suite must resolve its port through \
                  `fn test_port() -> u16`",
                 path.display()
             )
         });
+        let env = port_env_var(body)
+            .unwrap_or_else(|| panic!("{}: `fn test_port()` must read an env var", path.display()));
+        // Check the ARGUMENTS, not merely that some call exists: a copy-paste
+        // passing another suite's target name or env var would otherwise pass,
+        // recording the claim under the wrong key and naming the wrong override
+        // in the refusal message.
+        let expected =
+            format!("common::claim_resp_instance(\"{suite}\", \"{env}\", TEST_HOST, port);");
         assert!(
-            body.contains("common::claim_resp_instance("),
-            "{}: `fn test_port()` must call `common::claim_resp_instance(..)`. \
-             It is the choke point every path to the server goes through, so the \
-             ownership check belongs there and nowhere else. Body was:\n{body}",
+            squeeze(body).contains(&squeeze(&expected)),
+            "{}: `fn test_port()` must call exactly\n    {expected}\n\
+             (the choke point every path to the server goes through). Body was:\n{body}",
             path.display(),
         );
     }
 }
 
 // ---------------------------------------------------------------------------
-// The ownership decision itself
+// INV-P4 — the decision fails closed
 // ---------------------------------------------------------------------------
 
-fn inputs<'a>(
-    dbsize: i64,
-    index_count: usize,
-    prior: Option<&'a str>,
-    id: &'a str,
-) -> ClaimInputs<'a> {
+fn reachable(keys: i64, index_count: usize, id: &str) -> Probe {
+    Probe::Reachable {
+        keys,
+        index_count,
+        server_id: id.to_string(),
+    }
+}
+
+fn inputs<'a>(probe: &'a Probe, prior: Option<&'a str>) -> ClaimInputs<'a> {
     ClaimInputs {
         target: "integration_redis",
         port_env: "REDIS_TEST_PORT",
         host: "127.0.0.1",
         port: 6399,
-        dbsize,
-        index_count,
+        probe,
         prior_claim: prior,
-        server_id: id,
+        claim_path: "/tmp/target/vdbb-test-claims/integration_redis-127.0.0.1-6399.claim",
         forced: false,
     }
 }
 
 #[test]
+fn inv_p4_every_inconclusive_probe_refuses() {
+    // The real ways the old probe failed OPEN. Each used to become "0 keys",
+    // i.e. `Fresh`, i.e. FLUSHALL.
+    for why in [
+        "could not reach 127.0.0.1:6399 within 30s (connection refused)",
+        "127.0.0.1:6399 is still loading its dataset (INFO persistence reports loading:1)",
+        "`INFO keyspace` failed on 127.0.0.1:6399 (NOPERM)",
+        "`FT._LIST` failed on 127.0.0.1:6399 (unknown command)",
+    ] {
+        let probe = Probe::Inconclusive(why.to_string());
+        let v = claim_verdict(&inputs(&probe, None));
+        let Claim::Refuse(msg) = v else {
+            panic!("an inconclusive probe must refuse, got {v:?} for {why:?}");
+        };
+        assert!(
+            msg.contains(why),
+            "the refusal must quote why the probe was inconclusive: {msg}"
+        );
+    }
+}
+
+#[test]
+fn inv_p4_an_unreachable_server_is_not_treated_as_empty() {
+    // The specific regression: the guard used to `return` early when the server
+    // was still starting, so the suite's own 10-30s `wait_for_*()` then ran the
+    // whole destructive suite with NO claim ever recorded.
+    let probe = Probe::Inconclusive("could not reach 127.0.0.1:6399 within 30s".to_string());
+    assert_ne!(
+        claim_verdict(&inputs(&probe, None)),
+        Claim::Fresh,
+        "an unreachable server must never be classified Fresh"
+    );
+}
+
+#[test]
 fn claim_verdict_takes_an_empty_server() {
     // Positive control: the guard must not reject everything. A fresh container
-    // — which is what CI starts — has to be usable with no env set.
-    assert_eq!(claim_verdict(&inputs(0, 0, None, "abc")), Claim::Fresh);
+    // — what CI starts — has to be usable with no env set.
+    assert_eq!(
+        claim_verdict(&inputs(&reachable(0, 0, "abc"), None)),
+        Claim::Fresh
+    );
 }
 
 #[test]
 fn claim_verdict_refuses_foreign_data() {
-    let v = claim_verdict(&inputs(400, 1, None, "abc"));
-    assert!(
-        matches!(v, Claim::Refuse(_)),
-        "a server holding keys and indexes this harness never claimed must be \
-         refused, got {v:?}"
-    );
+    let p = reachable(400, 1, "abc");
+    assert!(matches!(claim_verdict(&inputs(&p, None)), Claim::Refuse(_)));
 }
 
 #[test]
 fn claim_verdict_refuses_keys_even_with_no_indexes() {
     // The #286 corpus that nearly got wiped was plain keys; FT._LIST was empty.
-    let v = claim_verdict(&inputs(400, 0, None, "abc"));
-    assert!(matches!(v, Claim::Refuse(_)), "got {v:?}");
+    let p = reachable(400, 0, "abc");
+    assert!(matches!(claim_verdict(&inputs(&p, None)), Claim::Refuse(_)));
+}
+
+#[test]
+fn claim_verdict_counts_keys_outside_db0() {
+    // `DBSIZE` reported db 0 only while `FLUSHALL` destroys every database, so a
+    // developer's Redis with an empty db 0 and Sidekiq/Celery data on db 1 read
+    // as "empty". The probe now sums `INFO keyspace`, so this must refuse.
+    let keys = sum_keyspace_keys("# Keyspace\r\ndb1:keys=3,expires=0,avg_ttl=0\r\n");
+    assert_eq!(keys, 3);
+    let p = reachable(keys, 0, "abc");
+    assert!(matches!(claim_verdict(&inputs(&p, None)), Claim::Refuse(_)));
 }
 
 #[test]
 fn claim_verdict_reuses_an_instance_this_target_dir_already_claimed() {
-    // Re-running the suite must work: after a full run the server is left
-    // non-empty, and its identity still matches the recorded claim.
     assert_eq!(
-        claim_verdict(&inputs(400, 1, Some("abc"), "abc")),
+        claim_verdict(&inputs(&reachable(400, 1, "abc"), Some("abc"))),
         Claim::Reused
     );
 }
 
 #[test]
 fn claim_verdict_ignores_a_claim_from_a_different_server() {
-    // Same port, different server (the container was replaced and repopulated
-    // by someone else): the recorded run_id no longer matches.
-    let v = claim_verdict(&inputs(400, 1, Some("abc"), "xyz"));
-    assert!(matches!(v, Claim::Refuse(_)), "got {v:?}");
+    let p = reachable(400, 1, "xyz");
+    assert!(matches!(
+        claim_verdict(&inputs(&p, Some("abc"))),
+        Claim::Refuse(_)
+    ));
 }
 
 #[test]
 fn claim_verdict_never_matches_an_unidentifiable_server() {
-    // A server that reports no `run_id` yields an empty identity. Two unrelated
-    // such servers must not look like the same one.
-    let v = claim_verdict(&inputs(400, 1, Some(""), ""));
-    assert!(matches!(v, Claim::Refuse(_)), "got {v:?}");
+    let p = reachable(400, 1, "");
+    assert!(matches!(
+        claim_verdict(&inputs(&p, Some(""))),
+        Claim::Refuse(_)
+    ));
 }
 
 #[test]
 fn claim_verdict_honours_the_waiver() {
-    let mut i = inputs(400, 1, None, "abc");
+    let p = reachable(400, 1, "abc");
+    let mut i = inputs(&p, None);
+    i.forced = true;
+    assert_eq!(claim_verdict(&i), Claim::Reused);
+    // ..and it overrides an inconclusive probe too, which is the point of an
+    // escape hatch: without that, an operator with an unusual server would have
+    // no way to run the suite at all.
+    let unreachable = Probe::Inconclusive("could not reach it".to_string());
+    let mut i = inputs(&unreachable, None);
     i.forced = true;
     assert_eq!(claim_verdict(&i), Claim::Reused);
 }
 
+// ---------------------------------------------------------------------------
+// The refusal message — the only thing a person ever sees
+// ---------------------------------------------------------------------------
+
 #[test]
 fn refusal_message_states_the_mechanism_and_the_way_out() {
-    let Claim::Refuse(msg) = claim_verdict(&inputs(400, 2, None, "abc")) else {
+    let p = reachable(400, 2, "abc");
+    let Claim::Refuse(msg) = claim_verdict(&inputs(&p, None)) else {
         panic!("expected a refusal");
     };
     for expected in [
         "integration_redis", // which suite
         "127.0.0.1:6399",    // which server
-        "400 key(s)",        // what is at risk
+        "400 key(s) across all databases",
         "2 search index(es)",
         "FLUSHALL",           // the true mechanism of the damage
         "FT._LIST",           // ..and the index half of it
         "REDIS_TEST_PORT",    // the supported override
         ALLOW_DIRTY_ENV,      // the escape hatch
         "harness_invariants", // why editing the source will not work
+        "vdbb-test-claims",   // WHERE the claim was looked for
     ] {
         assert!(
             msg.contains(expected),
             "refusal message must mention {expected:?}; message was:\n{msg}"
         );
     }
+    // It must not assert as fact something the guard cannot know: when your own
+    // container is restarted, the harness DID create the data it is refusing.
+    assert!(
+        !msg.contains("did not create"),
+        "the message must not claim the harness did not create the data — it \
+         only knows there is no matching claim. Message was:\n{msg}"
+    );
+    assert!(msg.contains("no claim for"));
+}
+
+#[test]
+fn refusal_message_distinguishes_a_missing_claim_from_a_stale_one() {
+    // Two opposite actions for the operator, so the message must not blur them.
+    let p = reachable(400, 1, "now-id");
+
+    let Claim::Refuse(missing) = claim_verdict(&inputs(&p, None)) else {
+        panic!("expected a refusal");
+    };
+    assert!(missing.contains("NO claim recorded"), "{missing}");
+    assert!(
+        missing.contains("cargo clean"),
+        "a missing claim should name the ways a claim gets lost: {missing}"
+    );
+
+    let Claim::Refuse(stale) = claim_verdict(&inputs(&p, Some("old-id"))) else {
+        panic!("expected a refusal");
+    };
+    assert!(stale.contains("A claim IS recorded"), "{stale}");
+    assert!(
+        stale.contains("old-id") && stale.contains("now-id"),
+        "{stale}"
+    );
+    assert!(
+        stale.contains("docker restart"),
+        "a stale claim is most often your OWN restarted container, and the \
+         message must say so: {stale}"
+    );
 }
 
 // ---------------------------------------------------------------------------
-// Server identity parsing (what makes a prior claim match, or not)
+// Probe parsing (what the guard reads off the wire)
 // ---------------------------------------------------------------------------
+
+#[test]
+fn keyspace_sum_covers_every_database_on_all_four_engines() {
+    // Captured live from `INFO keyspace` on each guarded engine — the field sets
+    // and their order differ, which is why the parser reads `keys=` by name.
+    for (engine, info, expected) in [
+        (
+            "redis:8.8.0",
+            "# Keyspace\r\ndb0:keys=1,expires=0,avg_ttl=0,subexpiry=0\r\n",
+            1,
+        ),
+        (
+            "valkey-bundle",
+            "# Keyspace\r\ndb0:keys=1,expires=0,avg_ttl=0,keys_with_volatile_items=0\r\n",
+            1,
+        ),
+        (
+            "dragonfly df-v1.40.1",
+            "# Keyspace\r\ndb0:keys=1,expires=0,hits=0,misses=0,hit_ratio=0.00,avg_ttl=-1\r\n",
+            1,
+        ),
+        (
+            "kividb v1.0.2-full",
+            "# Keyspace\r\ndb0:keys=1,expires=0,avg_ttl=0\r\n",
+            1,
+        ),
+        // The blocker this replaced DBSIZE for: keys parked outside db 0.
+        (
+            "multi-db",
+            "# Keyspace\r\ndb0:keys=2,expires=0\r\ndb1:keys=3,expires=0\r\ndb9:keys=5,expires=0\r\n",
+            10,
+        ),
+        // Redis omits empty databases, so an empty section really is zero.
+        ("empty", "# Keyspace\r\n", 0),
+    ] {
+        assert_eq!(
+            sum_keyspace_keys(info),
+            expected,
+            "keyspace sum wrong for {engine}"
+        );
+    }
+}
 
 #[test]
 fn info_field_reads_run_id_and_master_replid() {
@@ -448,4 +666,15 @@ fn info_field_reads_run_id_and_master_replid() {
         info_field(df_repl, "master_replid"),
         "4da04ff40e648670f83234caa27706516c67588b"
     );
+
+    // `loading:1` is what makes the probe inconclusive on a server replaying its
+    // RDB/AOF, whose keyspace is still filling and would otherwise read as 0.
+    assert_eq!(
+        info_field(
+            "# Persistence\r\nloading:1\r\nasync_loading:0\r\n",
+            "loading"
+        ),
+        "1"
+    );
+    assert_eq!(info_field("# Persistence\r\nloading:0\r\n", "loading"), "0");
 }

--- a/tests/harness_invariants.rs
+++ b/tests/harness_invariants.rs
@@ -118,6 +118,23 @@ fn is_standalone_number(hay: &str, at: usize, len: usize) -> bool {
     before_ok && after_ok
 }
 
+/// Remove Rust's digit separators so `6_399` is seen as `6399`. Only strips `_`
+/// that sits BETWEEN two digits, so `foo_6399` and `PORT_6` are untouched.
+fn strip_digit_separators(line: &str) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let mut out = String::with_capacity(line.len());
+    for (i, c) in chars.iter().enumerate() {
+        let is_separator = *c == '_'
+            && i > 0
+            && chars[i - 1].is_ascii_digit()
+            && chars.get(i + 1).is_some_and(|n| n.is_ascii_digit());
+        if !is_separator {
+            out.push(*c);
+        }
+    }
+    out
+}
+
 /// Code lines (comment lines excluded) that write `port` as a bare literal,
 /// other than the single declaration line `allowed_line`.
 fn bare_port_hits(src: &str, port: u16, allowed_line: usize) -> Vec<(usize, String)> {
@@ -130,10 +147,12 @@ fn bare_port_hits(src: &str, port: u16, allowed_line: usize) -> Vec<(usize, Stri
         if line.trim_start().starts_with("//") {
             continue;
         }
+        let scanned = strip_digit_separators(line);
         let mut from = 0;
-        while let Some(rel) = line[from..].find(&needle) {
+        while let Some(rel) = scanned[from..].find(&needle) {
             let at = from + rel;
-            if is_standalone_number(line, at, needle.len()) {
+            if is_standalone_number(&scanned, at, needle.len()) {
+                // Report the ORIGINAL line, not the normalised one.
                 hits.push((idx + 1, line.to_string()));
                 break;
             }
@@ -145,16 +164,41 @@ fn bare_port_hits(src: &str, port: u16, allowed_line: usize) -> Vec<(usize, Stri
 
 /// True when this source sends a command that wipes a whole server.
 ///
-/// Matches the QUOTED COMMAND NAME anywhere in the file rather than one exact
-/// call spelling. The first version matched the literal `cmd("FLUSHALL")`, and a
-/// synthetic wiping suite evaded it three ways — `cmd("FLUSHDB")`, a rustfmt-
-/// wrapped `cmd(\n    "FLUSHALL",\n)`, and `Cmd::new().arg("FLUSHALL")` — each of
-/// which passed every invariant with no claim call at all.
+/// Matches a QUOTED COMMAND NAME anywhere in the file, CASE-INSENSITIVELY, in
+/// either quote style. Two rounds of evasion produced that spec, and each round
+/// found a synthetic wiping suite with no claim call at all passing every
+/// invariant:
+///
+///   * spelling:  `cmd("FLUSHDB")`, a rustfmt-wrapped `cmd(\n "FLUSHALL",\n)`,
+///     `Cmd::new().arg("FLUSHALL")` — beat the original exact-call match.
+///   * case:      `cmd("flushall")`, `cmd("FlushAll")`, `cmd("flushdb")` — beat
+///     the widened-but-still-case-sensitive match. Redis command names ARE
+///     case-insensitive on the wire (`redis-cli flushall` on redis:8.8.0 takes a
+///     server from 2 keys to 0), so these are not hypothetical.
+///
+/// Single quotes are accepted so a Lua payload — `EVAL "redis.call('flushall')"`
+/// — is caught too.
 ///
 /// `FLUSHDB` counts: it wipes db 0 of a shared server, and it is the verb an
 /// author reaches for precisely because it sounds safer.
 fn wipes_whole_server(src: &str) -> bool {
-    src.contains("\"FLUSHALL\"") || src.contains("\"FLUSHDB\"")
+    let upper = src.to_ascii_uppercase();
+    for verb in ["FLUSHALL", "FLUSHDB"] {
+        let mut from = 0;
+        while let Some(rel) = upper[from..].find(verb) {
+            let at = from + rel;
+            let quoted_before = matches!(upper[..at].chars().next_back(), Some('"') | Some('\''));
+            let quoted_after = matches!(
+                upper[at + verb.len()..].chars().next(),
+                Some('"') | Some('\'')
+            );
+            if quoted_before && quoted_after {
+                return true;
+            }
+            from = at + 1;
+        }
+    }
+    false
 }
 
 /// Test-target names of the suites that wipe a server.
@@ -285,6 +329,33 @@ fn test_port() -> u16 {
 }
 
 #[test]
+fn inv_p1_scanner_sees_through_rust_digit_separators() {
+    // `6_399` is the same literal to rustc but a different string to a grep.
+    let src = "\
+const TEST_PORT: u16 = 6_399;
+fn test_port() -> u16 {
+    std::env::var(\"REDIS_TEST_PORT\")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6399)
+}
+";
+    let (line, port) = default_port(src).unwrap();
+    let hits = bare_port_hits(src, port, line);
+    assert_eq!(hits.len(), 1, "got {hits:?}");
+    assert!(
+        hits[0].1.contains("6_399"),
+        "the ORIGINAL line must be reported, not the normalised one: {hits:?}"
+    );
+    // ..and a separator that is not between two digits must not be collapsed,
+    // or `PORT_6399` would start matching.
+    assert_eq!(
+        strip_digit_separators("let foo_6399 = 1_000;"),
+        "let foo_6399 = 1000;"
+    );
+}
+
+#[test]
 fn inv_p1_scanner_accepts_comment_mentions_and_longer_numbers() {
     // Negative control: without it, a guard that rejects everything would pass
     // the positive controls above.
@@ -348,6 +419,58 @@ fn inv_p3_scanner_catches_every_spelling_that_evaded_it() {
             "spelling {name:?} must be detected as a whole-server wipe"
         );
     }
+}
+
+#[test]
+fn inv_p3_scanner_is_case_insensitive() {
+    // Second round of evasion. Redis command names are case-insensitive on the
+    // wire — `redis-cli flushall` against redis:8.8.0 takes a server from 2 keys
+    // to 0 — so a lowercase spelling wipes just as hard while the widened but
+    // still case-sensitive matcher passed all 23 invariants with no claim call.
+    for (name, src) in [
+        ("lower", "redis::cmd(\"flushall\").query(c)"),
+        ("mixed", "redis::cmd(\"FlushAll\").query(c)"),
+        ("lower-db", "redis::cmd(\"flushdb\").query(c)"),
+        // Single quotes: a Lua payload smuggles the same wipe.
+        (
+            "lua",
+            "redis::cmd(\"EVAL\").arg(\"redis.call('flushall')\").query(c)",
+        ),
+    ] {
+        assert!(
+            wipes_whole_server(src),
+            "spelling {name:?} must be detected as a whole-server wipe"
+        );
+    }
+}
+
+#[test]
+fn inv_p5_shared_helpers_must_not_wipe_a_server() {
+    // `mod common;` is included by ALL 15 integration suites, non-destructive
+    // ones included, and `wiping_suites()` only reads `tests/integration_*.rs`.
+    // So a `pub fn wipe_server()` moved into `tests/common/` would give every
+    // suite a server-wiping path that INV-P2/P3 cannot see — and that refactor is
+    // the LIKELY one, since the premise of this whole guard is that four suites
+    // share one `flush_db()` shape.
+    let dir = tests_dir().join("common");
+    let mut scanned = 0usize;
+    for entry in fs::read_dir(&dir).expect("tests/common must be readable") {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        scanned += 1;
+        let src = fs::read_to_string(&path).unwrap();
+        assert!(
+            !wipes_whole_server(&src),
+            "{}: shared test helpers must not issue FLUSHALL/FLUSHDB. Every suite \
+             includes `mod common;`, so a wipe here is invisible to the per-suite \
+             scan in INV-P2/P3. Put it in the suite that needs it, where the \
+             claim guard can see it.",
+            path.display(),
+        );
+    }
+    assert!(scanned > 0, "found no .rs files under {}", dir.display());
 }
 
 #[test]
@@ -482,7 +605,7 @@ fn claim_verdict_counts_keys_outside_db0() {
     // `DBSIZE` reported db 0 only while `FLUSHALL` destroys every database, so a
     // developer's Redis with an empty db 0 and Sidekiq/Celery data on db 1 read
     // as "empty". The probe now sums `INFO keyspace`, so this must refuse.
-    let keys = sum_keyspace_keys("# Keyspace\r\ndb1:keys=3,expires=0,avg_ttl=0\r\n");
+    let keys = sum_keyspace_keys("# Keyspace\r\ndb1:keys=3,expires=0,avg_ttl=0\r\n").unwrap();
     assert_eq!(keys, 3);
     let p = reachable(keys, 0, "abc");
     assert!(matches!(claim_verdict(&inputs(&p, None)), Claim::Refuse(_)));
@@ -630,15 +753,62 @@ fn keyspace_sum_covers_every_database_on_all_four_engines() {
             "# Keyspace\r\ndb0:keys=2,expires=0\r\ndb1:keys=3,expires=0\r\ndb9:keys=5,expires=0\r\n",
             10,
         ),
-        // Redis omits empty databases, so an empty section really is zero.
-        ("empty", "# Keyspace\r\n", 0),
+        // The two EMPTY-server layouts, both measured on a fresh container. They
+        // differ, and both must read as zero — this is the path CI takes on every
+        // run, so a parser that only handled one of them would refuse CI.
+        // redis:8.8.0 / valkey-bundle / kividb omit the db line entirely:
+        ("empty (redis/valkey/kividb)", "# Keyspace\r\n", 0),
+        // ..while dragonfly df-v1.40.1 still emits db0 with keys=0:
+        (
+            "empty (dragonfly)",
+            "# Keyspace\r\ndb0:keys=0,expires=0,hits=0,misses=0,hit_ratio=0.00,avg_ttl=-1\r\n",
+            0,
+        ),
     ] {
         assert_eq!(
             sum_keyspace_keys(info),
-            expected,
+            Some(expected),
             "keyspace sum wrong for {engine}"
         );
     }
+}
+
+#[test]
+fn keyspace_sum_says_unknown_rather_than_zero_when_it_cannot_tell() {
+    // The parser returns `i64` no more. Everything below used to collapse to
+    // `0` — i.e. to `Fresh`, i.e. to FLUSHALL — which is this guard's own bug
+    // class one notch in. All of these now yield `None`, which the probe turns
+    // into `Probe::Inconclusive` and `claim_verdict` refuses on.
+    for (name, info) in [
+        ("empty reply", ""),
+        ("no # Keyspace header", "db0:keys=3,expires=0\r\n"),
+        ("wrong section", "# Server\r\nrun_id:abc\r\n"),
+        (
+            "db line with no keys=",
+            "# Keyspace\r\ndb0:expires=0,avg_ttl=0\r\n",
+        ),
+        (
+            "unparseable keys=",
+            "# Keyspace\r\ndb0:keys=lots,expires=0\r\n",
+        ),
+        ("negative keys=", "# Keyspace\r\ndb0:keys=-1,expires=0\r\n"),
+        (
+            "overflow",
+            "# Keyspace\r\ndb0:keys=9223372036854775807\r\ndb1:keys=1\r\n",
+        ),
+    ] {
+        assert_eq!(
+            sum_keyspace_keys(info),
+            None,
+            "{name} must be reported as unknown, never as zero keys"
+        );
+    }
+    // Positive control for the header check: the guard must not now reject
+    // every real reply.
+    assert_eq!(
+        sum_keyspace_keys("# Keyspace\r\ndb0:keys=7,expires=0\r\n"),
+        Some(7)
+    );
 }
 
 #[test]

--- a/tests/harness_invariants.rs
+++ b/tests/harness_invariants.rs
@@ -1,0 +1,420 @@
+//! Test-harness invariants (issue #292) — regression tripwires for the way the
+//! integration suites pick, and guard, the server they run against.
+//!
+//! These are pure tests: they read `tests/*.rs` as TEXT and exercise the pure
+//! `common::claim_verdict` decision function. They need no database and run in
+//! the container-free CI job, next to `overhead_invariants.rs`.
+//!
+//! Background. Four suites (`integration_redis`, `integration_valkey`,
+//! `integration_dragonfly`, `integration_kividb`) share one `flush_db()` shape:
+//! drop every index `FT._LIST` reports, then `FLUSHALL`. Each one's default port
+//! is a container from `tests/docker-compose.test.yml` that several sessions
+//! share. Two incidents followed from that:
+//!
+//!   1. A port override spelled as a `sed` against `const TEST_PORT: u16 = 6399;`
+//!      matched nothing (the constant had become `fn test_port()`), exited 0, and
+//!      the run proceeded against the shared server with no error and no output
+//!      difference.
+//!   2. A `docker run -p 6399:6379` failed because the shared container already
+//!      held the port, so the writes landed in the shared server instead.
+//!
+//! Three invariants are locked in:
+//!
+//!   INV-P1  A suite's default port appears exactly ONCE in its executable
+//!           source: the `.unwrap_or(<port>)` inside `fn test_port()`. Any other
+//!           code-line occurrence — a reintroduced `const TEST_PORT`, a literal
+//!           handed to a spawned binary — is a second source of truth that an
+//!           env override cannot move. Comments may mention the port freely.
+//!
+//!   INV-P2  Every suite that issues `FLUSHALL` claims its instance from inside
+//!           `fn test_port()`, via `common::claim_resp_instance`. `test_port()`
+//!           is the choke point every path to the server goes through, so a
+//!           claim there cannot be bypassed by a helper that forgets to call it.
+//!
+//!   INV-P3  The FLUSHALL scan is not vacuous: the set of suites it discovers is
+//!           pinned, so deleting the guard from a suite fails INV-P2 rather than
+//!           quietly shrinking the set INV-P2 checks.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+mod common;
+
+use common::{claim_verdict, Claim, ClaimInputs, ALLOW_DIRTY_ENV};
+
+// ---------------------------------------------------------------------------
+// Source scanning helpers (pure — unit-tested against synthetic input below)
+// ---------------------------------------------------------------------------
+
+fn tests_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests")
+}
+
+/// Every `tests/integration_*.rs`, sorted.
+fn integration_sources() -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = fs::read_dir(tests_dir())
+        .expect("tests/ must be readable")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("integration_") && n.ends_with(".rs"))
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// Body of `fn test_port() -> u16 { .. }`, from the opening brace to the first
+/// closing brace in column 0.
+fn test_port_body(src: &str) -> Option<&str> {
+    let start = src.find("fn test_port() -> u16 {")?;
+    let rest = &src[start..];
+    let end = rest.find("\n}")?;
+    Some(&rest[..end])
+}
+
+/// The default port a suite falls back to, and the 0-based index of the line it
+/// is written on. `None` when the file has no `fn test_port()` fallback.
+fn default_port(src: &str) -> Option<(usize, u16)> {
+    let body = test_port_body(src)?;
+    let at = body.find(".unwrap_or(")?;
+    let digits: String = body[at + ".unwrap_or(".len()..]
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    let port: u16 = digits.parse().ok()?;
+    // Absolute line index of that `.unwrap_or(` within the whole file.
+    let abs = src.find("fn test_port() -> u16 {")? + at;
+    let line = src[..abs].lines().count() - 1;
+    Some((line, port))
+}
+
+/// True when `hay[at..at + needle_len]` is a standalone number (not a digit of a
+/// longer one).
+fn is_standalone_number(hay: &str, at: usize, len: usize) -> bool {
+    let before_ok = hay[..at]
+        .chars()
+        .next_back()
+        .is_none_or(|c| !c.is_ascii_digit());
+    let after_ok = hay[at + len..]
+        .chars()
+        .next()
+        .is_none_or(|c| !c.is_ascii_digit());
+    before_ok && after_ok
+}
+
+/// Code lines (comment lines excluded) that write `port` as a bare literal,
+/// other than the single declaration line `allowed_line`.
+///
+/// Returns `(1-based line number, line text)` pairs.
+fn bare_port_hits(src: &str, port: u16, allowed_line: usize) -> Vec<(usize, String)> {
+    let needle = port.to_string();
+    let mut hits = Vec::new();
+    for (idx, line) in src.lines().enumerate() {
+        if idx == allowed_line {
+            continue;
+        }
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        let mut from = 0;
+        while let Some(rel) = line[from..].find(&needle) {
+            let at = from + rel;
+            if is_standalone_number(line, at, needle.len()) {
+                hits.push((idx + 1, line.to_string()));
+                break;
+            }
+            from = at + 1;
+        }
+    }
+    hits
+}
+
+/// Suites whose source issues `FLUSHALL`, by test-target name.
+fn flushall_suites() -> BTreeSet<String> {
+    integration_sources()
+        .into_iter()
+        .filter(|p| {
+            fs::read_to_string(p)
+                .unwrap_or_default()
+                .contains("cmd(\"FLUSHALL\")")
+        })
+        .map(|p| {
+            p.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// INV-P1 — one source of truth for each suite's port
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inv_p1_suite_ports_have_a_single_source_of_truth() {
+    let mut checked: BTreeSet<String> = BTreeSet::new();
+    for path in integration_sources() {
+        let src = fs::read_to_string(&path).unwrap();
+        let Some((line, port)) = default_port(&src) else {
+            continue;
+        };
+        checked.insert(path.file_stem().unwrap().to_str().unwrap().to_string());
+        let hits = bare_port_hits(&src, port, line);
+        assert!(
+            hits.is_empty(),
+            "{}: port {} must appear in executable code ONLY on the \
+             `.unwrap_or({})` line inside `fn test_port()`; a second literal is a \
+             source of truth that the env override cannot move. Offending lines:\n{}",
+            path.display(),
+            port,
+            port,
+            hits.iter()
+                .map(|(n, l)| format!("  {n}: {}", l.trim()))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+    }
+    // Not vacuous: these five RESP suites must all be reached by the scan. If a
+    // suite stops resolving its port through `fn test_port() -> u16`, the scan
+    // would silently skip it — so pin the set instead of counting it.
+    for required in [
+        "integration_dragonfly",
+        "integration_kividb",
+        "integration_redis",
+        "integration_valkey",
+        "integration_vectorsets",
+    ] {
+        assert!(
+            checked.contains(required),
+            "{required} must resolve its port through a `fn test_port() -> u16` \
+             with a `.unwrap_or(<port>)` fallback so this scan can see it; \
+             scanned {checked:?}"
+        );
+    }
+}
+
+#[test]
+fn inv_p1_scanner_flags_the_historical_const_spelling() {
+    // Positive control: the exact shape whose `sed` override silently no-opped.
+    let src = "\
+//! Requires redis running on port 6399.
+const TEST_PORT: u16 = 6399;
+fn test_port() -> u16 {
+    std::env::var(\"REDIS_TEST_PORT\")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6399)
+}
+";
+    let (line, port) = default_port(src).expect("fallback must be found");
+    assert_eq!(port, 6399);
+    let hits = bare_port_hits(src, port, line);
+    assert_eq!(
+        hits.len(),
+        1,
+        "scanner must flag the `const TEST_PORT` line, got {hits:?}"
+    );
+    assert!(hits[0].1.contains("const TEST_PORT"));
+}
+
+#[test]
+fn inv_p1_scanner_flags_a_literal_handed_to_a_spawned_binary() {
+    // Positive control #2: the other spelling of a second source of truth.
+    let src = "\
+fn test_port() -> u16 {
+    std::env::var(\"REDIS_TEST_PORT\")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6399)
+}
+fn run() {
+    cmd.env(\"REDIS_PORT\", \"6399\");
+}
+";
+    let (line, port) = default_port(src).unwrap();
+    let hits = bare_port_hits(src, port, line);
+    assert_eq!(hits.len(), 1, "got {hits:?}");
+    assert!(hits[0].1.contains("REDIS_PORT"));
+}
+
+#[test]
+fn inv_p1_scanner_accepts_comment_mentions_and_longer_numbers() {
+    // Negative control: without it, a guard that rejects everything would pass
+    // the two positive controls above.
+    let src = "\
+//! Requires redis running on port 6399.
+//! Run with: REDIS_TEST_PORT=6399 cargo test --test integration_redis
+fn test_port() -> u16 {
+    std::env::var(\"REDIS_TEST_PORT\")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6399)
+}
+fn unrelated() -> u32 {
+    // 6399 in a trailing comment is fine too
+    163990
+}
+";
+    let (line, port) = default_port(src).unwrap();
+    assert!(
+        bare_port_hits(src, port, line).is_empty(),
+        "comment mentions and the digits of 163990 must not be flagged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// INV-P2 / INV-P3 — destructive suites claim the instance they run against
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inv_p3_flushall_suite_set_is_pinned() {
+    let found = flushall_suites();
+    let expected: BTreeSet<String> = [
+        "integration_dragonfly",
+        "integration_kividb",
+        "integration_redis",
+        "integration_valkey",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    assert_eq!(
+        found, expected,
+        "the set of suites issuing FLUSHALL changed. A NEW one must call \
+         `common::claim_resp_instance` from its `fn test_port()` (see issue #292) \
+         and be added here; a REMOVED one means its FLUSHALL is gone."
+    );
+}
+
+#[test]
+fn inv_p2_flushall_suites_claim_their_instance_in_test_port() {
+    let suites = flushall_suites();
+    assert!(!suites.is_empty(), "FLUSHALL scan found nothing");
+    for suite in suites {
+        let path = tests_dir().join(format!("{suite}.rs"));
+        let src = fs::read_to_string(&path).unwrap();
+        let body = test_port_body(&src).unwrap_or_else(|| {
+            panic!(
+                "{}: a FLUSHALL suite must resolve its port through \
+                 `fn test_port() -> u16`",
+                path.display()
+            )
+        });
+        assert!(
+            body.contains("common::claim_resp_instance("),
+            "{}: `fn test_port()` must call `common::claim_resp_instance(..)`. \
+             It is the choke point every path to the server goes through, so the \
+             ownership check belongs there and nowhere else. Body was:\n{body}",
+            path.display(),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The ownership decision itself
+// ---------------------------------------------------------------------------
+
+fn inputs<'a>(
+    dbsize: i64,
+    index_count: usize,
+    prior: Option<&'a str>,
+    id: &'a str,
+) -> ClaimInputs<'a> {
+    ClaimInputs {
+        target: "integration_redis",
+        port_env: "REDIS_TEST_PORT",
+        host: "127.0.0.1",
+        port: 6399,
+        dbsize,
+        index_count,
+        prior_claim: prior,
+        server_id: id,
+        forced: false,
+    }
+}
+
+#[test]
+fn claim_verdict_takes_an_empty_server() {
+    // Positive control: the guard must not reject everything. A fresh container
+    // — which is what CI starts — has to be usable with no env set.
+    assert_eq!(claim_verdict(&inputs(0, 0, None, "abc")), Claim::Fresh);
+}
+
+#[test]
+fn claim_verdict_refuses_foreign_data() {
+    let v = claim_verdict(&inputs(400, 1, None, "abc"));
+    assert!(
+        matches!(v, Claim::Refuse(_)),
+        "a server holding keys and indexes this harness never claimed must be \
+         refused, got {v:?}"
+    );
+}
+
+#[test]
+fn claim_verdict_refuses_keys_even_with_no_indexes() {
+    // The #286 corpus that nearly got wiped was plain keys; FT._LIST was empty.
+    let v = claim_verdict(&inputs(400, 0, None, "abc"));
+    assert!(matches!(v, Claim::Refuse(_)), "got {v:?}");
+}
+
+#[test]
+fn claim_verdict_reuses_an_instance_this_target_dir_already_claimed() {
+    // Re-running the suite must work: after a full run the server is left
+    // non-empty, and its identity still matches the recorded claim.
+    assert_eq!(
+        claim_verdict(&inputs(400, 1, Some("abc"), "abc")),
+        Claim::Reused
+    );
+}
+
+#[test]
+fn claim_verdict_ignores_a_claim_from_a_different_server() {
+    // Same port, different server (the container was replaced and repopulated
+    // by someone else): the recorded run_id no longer matches.
+    let v = claim_verdict(&inputs(400, 1, Some("abc"), "xyz"));
+    assert!(matches!(v, Claim::Refuse(_)), "got {v:?}");
+}
+
+#[test]
+fn claim_verdict_never_matches_an_unidentifiable_server() {
+    // A server that reports no `run_id` yields an empty identity. Two unrelated
+    // such servers must not look like the same one.
+    let v = claim_verdict(&inputs(400, 1, Some(""), ""));
+    assert!(matches!(v, Claim::Refuse(_)), "got {v:?}");
+}
+
+#[test]
+fn claim_verdict_honours_the_waiver() {
+    let mut i = inputs(400, 1, None, "abc");
+    i.forced = true;
+    assert_eq!(claim_verdict(&i), Claim::Reused);
+}
+
+#[test]
+fn refusal_message_states_the_mechanism_and_the_way_out() {
+    let Claim::Refuse(msg) = claim_verdict(&inputs(400, 2, None, "abc")) else {
+        panic!("expected a refusal");
+    };
+    for expected in [
+        "integration_redis", // which suite
+        "127.0.0.1:6399",    // which server
+        "400 key(s)",        // what is at risk
+        "2 search index(es)",
+        "FLUSHALL",           // the true mechanism of the damage
+        "FT._LIST",           // ..and the index half of it
+        "REDIS_TEST_PORT",    // the supported override
+        ALLOW_DIRTY_ENV,      // the escape hatch
+        "harness_invariants", // why editing the source will not work
+    ] {
+        assert!(
+            msg.contains(expected),
+            "refusal message must mention {expected:?}; message was:\n{msg}"
+        );
+    }
+}

--- a/tests/harness_invariants.rs
+++ b/tests/harness_invariants.rs
@@ -41,7 +41,7 @@ use std::path::{Path, PathBuf};
 
 mod common;
 
-use common::{claim_verdict, Claim, ClaimInputs, ALLOW_DIRTY_ENV};
+use common::{claim_verdict, info_field, Claim, ClaimInputs, ALLOW_DIRTY_ENV};
 
 // ---------------------------------------------------------------------------
 // Source scanning helpers (pure — unit-tested against synthetic input below)
@@ -417,4 +417,35 @@ fn refusal_message_states_the_mechanism_and_the_way_out() {
             "refusal message must mention {expected:?}; message was:\n{msg}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Server identity parsing (what makes a prior claim match, or not)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn info_field_reads_run_id_and_master_replid() {
+    // Captured live from redis:8.8.0 `INFO server` (abridged).
+    let server = "# Server\r\nredis_version:8.8.0\r\ntcp_port:6379\r\n\
+                  run_id:e47fa0a6160528b56d01a21bfc4146d716ee02e3\r\nuptime_in_seconds:12\r\n";
+    assert_eq!(
+        info_field(server, "run_id"),
+        "e47fa0a6160528b56d01a21bfc4146d716ee02e3"
+    );
+
+    // Dragonfly df-v1.40.1 `INFO server` reports NO run_id, which is why
+    // `server_identity` falls back to `master_replid` from `INFO replication`.
+    let df_server = "# Server\r\nredis_version:7.4.0\r\ndragonfly_version:df-v1.40.1\r\n\
+                     tcp_port:6379\r\nuptime_in_seconds:23\r\n";
+    assert_eq!(
+        info_field(df_server, "run_id"),
+        "",
+        "absent field must yield the empty identity, which never matches a claim"
+    );
+    let df_repl = "# Replication\r\nrole:master\r\n\
+                   master_replid:4da04ff40e648670f83234caa27706516c67588b\r\n";
+    assert_eq!(
+        info_field(df_repl, "master_replid"),
+        "4da04ff40e648670f83234caa27706516c67588b"
+    );
 }

--- a/tests/harness_invariants.rs
+++ b/tests/harness_invariants.rs
@@ -18,7 +18,7 @@
 //!   2. A `docker run -p 6399:6379` failed because the shared container already
 //!      held the port, so the writes landed in the shared server instead.
 //!
-//! Four invariants are locked in:
+//! Six invariants are locked in:
 //!
 //!   INV-P1  A suite's default port appears exactly ONCE in its executable
 //!           source: the `.unwrap_or(<port>)` inside `fn test_port()`. Any other
@@ -41,6 +41,17 @@
 //!           guard coerced an unreachable server, a denied `DBSIZE` and an
 //!           unsupported command all to "0 keys" — i.e. to `Fresh` — which fails
 //!           open in the one function whose job is to refuse.
+//!
+//!   INV-P5  No shared helper under `tests/common/` issues a server wipe. Every
+//!           suite includes `mod common;`, non-destructive ones included, so a
+//!           wipe there would be invisible to the per-suite scan in P2/P3.
+//!
+//!   INV-P6  Each wiping suite's default port equals the host port
+//!           `tests/docker-compose.test.yml` publishes for it, and the container
+//!           port it hands the claim equals the mapped container port. P1 rejects
+//!           a SECOND literal; only this rejects EDITING the single one — the
+//!           bypass incident 1 used, and the one the refusal message promises is
+//!           rejected.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -104,17 +115,17 @@ fn default_port(src: &str) -> Option<(usize, u16)> {
     Some((line, port))
 }
 
-/// True when `hay[at..at + len]` is a standalone number (not a digit of a longer
-/// one).
+/// True when `hay[at..at + len]` is a standalone NUMBER — not a run of digits
+/// inside a longer number (`163990`) and not part of an identifier
+/// (`foo_6399`, `PORT_6399`, `x6399`).
+///
+/// The identifier half matters: with only the digit check, `let foo_6399 = 1;`
+/// was reported as a bare port literal even though the line contains no literal
+/// at all, because `_` is not a digit and so read as a boundary.
 fn is_standalone_number(hay: &str, at: usize, len: usize) -> bool {
-    let before_ok = hay[..at]
-        .chars()
-        .next_back()
-        .is_none_or(|c| !c.is_ascii_digit());
-    let after_ok = hay[at + len..]
-        .chars()
-        .next()
-        .is_none_or(|c| !c.is_ascii_digit());
+    let boundary = |c: char| !c.is_ascii_alphanumeric() && c != '_';
+    let before_ok = hay[..at].chars().next_back().is_none_or(boundary);
+    let after_ok = hay[at + len..].chars().next().is_none_or(boundary);
     before_ok && after_ok
 }
 
@@ -210,6 +221,50 @@ fn wiping_suites() -> BTreeSet<String> {
         .collect()
 }
 
+/// The compose service each wiping suite is meant to talk to.
+const SUITE_COMPOSE_SERVICE: &[(&str, &str)] = &[
+    ("integration_dragonfly", "dragonfly"),
+    ("integration_kividb", "kividb"),
+    ("integration_redis", "redis"),
+    ("integration_valkey", "valkey"),
+];
+
+/// `(host_port, container_port)` from the first published port of a
+/// `tests/docker-compose.test.yml` service, e.g. `- "6386:6380"` -> `(6386, 6380)`.
+fn compose_ports(service: &str) -> Option<(u16, u16)> {
+    let compose = fs::read_to_string(tests_dir().join("docker-compose.test.yml")).ok()?;
+    let mut in_service = false;
+    let mut in_ports = false;
+    for line in compose.lines() {
+        // A service header is exactly two spaces of indent, e.g. `  kividb:`.
+        if let Some(name) = line.strip_prefix("  ").and_then(|l| l.strip_suffix(':')) {
+            if !name.starts_with(' ') {
+                in_service = name == service;
+                in_ports = false;
+                continue;
+            }
+        }
+        if !in_service {
+            continue;
+        }
+        let trimmed = line.trim();
+        if trimmed == "ports:" {
+            in_ports = true;
+            continue;
+        }
+        if in_ports {
+            if let Some(entry) = trimmed.strip_prefix("- ") {
+                let (host, container) = entry.trim().trim_matches('"').split_once(':')?;
+                return Some((host.parse().ok()?, container.parse().ok()?));
+            }
+            if !trimmed.starts_with('#') && !trimmed.is_empty() {
+                in_ports = false;
+            }
+        }
+    }
+    None
+}
+
 /// The env var a `test_port()` body reads, e.g. `REDIS_TEST_PORT`.
 fn port_env_var(body: &str) -> Option<String> {
     let at = body.find("std::env::var(\"")? + "std::env::var(\"".len();
@@ -218,9 +273,11 @@ fn port_env_var(body: &str) -> Option<String> {
     Some(rest[..end].to_string())
 }
 
-/// Collapse runs of whitespace so a match survives rustfmt rewrapping.
+/// Normalise a call so the match survives rustfmt: drop all whitespace (it may
+/// rewrap the arguments one per line) and the trailing comma it then adds.
 fn squeeze(s: &str) -> String {
-    s.split_whitespace().collect::<Vec<_>>().join(" ")
+    let no_ws: String = s.chars().filter(|c| !c.is_whitespace()).collect();
+    no_ws.replace(",)", ")")
 }
 
 // ---------------------------------------------------------------------------
@@ -347,12 +404,45 @@ fn test_port() -> u16 {
         hits[0].1.contains("6_399"),
         "the ORIGINAL line must be reported, not the normalised one: {hits:?}"
     );
-    // ..and a separator that is not between two digits must not be collapsed,
-    // or `PORT_6399` would start matching.
+    // The stripper only joins digits across a separator that sits BETWEEN two
+    // digits, so an identifier keeps its underscore. (Whether `foo_6399` is
+    // FLAGGED is a separate question, settled by `is_standalone_number` and
+    // covered by the next test.)
     assert_eq!(
         strip_digit_separators("let foo_6399 = 1_000;"),
         "let foo_6399 = 1000;"
     );
+}
+
+#[test]
+fn inv_p1_scanner_does_not_flag_identifiers_that_merely_end_in_the_port() {
+    // Negative control with teeth: none of these lines contains a port literal,
+    // and an earlier `is_standalone_number` flagged the first two — it treated
+    // `_` as a boundary, so `foo_6399` read as the bare number 6399.
+    let src = "\
+fn test_port() -> u16 {
+    std::env::var(\"REDIS_TEST_PORT\")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6399)
+}
+fn unrelated() {
+    let foo_6399 = 1;
+    let port_6399 = 2;
+    let x6399y = 3;
+}
+";
+    let (line, port) = default_port(src).unwrap();
+    let hits = bare_port_hits(src, port, line);
+    assert!(
+        hits.is_empty(),
+        "identifiers ending in the port number are not port literals: {hits:?}"
+    );
+    // ..and the real thing on the very same shape of line is still caught, so
+    // the precision fix did not cost the scanner its teeth.
+    let real = src.replace("let foo_6399 = 1;", "cmd.env(\"REDIS_PORT\", \"6399\");");
+    let (line, port) = default_port(&real).unwrap();
+    assert_eq!(bare_port_hits(&real, port, line).len(), 1);
 }
 
 #[test]
@@ -505,9 +595,19 @@ fn inv_p2_wiping_suites_claim_their_instance_in_test_port() {
         // Check the ARGUMENTS, not merely that some call exists: a copy-paste
         // passing another suite's target name or env var would otherwise pass,
         // recording the claim under the wrong key and naming the wrong override
-        // in the refusal message.
-        let expected =
-            format!("common::claim_resp_instance(\"{suite}\", \"{env}\", TEST_HOST, port);");
+        // in the refusal message. The container port is checked against compose
+        // for the same reason — the refusal prints a `docker run -p X:<it>` line,
+        // and kividb's is 6380, not 6379.
+        let service = SUITE_COMPOSE_SERVICE
+            .iter()
+            .find(|(s, _)| *s == suite)
+            .map(|(_, svc)| *svc)
+            .unwrap_or_else(|| panic!("{suite} must be listed in SUITE_COMPOSE_SERVICE"));
+        let (_host_port, container_port) = compose_ports(service)
+            .unwrap_or_else(|| panic!("no published port for compose service {service}"));
+        let expected = format!(
+            "common::claim_resp_instance(\"{suite}\", \"{env}\", TEST_HOST, port, {container_port});"
+        );
         assert!(
             squeeze(body).contains(&squeeze(&expected)),
             "{}: `fn test_port()` must call exactly\n    {expected}\n\
@@ -515,6 +615,43 @@ fn inv_p2_wiping_suites_claim_their_instance_in_test_port() {
             path.display(),
         );
     }
+}
+
+#[test]
+fn inv_p6_suite_defaults_match_the_compose_mapping() {
+    // INV-P1 rejects a SECOND literal for the port; on its own it does not
+    // reject EDITING the single one — `default_port()` re-reads whatever is on
+    // the `.unwrap_or(..)` line, so changing 6399 to 7911 left all invariants
+    // green. That is precisely the bypass incident 1 in #292 used, and the
+    // refusal message tells operators it is rejected. This is what makes that
+    // sentence true: the default is pinned to the port
+    // `tests/docker-compose.test.yml` publishes, so an edit fails the build, and
+    // the suite default and the compose mapping cannot drift apart either way.
+    for (suite, service) in SUITE_COMPOSE_SERVICE {
+        let src = fs::read_to_string(tests_dir().join(format!("{suite}.rs"))).unwrap();
+        let (_line, default) = default_port(&src)
+            .unwrap_or_else(|| panic!("{suite}: no `fn test_port()` fallback to check"));
+        let (host_port, _container) = compose_ports(service)
+            .unwrap_or_else(|| panic!("no published port for compose service {service}"));
+        assert_eq!(
+            default, host_port,
+            "{suite}'s default port ({default}) must equal the host port \
+             tests/docker-compose.test.yml publishes for `{service}` ({host_port}). \
+             To run against your own server use the suite's env var — editing this \
+             literal moves the default for everyone."
+        );
+    }
+}
+
+#[test]
+fn inv_p6_compose_parser_reads_a_non_6379_container_port() {
+    // Positive control for the parser, and the case that motivated it: kividb
+    // does NOT listen on 6379.
+    assert_eq!(compose_ports("kividb"), Some((6386, 6380)));
+    assert_eq!(compose_ports("redis"), Some((6399, 6379)));
+    // Negative control: an absent service must be reported as absent, not as
+    // some default that would make INV-P6 pass vacuously.
+    assert_eq!(compose_ports("no-such-service"), None);
 }
 
 // ---------------------------------------------------------------------------
@@ -538,6 +675,7 @@ fn inputs<'a>(probe: &'a Probe, prior: Option<&'a str>) -> ClaimInputs<'a> {
         probe,
         prior_claim: prior,
         claim_path: "/tmp/target/vdbb-test-claims/integration_redis-127.0.0.1-6399.claim",
+        container_port: 6379,
         forced: false,
     }
 }
@@ -667,12 +805,14 @@ fn refusal_message_states_the_mechanism_and_the_way_out() {
         "127.0.0.1:6399",    // which server
         "400 key(s) across all databases",
         "2 search index(es)",
-        "FLUSHALL",           // the true mechanism of the damage
-        "FT._LIST",           // ..and the index half of it
-        "REDIS_TEST_PORT",    // the supported override
-        ALLOW_DIRTY_ENV,      // the escape hatch
-        "harness_invariants", // why editing the source will not work
-        "vdbb-test-claims",   // WHERE the claim was looked for
+        "FLUSHALL",                // the true mechanism of the damage
+        "FT._LIST",                // ..and the index half of it
+        "REDIS_TEST_PORT",         // the supported override
+        ALLOW_DIRTY_ENV,           // the escape hatch
+        "harness_invariants",      // why editing the source will not work
+        "docker-compose.test.yml", // ..and the mechanism that makes that true
+        "vdbb-test-claims",        // WHERE the claim was looked for
+        "-p <your-port>:6379",     // a runnable remedy, with the RIGHT port
     ] {
         assert!(
             msg.contains(expected),
@@ -687,6 +827,35 @@ fn refusal_message_states_the_mechanism_and_the_way_out() {
          only knows there is no matching claim. Message was:\n{msg}"
     );
     assert!(msg.contains("no claim for"));
+
+    // The message must not claim a policing power the invariants do not have.
+    // The earlier wording — "Editing the port literal in tests/X.rs is rejected
+    // by tests/harness_invariants.rs" — was false: INV-P1 rejects a SECOND
+    // literal, and editing the single one left all invariants green. That is now
+    // true only because INV-P6 pins the default to the compose mapping, so the
+    // message has to cite THAT, and this asserts it does. Naming the file alone
+    // is what let the false sentence ship.
+    assert!(
+        msg.contains("pins that default to the"),
+        "the message must name the mechanism that actually rejects an edit \
+         (INV-P6's compose pin), not just the file: {msg}"
+    );
+
+    // The remedy has to be runnable for the suite it is printed for. kividb
+    // listens on 6380, so a hardcoded 6379 would hand the operator a container
+    // the suite cannot reach — and then a second refusal from this guard.
+    let mut kividb = inputs(&p, None);
+    kividb.target = "integration_kividb";
+    kividb.port_env = "KIVIDB_PORT";
+    kividb.container_port = 6380;
+    let Claim::Refuse(kv) = claim_verdict(&kividb) else {
+        panic!("expected a refusal");
+    };
+    assert!(
+        kv.contains("-p <your-port>:6380"),
+        "kividb's remedy must publish to 6380, not 6379: {kv}"
+    );
+    assert!(!kv.contains("-p <your-port>:6379"), "{kv}");
 }
 
 #[test]

--- a/tests/integration_dragonfly.rs
+++ b/tests/integration_dragonfly.rs
@@ -9,7 +9,8 @@
 //! supported way to point the suite at your own container — do NOT edit the port
 //! in this file (`tests/harness_invariants.rs` rejects a second port literal).
 //! `test_port()` also claims the instance on first use and refuses to run if the
-//! server holds state this harness did not create.
+//! server holds state it has no recorded claim for. Any probe it cannot complete
+//! (unreachable, still loading, a denied or unsupported command) also refuses.
 //!
 //! Scope: vector KNN (whole-corpus COSINE ground truth, so recall reflects index
 //! quality alone) PLUS metadata filtering — Dragonfly Search supports hybrid
@@ -39,7 +40,7 @@ type KnnData = (Vec<Vec<f32>>, Vec<Vec<f32>>, Vec<Vec<i64>>);
 /// move this suite off the shared default — these tests call `flush_db()`,
 /// which `FLUSHALL`s the whole server. The first call also claims the instance
 /// (see `common::claim_resp_instance`), so a server holding state this harness
-/// did not create is refused instead of destroyed.
+/// no recorded claim for is refused instead of destroyed.
 fn test_port() -> u16 {
     static PORT: std::sync::OnceLock<u16> = std::sync::OnceLock::new();
     *PORT.get_or_init(|| {

--- a/tests/integration_dragonfly.rs
+++ b/tests/integration_dragonfly.rs
@@ -4,6 +4,13 @@
 //! Start with: docker compose -f tests/docker-compose.test.yml up -d dragonfly
 //! Run with:   DRAGONFLY_PORT=6385 cargo test --test integration_dragonfly -- --test-threads=1
 //!
+//! DESTRUCTIVE. Every test calls `flush_db()`, which drops every index
+//! `FT._LIST` reports and then issues `FLUSHALL`. `DRAGONFLY_PORT` is the ONLY
+//! supported way to point the suite at your own container — do NOT edit the port
+//! in this file (`tests/harness_invariants.rs` rejects a second port literal).
+//! `test_port()` also claims the instance on first use and refuses to run if the
+//! server holds state this harness did not create.
+//!
 //! Scope: vector KNN (whole-corpus COSINE ground truth, so recall reflects index
 //! quality alone) PLUS metadata filtering — Dragonfly Search supports hybrid
 //! filtered KNN, so the `test_binary_dragonfly_*` tests exercise the filter path
@@ -28,11 +35,21 @@ type KnnData = (Vec<Vec<f32>>, Vec<Vec<f32>>, Vec<Vec<i64>>);
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Dragonfly port under test. `DRAGONFLY_PORT` is the ONLY supported way to
+/// move this suite off the shared default — these tests call `flush_db()`,
+/// which `FLUSHALL`s the whole server. The first call also claims the instance
+/// (see `common::claim_resp_instance`), so a server holding state this harness
+/// did not create is refused instead of destroyed.
 fn test_port() -> u16 {
-    std::env::var("DRAGONFLY_PORT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(6385)
+    static PORT: std::sync::OnceLock<u16> = std::sync::OnceLock::new();
+    *PORT.get_or_init(|| {
+        let port = std::env::var("DRAGONFLY_PORT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(6385);
+        common::claim_resp_instance("integration_dragonfly", "DRAGONFLY_PORT", TEST_HOST, port);
+        port
+    })
 }
 
 const TEST_HOST: &str = "127.0.0.1";

--- a/tests/integration_dragonfly.rs
+++ b/tests/integration_dragonfly.rs
@@ -40,7 +40,7 @@ type KnnData = (Vec<Vec<f32>>, Vec<Vec<f32>>, Vec<Vec<i64>>);
 /// move this suite off the shared default — these tests call `flush_db()`,
 /// which `FLUSHALL`s the whole server. The first call also claims the instance
 /// (see `common::claim_resp_instance`), so a server holding state this harness
-/// no recorded claim for is refused instead of destroyed.
+/// has no recorded claim for is refused instead of destroyed.
 fn test_port() -> u16 {
     static PORT: std::sync::OnceLock<u16> = std::sync::OnceLock::new();
     *PORT.get_or_init(|| {

--- a/tests/integration_dragonfly.rs
+++ b/tests/integration_dragonfly.rs
@@ -48,7 +48,13 @@ fn test_port() -> u16 {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(6385);
-        common::claim_resp_instance("integration_dragonfly", "DRAGONFLY_PORT", TEST_HOST, port);
+        common::claim_resp_instance(
+            "integration_dragonfly",
+            "DRAGONFLY_PORT",
+            TEST_HOST,
+            port,
+            6379,
+        );
         port
     })
 }

--- a/tests/integration_kividb.rs
+++ b/tests/integration_kividb.rs
@@ -9,7 +9,8 @@
 //! supported way to point the suite at your own container — do NOT edit the port
 //! in this file (`tests/harness_invariants.rs` rejects a second port literal).
 //! `test_port()` also claims the instance on first use and refuses to run if the
-//! server holds state this harness did not create.
+//! server holds state it has no recorded claim for. Any probe it cannot complete
+//! (unreachable, still loading, a denied or unsupported command) also refuses.
 //!
 //! Scope: vector KNN (whole-corpus COSINE ground truth, so recall reflects index
 //! quality alone), plus HNSW/FLAT algorithm selection, EF_RUNTIME behavior,

--- a/tests/integration_kividb.rs
+++ b/tests/integration_kividb.rs
@@ -4,6 +4,13 @@
 //! Start with: docker compose -f tests/docker-compose.test.yml up -d kividb
 //! Run with:   KIVIDB_PORT=6386 cargo test --test integration_kividb -- --test-threads=1
 //!
+//! DESTRUCTIVE. Every test calls `flush_db()`, which drops every index
+//! `FT._LIST` reports and then issues `FLUSHALL`. `KIVIDB_PORT` is the ONLY
+//! supported way to point the suite at your own container — do NOT edit the port
+//! in this file (`tests/harness_invariants.rs` rejects a second port literal).
+//! `test_port()` also claims the instance on first use and refuses to run if the
+//! server holds state this harness did not create.
+//!
 //! Scope: vector KNN (whole-corpus COSINE ground truth, so recall reflects index
 //! quality alone), plus HNSW/FLAT algorithm selection, EF_RUNTIME behavior,
 //! per-config keyspace coexistence / --skip-upload, AND metadata filtering
@@ -32,11 +39,21 @@ type KnnData = (Vec<Vec<f32>>, Vec<Vec<f32>>, Vec<Vec<i64>>);
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// KiviDB port under test. `KIVIDB_PORT` is the ONLY supported way to move this
+/// suite off the shared default — these tests call `flush_db()`, which
+/// `FLUSHALL`s the whole server. The first call also claims the instance (see
+/// `common::claim_resp_instance`), so a server holding state this harness did
+/// not create is refused instead of destroyed.
 fn test_port() -> u16 {
-    std::env::var("KIVIDB_PORT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(6386)
+    static PORT: std::sync::OnceLock<u16> = std::sync::OnceLock::new();
+    *PORT.get_or_init(|| {
+        let port = std::env::var("KIVIDB_PORT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(6386);
+        common::claim_resp_instance("integration_kividb", "KIVIDB_PORT", TEST_HOST, port);
+        port
+    })
 }
 
 const TEST_HOST: &str = "127.0.0.1";

--- a/tests/integration_kividb.rs
+++ b/tests/integration_kividb.rs
@@ -40,11 +40,14 @@ type KnnData = (Vec<Vec<f32>>, Vec<Vec<f32>>, Vec<Vec<i64>>);
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// KiviDB port under test. `KIVIDB_PORT` is the ONLY supported way to move this
+/// KiviDB port under test. The `6380` handed to the claim is the port KiviDB
+/// listens on INSIDE its container (not 6379); it only shapes the `docker run -p`
+/// line the refusal prints, and `tests/harness_invariants.rs` checks it against
+/// the `kividb` mapping in `tests/docker-compose.test.yml`. `KIVIDB_PORT` is the ONLY supported way to move this
 /// suite off the shared default — these tests call `flush_db()`, which
 /// `FLUSHALL`s the whole server. The first call also claims the instance (see
-/// `common::claim_resp_instance`), so a server holding state this harness did
-/// not create is refused instead of destroyed.
+/// `common::claim_resp_instance`), so a server holding state this harness
+/// has no recorded claim for is refused instead of destroyed.
 fn test_port() -> u16 {
     static PORT: std::sync::OnceLock<u16> = std::sync::OnceLock::new();
     *PORT.get_or_init(|| {
@@ -52,7 +55,7 @@ fn test_port() -> u16 {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(6386);
-        common::claim_resp_instance("integration_kividb", "KIVIDB_PORT", TEST_HOST, port);
+        common::claim_resp_instance("integration_kividb", "KIVIDB_PORT", TEST_HOST, port, 6380);
         port
     })
 }

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -15,7 +15,9 @@
 //! this file: `tests/harness_invariants.rs` rejects a second port literal, and
 //! an edit is invisible to anyone reading the command you ran. As a backstop,
 //! `test_port()` claims the instance on first use and refuses to run at all if
-//! the server already holds state this harness did not create.
+//! the server already holds state it has no recorded claim for. Any probe it
+//! cannot complete (unreachable, still loading, a denied or unsupported command)
+//! also refuses, because guessing "empty" is unrecoverable.
 
 use std::fs;
 use std::path::PathBuf;
@@ -40,7 +42,7 @@ mod common;
 /// each other.
 ///
 /// The first call also claims the instance (`common::claim_resp_instance`): if
-/// the server already holds keys or indexes this harness did not create, every
+/// the server already holds keys or indexes it has no recorded claim for, every
 /// test fails with an explanatory panic instead of destroying that data. The
 /// claim lives here rather than in `flush_db()` because `test_port()` is the one
 /// place EVERY path to the server goes through — the direct `redis::Client`

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -3,6 +3,19 @@
 //! Requires redis:8.6.0 running on port 6399.
 //! Start with: docker compose -f tests/docker-compose.test.yml up -d
 //! Run with:   cargo test --test integration_redis -- --test-threads=1
+//!
+//! DESTRUCTIVE. Every test calls `flush_db()`, which drops every index
+//! `FT._LIST` reports and then issues `FLUSHALL` — it destroys the whole server,
+//! not just this suite's keys. The default port 6399 is the container several
+//! sessions share, so to run against your own instance set the env var:
+//!
+//!     REDIS_TEST_PORT=<your-port> cargo test --test integration_redis -- --test-threads=1
+//!
+//! `REDIS_TEST_PORT` is the ONLY supported mechanism. Do NOT edit the port in
+//! this file: `tests/harness_invariants.rs` rejects a second port literal, and
+//! an edit is invisible to anyone reading the command you ran. As a backstop,
+//! `test_port()` claims the instance on first use and refuses to run at all if
+//! the server already holds state this harness did not create.
 
 use std::fs;
 use std::path::PathBuf;
@@ -21,23 +34,37 @@ mod common;
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Redis port under test. Overridable so a session can run against its OWN
-/// container instead of the shared 6399 one — these tests call `flush_db()`, so
-/// two sessions sharing an instance clobber each other.
+/// Redis port under test. `REDIS_TEST_PORT` is the ONLY supported way to move
+/// this suite off the shared default — these tests call `flush_db()`, which
+/// `FLUSHALL`s the whole server, so two sessions sharing an instance clobber
+/// each other.
+///
+/// The first call also claims the instance (`common::claim_resp_instance`): if
+/// the server already holds keys or indexes this harness did not create, every
+/// test fails with an explanatory panic instead of destroying that data. The
+/// claim lives here rather than in `flush_db()` because `test_port()` is the one
+/// place EVERY path to the server goes through — the direct `redis::Client`
+/// helpers and the `REDIS_PORT` value handed to spawned benchmark binaries.
 fn test_port() -> u16 {
-    std::env::var("REDIS_TEST_PORT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(6399)
+    static PORT: std::sync::OnceLock<u16> = std::sync::OnceLock::new();
+    *PORT.get_or_init(|| {
+        let port = std::env::var("REDIS_TEST_PORT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(6399);
+        common::claim_resp_instance("integration_redis", "REDIS_TEST_PORT", TEST_HOST, port);
+        port
+    })
 }
 const TEST_HOST: &str = "127.0.0.1";
 
 fn get_test_connection() -> Connection {
-    let url = format!("redis://{}:{}/", TEST_HOST, test_port());
+    let port = test_port();
+    let url = format!("redis://{}:{}/", TEST_HOST, port);
     let client = redis::Client::open(url.as_str()).expect("Failed to create Redis client");
-    client
-        .get_connection()
-        .expect("Failed to connect to Redis. Is redis:8.6.0 running on port 6399?")
+    client.get_connection().unwrap_or_else(|e| {
+        panic!("Failed to connect to Redis on port {port} (set REDIS_TEST_PORT to move the suite): {e}")
+    })
 }
 
 fn wait_for_redis() {

--- a/tests/integration_redis.rs
+++ b/tests/integration_redis.rs
@@ -54,7 +54,13 @@ fn test_port() -> u16 {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(6399);
-        common::claim_resp_instance("integration_redis", "REDIS_TEST_PORT", TEST_HOST, port);
+        common::claim_resp_instance(
+            "integration_redis",
+            "REDIS_TEST_PORT",
+            TEST_HOST,
+            port,
+            6379,
+        );
         port
     })
 }

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -30,8 +30,8 @@ mod common;
 /// Valkey port under test. `VALKEY_PORT` is the ONLY supported way to move this
 /// suite off the shared default — these tests call `flush_db()`, which
 /// `FLUSHALL`s the whole server. The first call also claims the instance (see
-/// `common::claim_resp_instance`), so a server holding state this harness did
-/// not create is refused instead of destroyed.
+/// `common::claim_resp_instance`), so a server holding state this harness
+/// has no recorded claim for is refused instead of destroyed.
 fn test_port() -> u16 {
     static PORT: std::sync::OnceLock<u16> = std::sync::OnceLock::new();
     *PORT.get_or_init(|| {
@@ -39,7 +39,7 @@ fn test_port() -> u16 {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(6380);
-        common::claim_resp_instance("integration_valkey", "VALKEY_PORT", TEST_HOST, port);
+        common::claim_resp_instance("integration_valkey", "VALKEY_PORT", TEST_HOST, port, 6379);
         port
     })
 }

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -3,6 +3,13 @@
 //! Requires valkey/valkey-bundle running on port 6380.
 //! Start with: docker compose -f tests/docker-compose.test.yml up -d valkey
 //! Run with:   VALKEY_PORT=6380 cargo test --test integration_valkey -- --test-threads=1
+//!
+//! DESTRUCTIVE. Every test calls `flush_db()`, which drops every index
+//! `FT._LIST` reports and then issues `FLUSHALL`. `VALKEY_PORT` is the ONLY
+//! supported way to point the suite at your own container — do NOT edit the port
+//! in this file (`tests/harness_invariants.rs` rejects a second port literal).
+//! `test_port()` also claims the instance on first use and refuses to run if the
+//! server holds state this harness did not create.
 
 use std::fs;
 use std::path::PathBuf;
@@ -19,11 +26,21 @@ mod common;
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Valkey port under test. `VALKEY_PORT` is the ONLY supported way to move this
+/// suite off the shared default — these tests call `flush_db()`, which
+/// `FLUSHALL`s the whole server. The first call also claims the instance (see
+/// `common::claim_resp_instance`), so a server holding state this harness did
+/// not create is refused instead of destroyed.
 fn test_port() -> u16 {
-    std::env::var("VALKEY_PORT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(6380)
+    static PORT: std::sync::OnceLock<u16> = std::sync::OnceLock::new();
+    *PORT.get_or_init(|| {
+        let port = std::env::var("VALKEY_PORT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(6380);
+        common::claim_resp_instance("integration_valkey", "VALKEY_PORT", TEST_HOST, port);
+        port
+    })
 }
 
 const TEST_HOST: &str = "127.0.0.1";

--- a/tests/integration_valkey.rs
+++ b/tests/integration_valkey.rs
@@ -9,7 +9,8 @@
 //! supported way to point the suite at your own container — do NOT edit the port
 //! in this file (`tests/harness_invariants.rs` rejects a second port literal).
 //! `test_port()` also claims the instance on first use and refuses to run if the
-//! server holds state this harness did not create.
+//! server holds state it has no recorded claim for. Any probe it cannot complete
+//! (unreachable, still loading, a denied or unsupported command) also refuses.
 
 use std::fs;
 use std::path::PathBuf;


### PR DESCRIPTION
Closes #292.

## The defect

Four integration suites share one `flush_db()` shape — drop every index `FT._LIST`
reports, then `FLUSHALL` — and each defaults to a port from
`tests/docker-compose.test.yml` that several sessions share. The `REDIS_TEST_PORT`
style override existed, but the *default* was the shared instance, so the
protection only helped whoever remembered to set it. Two incidents followed:

1. A port override spelled as a `sed` against `const TEST_PORT: u16 = 6399;`
   matched nothing (the constant had become `fn test_port()`), exited 0, and the
   run proceeded against the shared server. No error, no output difference.
2. A `docker run -p 6399:6379` failed because the shared container already held
   the port, so the writes landed in the shared server.

The common shape is **an override that looks applied but isn't, on a shared
instance whose teardown path is destructive.**

## What this PR does

**1 — refuse to run against an instance the harness has no claim for**
(`tests/common/mod.rs`: `claim_verdict` / `claim_resp_instance`). On first use a
destructive suite probes the server. Unless it can *positively* establish the
server is safe, every test in the suite fails with an explanatory panic.

The claim lives inside `fn test_port()`, not inside `flush_db()`, because
`test_port()` is the one place every path to the server resolves through: the
direct `redis::Client` helpers *and* the `REDIS_PORT`-style value handed to
spawned benchmark binaries.

The probe reads `INFO persistence` (loading), `INFO keyspace` (keys across **all**
databases) and `FT._LIST`. **Every** way it can fail — unreachable, still
loading, a denied or unsupported command, an unparseable reply — produces
`Probe::Inconclusive`, which `claim_verdict` refuses on. `Probe::Reachable` is
constructed at exactly one place: the last statement of `probe_server`, after
both `INFO keyspace` and `FT._LIST` returned `Ok`.

Identity is `run_id` from `INFO server`, falling back to `master_replid` from
`INFO replication` (dragonfly df-v1.40.1 reports no `run_id`). The claim is
recorded in a file under the test binary's target directory
(`<target>/vdbb-test-claims/<suite>-<host>-<port>.claim`), *not* as a key on the
server — `integration_valkey` asserts exact `DBSIZE` values, so a server-side
marker key would have broken it. Escape hatch: `VDBB_TEST_ALLOW_DIRTY=1`, which
warns on every run.

**2 — single-source the port, enforced by a test** (`tests/harness_invariants.rs`,
a new pure test target wired into the container-free CI job next to
`overhead_invariants`). Seven invariants: one source of truth per port (P1); every server-wiping suite's
`test_port()` matches the one allowed shape, claim call and arguments included
(P2); the wipe scan's suite set is pinned (P3); the decision fails closed, and so
does the probe that feeds it (P4); no shared helper under `tests/common/`, at any
depth, may wipe a server (P5); each suite's default port equals the port
`docker-compose.test.yml` publishes for it (P6); and the set of test targets is
pinned so a new one must be classified (P7).

Not chosen: a randomised default port (CI and `docker-compose.test.yml` could no
longer name the port, and it does nothing about a stale override spelling), and a
marker key on the server (breaks valkey's `DBSIZE` assertions).

## The single clearest demonstration

A Redis holding **20 000 000 keys**, restarted so it replays its RDB, with the
suite fired during the replay. At `556914d` (the first version of this guard):

```
=== RUN 1 at 556914d, fired during the RDB replay ===
running 1 test
test test_redis_upload_and_retrieve ... FAILED
thread 'test_redis_upload_and_retrieve' panicked at tests/integration_redis.rs:83:13:
Redis not available on port 7626 after 10s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 43 filtered out; finished in 10.01s
claim minted DURING the load: integration_redis-127.0.0.1-7626.claim
claim content: 4ea63d80ebb97465068e192e22fa9080cc0c2c1d
```

Run 1 fails — but at `wait_for_redis()`, **not at the guard**. `DBSIZE` had
errored with `-LOADING`, `.unwrap_or(0)` turned that into "0 keys", the verdict was
`Fresh`, and **a claim was minted for that server**. Once the load finished:

```
load finished, dbsize=20000000
=== RUN 2 at 556914d, via the claim run 1 minted ===
running 1 test
test test_redis_upload_and_retrieve ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 43 filtered out; finished in 20.36s
dbsize after: 0
```

Twenty million foreign keys destroyed on the second run, reported as `ok`. On this
branch, same container, same sequence — refused twice, nothing minted, nothing
lost:

```
=== RUN 1 on b5c8b32, during the replay ===
test test_redis_upload_and_retrieve ... FAILED
    127.0.0.1:7626 is still loading its dataset (INFO persistence reports loading:1), so its keyspace cannot be trusted yet
claim minted during load: ls: cannot access '.../vdbb-test-claims/': No such file or directory
load finished, dbsize=20000000
=== RUN 2 on b5c8b32 ===
test test_redis_upload_and_retrieve ... FAILED
REFUSING TO RUN `integration_redis` AGAINST 127.0.0.1:7626
That server holds 20000000 key(s) across all databases and 0 search index(es)
This target directory has NO claim recorded for 127.0.0.1:7626.
dbsize after: 20000000
```

## Review round 2 — three bypasses INSIDE the guard

All shared one cause: **the probe was narrower than the destruction, and every way
it could fail was coerced to "empty".** Each reproduced live, before and after.

**B1 — skipped while the server was starting.** The guard returned early when it
could not connect ("an unreachable server cannot be damaged"). False: the suite's
own `wait_for_*()` then waits 10-30 s, the server comes up, and the `OnceLock`
means the claim is never retried. RED at `556914d` — seeded container, `docker
start` fired 3 s in:

```
running 1 test
test test_redis_upload_and_retrieve ... ok
test result: ok. 1 passed; ... finished in 4.25s
after: keyspace=# Keyspace  FT._LIST=[ ]
claim files: ls: cannot access '.../vdbb-test-claims/': No such file or directory
```

GREEN, same race: `REFUSING …`, `keyspace=db0:keys=3`, `FT._LIST=[prod_idx ]`. The
probe now retries for 30 s (>= the longest `wait_for_*()` deadline in the guarded
suites) and refuses if the server never becomes reachable.

**B2 — probe errors swallowed.** RED at `556914d` with `ACL SETUSER default
-dbsize` (`FLUSHALL` still permitted): `test … ok`, 3 keys destroyed. GREEN twice:
with `-dbsize` the probe no longer uses it and refuses on `INFO keyspace`; with
`-info` denied it refuses with
`` `INFO keyspace` failed … (NoPerm: … 'info' command), so the number of keys at risk is unknown ``.

**B3 — `DBSIZE` measures one database, `FLUSHALL` destroys all.** RED at
`556914d`, 3 keys in db 1 and an empty db 0: `test … ok`, `after: db0=0 db1=0`.
GREEN: refuses, `db0=0 db1=3`. The probe sums `INFO keyspace` over every `dbN:`
line, parsing `keys=` **by name** because the layouts differ — all captured live
and pinned, including both empty-server shapes (redis/valkey/kividb omit the db
line; dragonfly still emits `db0:keys=0`).

Also in that round: INV-P3's scan was widened from one call spelling to the quoted
command name; INV-P2 gained an argument check; INV-P1 learned
`.unwrap_or_else(|| N)`; the waiver gained a warning written straight to
`std::io::stderr()` (libtest only replays `eprintln!` for *failing* tests); and the
refusal message stopped asserting "this harness did not create" — false when your
own container is restarted — in favour of "has no claim for", plus the claim path
and a missing-vs-stale distinction.

## Review round 3 — three more, each reproduced against `7ad5e51`

**SF1 — the wipe scan was case-sensitive.** Round 2 widened the matcher from one
call spelling to "the quoted command name" and **never mutated case**: the same
guards-one-notch-weak pattern, inside the fix for the previous instance of it.
Redis command names are case-insensitive on the wire, so `cmd("flushall")` wipes
just as hard.

**SF2 — the scan never read `tests/common/mod.rs`.** Moving the `FT._LIST` drop
loop + `FLUSHALL` into a shared `pub fn wipe_server()` is the *likely* refactor,
since this guard's premise is that four suites share one `flush_db()` shape.

RED at `7ad5e51`, with a synthetic `tests/integration_synthwipe.rs` whose
`flush_db` is `cmd("flushall")` and which has **no claim call at all**, plus that
`wipe_server()` appended to `tests/common/mod.rs`:

```
=== RED at 7ad5e51: same two evasions ===
running 23 tests
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

GREEN on this branch, identical mutations:

```
running 27 tests
test inv_p5_shared_helpers_must_not_wipe_a_server ... FAILED
test inv_p3_wiping_suite_set_is_pinned ... FAILED
test inv_p2_wiping_suites_claim_their_instance_in_test_port ... FAILED
(the set diff below is INV-P3's output)
  left: {"integration_dragonfly", "integration_kividb", "integration_redis", "integration_synthwipe", "integration_valkey"}
 right: {"integration_dragonfly", "integration_kividb", "integration_redis", "integration_valkey"}
test result: FAILED. 24 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s
```

Both synthetic mutations were reverted afterwards and the pushed tree
grep-verified clean (`wipe_server` → 0 hits, no `synthwipe` file). The matcher now
uppercases the source and accepts either quote style, so `"flushall"`,
`"FlushAll"`, `"flushdb"` and a Lua `EVAL "redis.call('flushall')"` are all
positive controls, with a prose-mention negative control that keeps
`integration_vectorsets` out of the pinned set.

**SF3 — the 30 s probe re-ran for every test.** `OnceLock::get_or_init` does not
memoize a panicking initializer, so after a refusal each later test paid the full
reachability loop again — and the PR body claimed "runs once per process", which
was false on exactly the refusal path. The memoized value is now the **verdict**
(`None` = allowed, `Some(msg)` = refuse) and the panic happens outside the
initializer. Measured against a dead port (7999), same tests, same command:

| | `7ad5e51` | `b5c8b32` |
|---|---|---|
| 2 tests (`test_redis_knn`) | `finished in 60.21s` | `finished in 30.07s` |
| full suite (44 tests) | not run to completion | `running 44 tests` … `finished in 30.17s` |

At `7ad5e51` the 44-test suite would have taken ~22 minutes to report "server not
available"; it now takes 30.17 s in total.

**NITs also closed.** `sum_keyspace_keys` returns `Option<i64>` so it can say "I
cannot tell" instead of `0` — an empty reply, a missing `# Keyspace` header, a
`dbN:` line with no usable `keys=`, a negative count and an overflow are each a
`None` (which becomes `Inconclusive`) rather than `Fresh`; that was this guard's
own bug class one notch in. INV-P1 now sees through Rust digit separators
(`6_399`) while leaving `foo_6399` alone. The `INFO persistence` loading check is
documented as best-effort and **inert on kividb v1.0.2-full**, which reports no
`loading` field (measured). Doc typo in `integration_dragonfly.rs` fixed.

## Review rounds 4-5 — the audits found the guard's own claims, then the claim itself

**Round 4 (claims audit at `b5c8b32`).** Every refusal said *"Editing the port
literal in tests/<suite>.rs is rejected by tests/harness_invariants.rs"*. It was
not: INV-P1 rejects a **second** literal, and `default_port()` re-reads whatever
is on the `.unwrap_or(..)` line, so editing the single one straight through is
unpoliced — the exact bypass incident 1 used. Worse, the test policing the
message asserted only that the string `"harness_invariants"` was *present*, never
that it was true.

RED at `b5c8b32`, `.unwrap_or(6399)` → `.unwrap_or(7911)`, nothing else touched:

```
running 27 tests
test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
```

GREEN here, same one-line edit:

```
running 30 tests
test inv_p6_suite_defaults_match_the_compose_mapping ... FAILED
assertion `left == right` failed: integration_redis's default port (7911) must equal the host port tests/docker-compose.test.yml publishes for `redis` (6399). To run against your own server use the suite's env var — editing this literal moves the default for everyone.
```

Fixed by making the sentence true, not by weakening it: **INV-P6** pins each
wiping suite's default to the host port compose publishes, parsed from the
compose file so the two cannot drift apart in either direction. Also in round 4:

- **The remedy was unrunnable on kividb.** The footer hardcoded
  `docker run -p <your-port>:6379`, but kividb listens on **6380** (compose maps
  `6386:6380`), so an operator following its refusal got a container the suite
  cannot reach — and then a second refusal from this same guard. The container
  port is now per-suite data, checked against compose. Live:
  `docker run -d --rm -p <your-port>:6380 … / KIVIDB_PORT=<your-port> …` for
  kividb, `:6379` for redis.
- `is_standalone_number` treated `_` as a boundary, so INV-P1 flagged
  `let foo_6399 = 1;` — a line with no literal at all — and the comment claiming
  otherwise was false. Identifier characters now disqualify, with a negative
  control that also proves a real literal on the same shape of line is still
  caught.
- `CLAIM_OUTCOME`'s doc cited "60.14 s instead of 20.13 s". 20.13 s is not
  reproducible and is structurally impossible (the wait is 30 s either way).
  Replaced with the measured pair, 60.21 s → 30.07 s.
- The header said "Four invariants" while shipping five; the CI comment said
  "INV-P1/P2/P3". Both corrected.
- `integration_valkey.rs` and `integration_kividb.rs` still said "state this
  harness did not create" — the phrasing the message test forbids in the message.

**Round 5 (mutation campaign at `b5c8b32`).** Sixteen invariant mutants were
caught; two were not.

**The claim could simply be commented out.** INV-P2 matched
`squeeze(body).contains(..)` against raw source, while INV-P1's `bare_port_hits`
had skipped `//` lines since round 1 — same file, one dimension short. Live A/B
on a redis:8.8.0 seeded with 1 key in db0, 1 key in db1 and one FT index. RED at
`b5c8b32` with a single `/` prepended to the claim line:

```
running 27 tests
test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
running 1 test
test test_redis_upload_and_retrieve ... ok
server after: keyspace=[# Keyspace ] idx=[ ]
```

INV-P2 now compares the **whole** `test_port()` body, comments stripped, against
the single shape it may have. Equality also closes `if false { .. }` and
`stringify!(..)`, pins the arguments and container port, and makes `squeeze`'s
rustfmt tolerance load-bearing. The comment stripper leaves string literals
alone so `redis://` survives, with a control.

**INV-P5 read one directory level.** Round 3's headline fix, re-evaded in its own
idiom: a wipe helper at `tests/common/wipe/mod.rs` was invisible. The walk now
recurses and the file set is pinned rather than asserted `> 0`.

GREEN here with **both** mutations applied at once:

```
running 38 tests
test inv_p5_shared_helpers_must_not_wipe_a_server ... FAILED
test inv_p2_wiping_suites_claim_their_instance_in_test_port ... FAILED
test result: FAILED. 36 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
```

Both mutations were reverted and the pushed tree grep-verified (`common/wipe` → 0
files, `// common::claim` → 0 hits).

Round 5 also closed four gaps where the guard could be made **inert** with every
suite still passing — a permissive mutation makes integration tests pass harder,
so only a source pin can catch them:

- INV-P4 exercised `claim_verdict`, the *consumer*, only. A `probe_server`
  returning `Reachable { keys: 0, index_count: 0 }` for an unreachable server —
  the exact regression INV-P4's own docstring cites — passed everything.
  `probe_server` is now `pub` and asserted `Inconclusive` against a closed
  ephemeral port at zero wait, plus source pins that every early return is
  `Inconclusive`, that `Probe::Reachable` is constructed exactly once and last,
  that `claim_resp_instance` panics on a refusal, that the waiver defaults to
  off, and that `CLAIM_REACHABLE_WAIT` >= the longest `wait_for_*()` deadline.
- `Fresh` whenever `keys == 0` was unpinned even though `flush_db()` drops
  indexes and the refusal counts them: 0 keys + 1 index must now refuse.
- `\"FLUSHALL\"` — the natural Rust spelling of a Lua payload — was not matched,
  which made the shipped "either quote style" claim false. `\` is now a quote
  boundary, with a positive control.
- New **INV-P7** pins the set of test targets, so a wiping suite named outside
  `integration_*.rs` cannot slip past the INV-P3 scan unclassified.

## Engine survey

**Server-wide destruction — guarded here, all four live-validated:**

| suite | default port | destructive helper |
|---|---|---|
| `integration_redis` | 6399 | `flush_db()` → `FT.DROPINDEX <each> DD` + `FLUSHALL` |
| `integration_valkey` | 6380 | `flush_db()` → `FT.DROPINDEX <each>` + `FLUSHALL` |
| `integration_dragonfly` | 6385 | `flush_db()` → `FT.DROPINDEX <each>` + `FLUSHALL` |
| `integration_kividb` | 6386 | `flush_db()` → `FT.DROPINDEX <each>` + `FLUSHALL` |

**Narrower destruction, NOT guarded here.** No other suite has an
enumerate-and-delete loop, a `DROP DATABASE`/`SCHEMA`, a `dropDatabase`, a
`DELETE /_all` or a wildcard index delete. Two are worth naming rather than filing
under "named targets only":

- **`integration_pgvector` (5433)** — `DROP TABLE IF EXISTS items CASCADE` at
  `:54`, `:60`, `:485`. The in-process connection is built from
  `const PG_PORT: u16 = 5433` / `PG_DB = "postgres"` with **no env read at all**
  (`PGVECTOR_PORT` only reaches the spawned child), so the target is unmovable,
  the table name is maximally generic, and `CASCADE` takes dependents with it.
  This is the natural #292 follow-up.
- **`integration_qdrant` (6334/6335)** — `:2030` and `:2127` take the collection
  from `std::env::var("QDRANT_COLLECTION_NAME").unwrap_or("benchmark")` and those
  two tests' child spawns do not pin the var, so an inherited value steers the
  drop/recreate.
- pgvector's other tables, `integration_mongodb`'s `drop_test_collection()`,
  ES/OS's `DELETE /<index>`, and milvus/weaviate/chroma's named collection/class
  deletes are all fixed-name targets.
- `integration_vectorsets` (6398) issues no wipe; since #236 each config owns
  `idx:<config-name>`. Covered by INV-P1, not by the claim.

## Gates

Baselines derived on `e99d2b5` in a dedicated target dir, after
`touch src/lib.rs src/bin/vector_db_benchmark/main.rs`:

| gate | `e99d2b5` | this branch |
|---|---|---|
| `cargo fmt --check` | — | clean |
| `cargo clippy --all-targets -- -D warnings` | — | exit code 0, zero `warning`/`error` lines |
| `cargo test --lib --bins` | 129 + 0 + 0 + 0 + 2 + 806 = **937** | **937**, all passed |
| `cargo test --test overhead_invariants` | `running 9 tests`, 9 passed | `running 9 tests`, 9 passed |
| `cargo test --test harness_invariants` | target does not exist | `running 38 tests`, 38 passed |
| `integration_redis -- --test-threads=1` | `running 44 tests` | `running 44 tests`, 44 passed |
| `integration_valkey -- --test-threads=1` | — | `running 29 tests`, 29 passed |
| `integration_dragonfly -- --test-threads=1` | — | `running 15 tests`, 15 passed |
| `integration_kividb -- --test-threads=1` | — | `running 21 tests`, 21 passed (622.48s) |
| `integration_vectorsets` (untouched) | — | `running 15 tests`, 15 passed |

Refusal checks with foreign data present, all on my own containers: redis 7621,
valkey 7624, dragonfly 7622 — each `REFUSING …`, `holds 2 key(s) across all
databases`, `keys intact: 2`. Ports 7601-7999 only; 6399/6398/6380/27018 were
never touched, and `tests-redis-1`/`tests-valkey-1` confirmed still running.

One filtered run of mine printed `running 0 tests` / `ok` because the filter
matched no test name. I caught it, found the real name, and re-ran — every count
above is from a line I read.

## Stated limits

- **False positive: `docker restart` of your own container.** Both `run_id` and
  `master_replid` are regenerated on restart while an RDB-persisted dataset
  survives, so the claim goes stale and the suite refuses data it created itself.
  Safe direction; the refusal message names this case and the one-line fix.
- **False positive: a lost claim directory.** `cargo clean`, a fresh
  `CARGO_TARGET_DIR`, a new worktree, a CI cache miss, or `--target <triple>` all
  drop the claim. This only bites after a run killed mid-suite: a clean full run
  leaves the server empty, so ordinary re-runs take the `Fresh` path.
- **A search-less but provably empty Redis is refused**, because `FT._LIST`
  failing is treated as inconclusive. Correct for these four suites — they all
  call `FT.DROPINDEX` — but it does mean the guard is stricter than "has data".
- **The loading check is best-effort.** An engine whose `INFO persistence` errors
  or omits `loading` gets no loading check; kividb v1.0.2-full is such an engine
  (measured). A server so locked down that INFO fails entirely is still caught by
  `INFO keyspace`.
- **Concurrent runs are only partly detected.** A rival session's run is refused
  once it has written anything, but in the window right after its `flush_db()` the
  server is empty and this guard will claim it.
- **`master_replid` identifies a replication GROUP, not an instance.** A Dragonfly
  replica reports the same value as its primary, so a claim recorded against a
  primary would also authorise a replica of it that later took the same
  `host:port`. `run_id` (redis/valkey/kividb) does not have this property.
- **An unreachable server costs 30 s** before the refusal, once per process.
- **The wipe scan is a text scan.** It catches a quoted command name in any case,
  in either quote style, and escaped (`\"FLUSHALL\"`), but not a `KEYS *` + `DEL`
  loop, a `SCAN`+`UNLINK` sweep, or a command assembled from fragments. All three
  were confirmed missed, exactly as stated.
- **INV-P2 pins the SHAPE of `test_port()`, not its runtime effect.** Any
  refactor of that function fails the invariant until the expected body is
  updated — deliberate, because it is the choke point, but it is friction.
- **The comment stripper does not understand raw strings** (`r#"..."#`). No suite
  uses one inside `test_port()`, and INV-P2's equality would fail loudly rather
  than silently if one appeared.
- **INV-P1 covers only suites with a `fn test_port() -> u16` fallback** — the five
  RESP suites. `integration_opensearch`, `_milvus`, `_elasticsearch` and
  `_pgvector` still pass bare port literals to spawned binaries; not fixed here,
  and none of them can wipe a server.
- **Two literals live outside every scan**, noted rather than fixed:
  `src/redisearch/configure.rs:53` FLUSHALLs as a Memorystore fallback (the scan
  reads only `tests/`), and `src/bin/vector_db_benchmark/engine/dragonfly.rs:101`
  has `.unwrap_or(6385)` in production code.
- **No production code changed.** Everything is under `tests/`, plus one CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

