### PR TITLE
mongodb: give every config its own collection and search index (#306)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -39,6 +39,10 @@ pub use elasticsearch::ElasticsearchEngine;
 pub use kividb::KividbEngine;
 pub use milvus::MilvusEngine;
 pub use mongodb_engine::MongoDBEngine;
+// #306: the startup collision guard has to answer "do these two configs address
+// the same MongoDB collection?" before any engine is constructed — constructing
+// one would open a connection to a server the guard has no business touching.
+pub(crate) use mongodb_engine::config_collection_name as mongodb_collection_name;
 pub use opensearch::OpenSearchEngine;
 pub use pgvector::PgVectorEngine;
 pub use qdrant::QdrantEngine;

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -17,6 +17,7 @@ use rand::{seq::SliceRandom, SeedableRng};
 use super::geo;
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
+use crate::engine::index_naming::derive_index_name;
 use crate::engine::{CorpusCount, Engine, SearchResults, UpdateSearchRatio, UploadStats};
 use vector_db_benchmark::query_filter::QueryFilter;
 use vector_db_benchmark::readers::metadata::MetadataItem;
@@ -25,6 +26,97 @@ use vector_db_benchmark::start_gate::WorkerPool;
 const DEFAULT_DB: &str = "bench";
 const DEFAULT_COLLECTION: &str = "vectors";
 const DEFAULT_INDEX_NAME: &str = "vector_index";
+
+/// MongoDB refuses a fully-qualified namespace (`<db>.<collection>`) longer
+/// than 255 bytes. Verified live against `mongodb/mongodb-atlas-local:8.0.17`:
+/// a 200-byte collection under an 8-byte db is accepted, a 250-byte one is
+/// rejected with `Fully qualified namespace is too long`. The Redis-wire
+/// engines have no analogue — a Redis key name is bounded by 512 MB — so the
+/// bounding below is MongoDB's own concern and deliberately does NOT live in
+/// the shared `index_naming` module.
+///
+/// The search index name has no comparable ceiling: the same server accepted a
+/// 5000-byte `createSearchIndexes` name, so `index_name` is left unbounded and
+/// carries the config suffix verbatim.
+const MAX_NAMESPACE_BYTES: usize = 255;
+
+/// Per-config collection name (#306).
+///
+/// Before this, every config in a sweep addressed the one literal
+/// `bench.vectors`. Because `configure()` drops that collection, config B
+/// destroyed config A's corpus; and because `--skip-upload` skips `configure()`
+/// entirely, all twelve configs of the shipped `mongodb-single-node.json`
+/// M×EF_CONSTRUCTION sweep queried whichever HNSW graph the first config had
+/// built — twelve result files, twelve distinct labels, one measurement.
+///
+/// The suffix is derived by [`derive_index_name`], the same helper the
+/// Redis-wire engines use (#151-4), so `MONGODB_COLLECTION` keeps working as an
+/// override but is now the *base*: the config suffix is always appended, so a
+/// pinned base cannot re-collapse a sweep. `MONGODB_COLLECTION_EXACT=1` is the
+/// escape hatch that drops the suffix and uses the base verbatim; combining it
+/// with more than one MongoDB config is rejected at startup by the collision
+/// guard in `experiment::run`.
+///
+/// `db_name` is passed in rather than read here because it consumes part of the
+/// 255-byte namespace budget the collection name has to fit inside.
+pub(crate) fn derive_collection_name(db_name: &str, engine_name: &str) -> String {
+    let derived = derive_index_name("MONGODB_COLLECTION", DEFAULT_COLLECTION, engine_name);
+    // `<db>` + `.` + `<collection>` must fit in MAX_NAMESPACE_BYTES.
+    let budget = MAX_NAMESPACE_BYTES.saturating_sub(db_name.len() + 1);
+    bound_to_bytes(&derived, budget)
+}
+
+/// The collection this process's MongoDB configs address, reading `MONGODB_DB`
+/// for the namespace budget. Used by the startup collision guard, which must
+/// answer "do these two configs address the same collection?" without opening a
+/// connection.
+pub(crate) fn config_collection_name(engine_name: &str) -> String {
+    let db_name = crate::effective_config::env_or("MONGODB_DB", DEFAULT_DB);
+    derive_collection_name(&db_name, engine_name)
+}
+
+/// Deterministically bound `name` to `max_bytes` while keeping distinct inputs
+/// distinct.
+///
+/// Names already inside the bound are returned verbatim, so the common case is
+/// the readable `vectors:mongodb-m-16-efc-100`. A longer name becomes
+/// `<head>~<16 hex digits>`, where the digest is taken over the WHOLE name — the
+/// part that was cut included. A plain truncation would map
+/// `vectors:<200 shared bytes>-efc-100` and `…-efc-800` onto one collection and
+/// silently reinstate exactly the bug this function exists to prevent.
+///
+/// FNV-1a rather than `DefaultHasher`: SipHash's keys and output are not
+/// guaranteed stable across Rust releases, and this name has to resolve to the
+/// same collection next week, from a differently-built binary, or `--skip-upload`
+/// cannot find the corpus it is promised.
+fn bound_to_bytes(name: &str, max_bytes: usize) -> String {
+    if name.len() <= max_bytes {
+        return name.to_string();
+    }
+    let digest = format!("~{:016x}", fnv1a64(name.as_bytes()));
+    if max_bytes <= digest.len() {
+        // Pathological budget (an absurdly long MONGODB_DB). Keep the tail of
+        // the digest: still a function of the whole name, so still distinct.
+        return digest[digest.len() - max_bytes..].to_string();
+    }
+    // `derive_index_name`'s base comes straight from the environment and is not
+    // sanitized, so `name` may hold multi-byte UTF-8; walk back to a boundary.
+    let mut head_end = max_bytes - digest.len();
+    while head_end > 0 && !name.is_char_boundary(head_end) {
+        head_end -= 1;
+    }
+    format!("{}{}", &name[..head_end], digest)
+}
+
+/// FNV-1a 64-bit. Fixed constants, no seed, no version dependence.
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
 
 #[derive(Clone)]
 struct MongoConfig {
@@ -63,9 +155,18 @@ impl MongoDBEngine {
         let port: u16 = crate::effective_config::env_parsed("MONGODB_PORT", 27017);
 
         let db_name = crate::effective_config::env_or("MONGODB_DB", DEFAULT_DB);
-        let collection_name =
-            crate::effective_config::env_or("MONGODB_COLLECTION", DEFAULT_COLLECTION);
-        let index_name = crate::effective_config::env_or("MONGODB_INDEX_NAME", DEFAULT_INDEX_NAME);
+        // #306: both objects this engine owns are per-config. The collection is
+        // the load-bearing one — `configure()` drops it, and `corpus_row_count()`
+        // counts it — but the search index carries the config's HNSW knobs, so it
+        // is namespaced too: under a pinned `MONGODB_COLLECTION_EXACT` base the
+        // collection is shared and the index name is then the only thing keeping
+        // two configs' graphs apart.
+        let collection_name = derive_collection_name(&db_name, &engine_config.name);
+        let index_name = derive_index_name(
+            "MONGODB_INDEX_NAME",
+            DEFAULT_INDEX_NAME,
+            &engine_config.name,
+        );
 
         let parallel = engine_config
             .upload_params
@@ -1550,6 +1651,19 @@ impl Engine for MongoDBEngine {
     /// (issue #238). `countDocuments({})` on the benchmark collection — an exact
     /// count, not the metadata estimate, because the estimate can lag a drop and
     /// report a corpus that is no longer there. A missing collection answers 0.
+    ///
+    /// #306 — why this stays a pure count and gained no identity marker. The
+    /// collection it counts is now per-config (see [`derive_collection_name`]),
+    /// so the "corpus built by a *different config*" case no longer reaches this
+    /// check as a plausible number: config B's collection does not exist, the
+    /// count is 0, and `classify_reuse_precondition` fails the run. An
+    /// upload-time marker document would answer the same question one layer
+    /// later and would itself be a row in the count.
+    ///
+    /// What remains unverified is the *dataset* dimension — one config reused
+    /// across two same-sized datasets still certifies. That is #279, it is
+    /// identical on every engine, and it wants one cross-engine mechanism rather
+    /// than a MongoDB-only marker that hides the gap on this engine alone.
     fn corpus_row_count(&mut self) -> Result<Option<CorpusCount>, String> {
         let coll = self
             .client
@@ -2205,6 +2319,232 @@ impl Engine for MongoDBEngine {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // ── #306: per-config collection / index namespacing ──────────────────
+    //
+    // `derive_index_name` resolves through the process-wide effective-config
+    // recorder (#212), so every test below takes `test_lock()` to serialize with
+    // the other tests that drive it.
+
+    /// The headline of #306, pinned to literal strings.
+    ///
+    /// Two configs of the shipped M×EF_CONSTRUCTION sweep must address two
+    /// different collections AND two different search indexes. Before the fix
+    /// both resolved to the bare `vectors` / `vector_index`, so `configure()`
+    /// dropped the sibling's corpus and `--skip-upload` measured whichever HNSW
+    /// graph happened to survive.
+    ///
+    /// FAILS ON REVERT: with the constants read straight from `env_or`, both
+    /// configs get `"vectors"` and `"vector_index"` — the `assert_ne!`s and the
+    /// literal-equality assertions all break.
+    #[test]
+    fn sweep_configs_derive_distinct_collections_and_indexes() {
+        let _recorder_lock = crate::effective_config::test_lock();
+        let a = derive_collection_name("bench", "mongodb-m-16-efc-100");
+        let b = derive_collection_name("bench", "mongodb-m-64-efc-800");
+        assert_eq!(a, "vectors:mongodb-m-16-efc-100");
+        assert_eq!(b, "vectors:mongodb-m-64-efc-800");
+        assert_ne!(a, b);
+        // And neither may be the bare legacy collection every config shared.
+        assert_ne!(a, DEFAULT_COLLECTION);
+        assert_ne!(b, DEFAULT_COLLECTION);
+
+        let ia = derive_index_name(
+            "MONGODB_INDEX_NAME",
+            DEFAULT_INDEX_NAME,
+            "mongodb-m-16-efc-100",
+        );
+        let ib = derive_index_name(
+            "MONGODB_INDEX_NAME",
+            DEFAULT_INDEX_NAME,
+            "mongodb-m-64-efc-800",
+        );
+        assert_eq!(ia, "vector_index:mongodb-m-16-efc-100");
+        assert_eq!(ib, "vector_index:mongodb-m-64-efc-800");
+        assert_ne!(ia, ib);
+        assert_ne!(ia, DEFAULT_INDEX_NAME);
+    }
+
+    /// The shipped sweep is the artefact the issue names: 12 configs, 12 result
+    /// files, one measurement. Read the real file rather than a hand-copied list
+    /// so adding a 13th config that collides is caught here and not in a
+    /// published result set.
+    ///
+    /// FAILS ON REVERT: all 12 configs collapse to `"vectors"`, so the set of
+    /// distinct names is 1, not 12.
+    #[test]
+    fn shipped_hnsw_sweep_gives_every_config_its_own_collection() {
+        let _recorder_lock = crate::effective_config::test_lock();
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/experiments/configurations/mongodb-single-node.json"
+        );
+        let raw = std::fs::read_to_string(path).expect("shipped mongodb sweep config");
+        let configs: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("valid JSON array");
+        assert!(
+            configs.len() >= 12,
+            "the sweep this issue is about ships 12 configs, found {}",
+            configs.len()
+        );
+
+        let mut seen: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        for cfg in &configs {
+            let name = cfg["name"].as_str().expect("config name").to_string();
+            let coll = derive_collection_name("bench", &name);
+            if let Some(prev) = seen.insert(coll.clone(), name.clone()) {
+                panic!("configs '{prev}' and '{name}' both address collection '{coll}'");
+            }
+        }
+        assert_eq!(
+            seen.len(),
+            configs.len(),
+            "every config must own its collection"
+        );
+    }
+
+    /// The namespace ceiling. `<db>.<collection>` over 255 bytes is refused by
+    /// the server outright, so a long config name must be bounded — and bounding
+    /// must not undo the isolation it is bounding.
+    ///
+    /// This is the collision path #294 warns about being shipped untested: the
+    /// two names below share a 300-byte prefix and differ only in the tail that
+    /// truncation throws away.
+    ///
+    /// FAILS ON REVERT of the bounding: a plain truncate makes the two names
+    /// equal. FAILS ON REVERT of #306 entirely: both become `"vectors"`, equal
+    /// again.
+    #[test]
+    fn long_config_names_are_bounded_without_colliding() {
+        let _recorder_lock = crate::effective_config::test_lock();
+        let shared = "x".repeat(300);
+        let a = derive_collection_name("bench", &format!("{shared}-efc-100"));
+        let b = derive_collection_name("bench", &format!("{shared}-efc-800"));
+
+        for (label, n) in [("a", &a), ("b", &b)] {
+            assert!(
+                "bench".len() + 1 + n.len() <= MAX_NAMESPACE_BYTES,
+                "{label} namespace is {} bytes, over MongoDB's {MAX_NAMESPACE_BYTES}: {n}",
+                "bench".len() + 1 + n.len()
+            );
+        }
+        assert_ne!(
+            a, b,
+            "two configs differing only past the truncation point must NOT share \
+             a collection — that is #306 reintroduced through the bounding"
+        );
+        assert!(a.contains('~') && b.contains('~'), "{a} / {b}");
+    }
+
+    /// A longer database name eats into the collection's budget, and the result
+    /// must still be a legal namespace. Pins that the budget is computed from the
+    /// db name rather than assumed.
+    ///
+    /// FAILS ON REVERT: `saturating_sub` removed / db length ignored → the long-db
+    /// case exceeds 255 bytes.
+    #[test]
+    fn the_namespace_budget_accounts_for_the_database_name() {
+        let _recorder_lock = crate::effective_config::test_lock();
+        let cfg = "y".repeat(400);
+        for db in ["b", "bench", &"d".repeat(200)] {
+            let coll = derive_collection_name(db, &cfg);
+            assert!(
+                db.len() + 1 + coll.len() <= MAX_NAMESPACE_BYTES,
+                "db '{}' ({} bytes) + collection ({} bytes) exceeds {MAX_NAMESPACE_BYTES}",
+                db,
+                db.len(),
+                coll.len()
+            );
+            assert!(
+                !coll.is_empty(),
+                "an empty collection name is not addressable"
+            );
+        }
+    }
+
+    /// The bounding must be reproducible across processes and builds: a
+    /// `--skip-upload` run has to resolve to the collection last week's upload
+    /// created. FNV-1a's constants are fixed; `DefaultHasher`'s are not
+    /// guaranteed to be.
+    ///
+    /// FAILS ON REVERT to a seeded/unstable hash only if the seed changes within
+    /// the process, so it also pins the literal digest — a switch to any other
+    /// hash function changes this string.
+    #[test]
+    fn bounding_is_deterministic() {
+        assert_eq!(fnv1a64(b""), 0xcbf2_9ce4_8422_2325);
+        assert_eq!(fnv1a64(b"a"), 0xaf63_dc4c_8601_ec8c);
+        assert_eq!(fnv1a64(b"foobar"), 0x85944171f73967e8);
+
+        let long = "z".repeat(400);
+        assert_eq!(bound_to_bytes(&long, 40), bound_to_bytes(&long, 40));
+        assert_eq!(bound_to_bytes(&long, 40).len(), 40);
+        // Short names are returned untouched — readability of the common case.
+        assert_eq!(bound_to_bytes("vectors:cfg", 255), "vectors:cfg");
+    }
+
+    /// A budget smaller than the digest itself must still produce a distinct,
+    /// non-empty, correctly-sized name rather than panicking or slicing out of
+    /// bounds. Reachable via an absurd `MONGODB_DB`.
+    #[test]
+    fn bounding_survives_a_budget_smaller_than_the_digest() {
+        // Both inputs are longer than every budget tried, so the bounded form is
+        // always exercised (a name shorter than its budget is returned verbatim).
+        let alpha = format!("vectors:{}", "a".repeat(60));
+        let beta = format!("vectors:{}", "b".repeat(60));
+        for budget in [1usize, 4, 8, 16, 17, 18, 32] {
+            let a = bound_to_bytes(&alpha, budget);
+            let b = bound_to_bytes(&beta, budget);
+            assert_eq!(a.len(), budget, "budget {budget}");
+            assert_eq!(b.len(), budget, "budget {budget}");
+            if budget >= 8 {
+                assert_ne!(a, b, "budget {budget} collapsed two distinct names");
+            }
+        }
+    }
+
+    /// Multi-byte UTF-8 in the base (which comes from the environment and is NOT
+    /// sanitized) must not be sliced mid-character.
+    #[test]
+    fn bounding_cuts_on_a_char_boundary() {
+        let name = "é".repeat(200); // 400 bytes, 200 chars
+        for budget in 17..40 {
+            // Slicing at a non-boundary would panic here — that is the assertion.
+            let out = bound_to_bytes(&name, budget);
+            assert!(out.len() <= budget, "budget {budget}: {out}");
+            let head = out.split('~').next().unwrap();
+            assert!(
+                head.chars().all(|c| c == 'é'),
+                "budget {budget} cut mid-character: {head:?}"
+            );
+        }
+    }
+
+    /// `MONGODB_COLLECTION` remains an override, but as a BASE: the config
+    /// suffix is still appended, so pinning it cannot re-collapse a sweep.
+    /// `MONGODB_COLLECTION_EXACT=1` is the documented escape hatch that drops
+    /// the suffix — and the startup guard in `experiment::run` rejects it with
+    /// more than one MongoDB config.
+    ///
+    /// FAILS ON REVERT: the non-exact half asserts the suffix is present, which
+    /// the old `env_or` passthrough does not produce.
+    #[test]
+    fn collection_env_override_is_a_base_not_a_pin() {
+        let _recorder_lock = crate::effective_config::test_lock();
+        std::env::set_var("MONGODB_COLLECTION", "mycoll");
+        assert_eq!(
+            derive_collection_name("bench", "mongodb-m-16-efc-100"),
+            "mycoll:mongodb-m-16-efc-100"
+        );
+
+        std::env::set_var("MONGODB_COLLECTION_EXACT", "1");
+        assert_eq!(
+            derive_collection_name("bench", "mongodb-m-16-efc-100"),
+            "mycoll"
+        );
+
+        std::env::remove_var("MONGODB_COLLECTION_EXACT");
+        std::env::remove_var("MONGODB_COLLECTION");
+    }
 
     /// Issue #216: `hnsw_config` must be translated into the names MongoDB
     /// accepts, not the HNSW-generic `m`/`efConstruction` (which the server

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -215,10 +215,10 @@ pub fn run(args: &Args) -> Result<(), String> {
     }
 
     // Collision guard (#151-4): among the selected configs, no two configs of the
-    // same destructive Redis-wire engine (redis/valkey/dragonfly/kividb/vectorsets)
+    // same destructive engine (redis/valkey/dragonfly/kividb/vectorsets/mongodb)
     // may derive the same index namespace, or a sweep would silently overwrite one config's graph
     // and keyspace with another's (the exact bug this fix closes). Also fires when
-    // an `*_INDEX_NAME_EXACT` pin is set with >1 config for that engine (every
+    // an `*_EXACT` pin is set with >1 config for that engine (every
     // config then resolves to the same verbatim base). In --skip-vector-index mode
     // the dedup above already leaves one config per engine, so this is a no-op.
     {
@@ -236,9 +236,24 @@ pub fn run(args: &Args) -> Result<(), String> {
                 // vector set, derived by the same helper, so it collides the same
                 // way and belongs in the same guard.
                 "vectorsets" => "VECTORSETS_INDEX_NAME",
+                // #306: MongoDB's destructible namespace is the COLLECTION, not
+                // the search index — `configure()` calls `collection.drop()`, and
+                // the search index lives inside the collection it drops. So the
+                // collection is what two configs must not share, and
+                // `MONGODB_COLLECTION` (not `MONGODB_INDEX_NAME`) is the base
+                // whose `_EXACT` pin can re-collapse a sweep.
+                "mongodb" => "MONGODB_COLLECTION",
                 _ => continue,
             };
-            let idx = derive_index_name(base_env, "idx", &config.name);
+            // MongoDB's name is bounded to fit the 255-byte `<db>.<collection>`
+            // namespace, so it must come from the engine rather than from a bare
+            // `derive_index_name` here — otherwise the guard would compare names
+            // the engine never uses.
+            let idx = if engine_type == "mongodb" {
+                crate::engine::mongodb_collection_name(&config.name)
+            } else {
+                derive_index_name(base_env, "idx", &config.name)
+            };
             if let Some(prev) =
                 seen.insert((engine_type.to_string(), idx.clone()), config.name.clone())
             {
@@ -247,10 +262,16 @@ pub fn run(args: &Args) -> Result<(), String> {
                 } else {
                     String::new()
                 };
+                let object = if engine_type == "mongodb" {
+                    "collection"
+                } else {
+                    "index"
+                };
                 return Err(format!(
-                    "Configs '{}' and '{}' derive the same index namespace '{}'; rename them — \
-                     a sweep would silently overwrite one with the other (issue #151-4).{}",
-                    prev, config.name, idx, exact_hint
+                    "Configs '{}' and '{}' derive the same index namespace '{}' (the {} {}); \
+                     rename them — a sweep would silently overwrite one with the other \
+                     (issue #151-4).{}",
+                    prev, config.name, idx, engine_type, object, exact_hint
                 ));
             }
         }

--- a/tests/integration_mongodb.rs
+++ b/tests/integration_mongodb.rs
@@ -115,12 +115,51 @@ fn test_update_one_matched_count_distinguishes_a_missing_document_from_an_update
     let _ = coll.drop().run();
 }
 
+/// The collection the ENGINE addresses for config `engine_name` when the run is
+/// given `MONGODB_COLLECTION=TEST_COLLECTION` (#306).
+///
+/// Deliberately spelled out rather than imported: the engine lives in a binary
+/// crate this test cannot link against, so this literal is the independent
+/// statement of the naming contract. If the engine's derivation changes, these
+/// tests must fail — that is the point.
+fn engine_collection(engine_name: &str) -> String {
+    format!("{TEST_COLLECTION}:{engine_name}")
+}
+
+/// The search index the ENGINE builds for config `engine_name` when the run is
+/// given `MONGODB_INDEX_NAME=TEST_INDEX` (#306).
+fn engine_index(engine_name: &str) -> String {
+    format!("{TEST_INDEX}:{engine_name}")
+}
+
+/// Count documents in a specific collection of the test database, server-side.
+fn count_docs(collection: &str) -> u64 {
+    mongodb_client()
+        .database(TEST_DB)
+        .collection::<Document>(collection)
+        .count_documents(doc! {})
+        .run()
+        .expect("countDocuments")
+}
+
 /// Drop the search index (if any), wait for it to disappear, then drop the
 /// collection and wait for it to be gone.  Mirrors the engine's configure()
 /// cleanup so tests exercise the same Atlas-safe path.
+///
+/// #306: the engine no longer writes to the bare `TEST_COLLECTION`; each config
+/// gets `TEST_COLLECTION:<config>`. Those are dropped too — scoped to this
+/// file's own `vectors:` namespace rather than wiping the database, so a
+/// concurrently running suite on another branch is not collateral.
 fn drop_test_collection() {
     let client = mongodb_client();
     let db = client.database(TEST_DB);
+
+    let per_config_prefix = format!("{TEST_COLLECTION}:");
+    for name in db.list_collection_names().run().unwrap_or_default() {
+        if name.starts_with(&per_config_prefix) {
+            let _ = db.collection::<Document>(&name).drop().run();
+        }
+    }
 
     // Drop search index explicitly
     let _ = db
@@ -891,7 +930,7 @@ fn test_binary_mongodb_multi_dataset() {
     let client = mongodb_client();
     let coll = client
         .database(TEST_DB)
-        .collection::<Document>(TEST_COLLECTION);
+        .collection::<Document>(&engine_collection(engine_name));
     // Collection may already be dropped by engine.delete(), which is fine
     let doc_count = coll.count_documents(doc! {}).run().unwrap_or(0);
     assert!(
@@ -1537,14 +1576,17 @@ fn test_binary_mongodb_match_any_int() {
 /// that a default index and a tuned index produce identical results, which is
 /// precisely why issue #216 (all 96 MongoDB sweep rows measuring one default
 /// index) survived undetected — "recall looks plausible throughout".
-fn read_back_index_definition() -> Document {
+fn read_back_index_definition(engine_name: &str) -> Document {
     let client = mongodb_client();
     let db = client.database(TEST_DB);
+    // #306: per-config collection + per-config index name.
+    let collection = engine_collection(engine_name);
+    let index = engine_index(engine_name);
 
     let deadline = Instant::now() + Duration::from_secs(60);
     loop {
         let result = db
-            .run_command(doc! { "listSearchIndexes": TEST_COLLECTION })
+            .run_command(doc! { "listSearchIndexes": &collection })
             .run();
         if let Ok(result) = result {
             let batch = result
@@ -1557,7 +1599,7 @@ fn read_back_index_definition() -> Document {
                 let Some(idx) = idx.as_document() else {
                     continue;
                 };
-                if idx.get_str("name").ok() != Some(TEST_INDEX) {
+                if idx.get_str("name").ok() != Some(index.as_str()) {
                     continue;
                 }
                 if let Ok(def) = idx.get_document("latestDefinition") {
@@ -1568,9 +1610,9 @@ fn read_back_index_definition() -> Document {
         assert!(
             Instant::now() < deadline,
             "index '{}' never appeared in listSearchIndexes on {}.{}",
-            TEST_INDEX,
+            index,
             TEST_DB,
-            TEST_COLLECTION
+            collection
         );
         thread::sleep(Duration::from_secs(2));
     }
@@ -1657,7 +1699,7 @@ fn run_and_read_back_definition(
         stderr
     );
 
-    (read_back_index_definition(), project)
+    (read_back_index_definition(engine_name), project)
 }
 
 /// Issue #216: `collection_params.hnsw_config` must reach the server as
@@ -1900,9 +1942,10 @@ fn test_binary_mongodb_geo() {
     // `vectorSearch`-type index here would mean the geo filter never had a
     // chance, and only the recall assertion below would (eventually) notice.
     let client = mongodb_client();
+    let geo_index = engine_index("mongo-geo");
     let indexes: Vec<mongodb::bson::Document> = client
         .database(TEST_DB)
-        .collection::<mongodb::bson::Document>(TEST_COLLECTION)
+        .collection::<mongodb::bson::Document>(&engine_collection("mongo-geo"))
         .aggregate(vec![doc! { "$listSearchIndexes": {} }])
         .run()
         .expect("listSearchIndexes")
@@ -1910,8 +1953,8 @@ fn test_binary_mongodb_geo() {
         .collect();
     let ours = indexes
         .iter()
-        .find(|i| i.get_str("name").unwrap_or("") == TEST_INDEX)
-        .unwrap_or_else(|| panic!("no index named {TEST_INDEX}: {indexes:?}"));
+        .find(|i| i.get_str("name").unwrap_or("") == geo_index)
+        .unwrap_or_else(|| panic!("no index named {geo_index}: {indexes:?}"));
     assert_eq!(
         ours.get_str("type").unwrap_or(""),
         "search",
@@ -1927,16 +1970,6 @@ fn test_binary_mongodb_geo() {
 // ---------------------------------------------------------------------------
 // Issue #238 — `--skip-upload` must reuse the corpus, not destroy it
 // ---------------------------------------------------------------------------
-
-/// Count documents in the benchmark collection, server-side.
-fn count_test_docs() -> u64 {
-    mongodb_client()
-        .database(TEST_DB)
-        .collection::<Document>(TEST_COLLECTION)
-        .count_documents(doc! {})
-        .run()
-        .expect("countDocuments")
-}
 
 /// MongoDB's destruction path is a third shape: `collection.drop()`, which is
 /// unbounded — unlike Redis/Valkey, whose `DD`/UNLINK are scoped to this config's
@@ -1984,7 +2017,10 @@ fn test_binary_mongodb_skip_upload_skip_vector_index_preserves_corpus() {
         ),
         "phase 1 (upload with --skip-vector-index) failed"
     );
-    let before = count_test_docs();
+    // `--skip-vector-index` rewrites the config name to `<engine>-no-vector`
+    // (experiment::run), so the collection the engine addresses is derived from
+    // THAT name, not from `cfg238mg`.
+    let before = count_docs(&engine_collection("mongodb-no-vector"));
     assert_eq!(before, common::N_DOCS as u64, "phase 1 corpus");
 
     assert!(
@@ -1999,7 +2035,7 @@ fn test_binary_mongodb_skip_upload_skip_vector_index_preserves_corpus() {
         "phase 2 (--skip-upload --skip-vector-index) failed"
     );
 
-    let after = count_test_docs();
+    let after = count_docs(&engine_collection("mongodb-no-vector"));
     assert_eq!(
         after, before,
         "--skip-upload --skip-vector-index dropped the collection it was told to \
@@ -2052,17 +2088,21 @@ fn test_binary_mongodb_skip_upload_short_corpus_is_fatal() {
         ),
         "phase 1 (upload) failed"
     );
-    assert_eq!(count_test_docs(), common::N_DOCS as u64, "phase 1 corpus");
+    assert_eq!(
+        count_docs(&engine_collection("cfg238mgshort")),
+        common::N_DOCS as u64,
+        "phase 1 corpus"
+    );
 
     let half = (common::N_DOCS / 2) as i64;
     mongodb_client()
         .database(TEST_DB)
-        .collection::<Document>(TEST_COLLECTION)
+        .collection::<Document>(&engine_collection("cfg238mgshort"))
         .delete_many(doc! { "_id": { "$lt": half } })
         .run()
         .expect("delete_many");
     assert_eq!(
-        count_test_docs(),
+        count_docs(&engine_collection("cfg238mgshort")),
         half as u64,
         "half the corpus should remain"
     );
@@ -2161,7 +2201,7 @@ fn test_binary_mongodb_mixed_updates_that_miss_the_corpus_are_fatal() {
         );
         let coll = mongodb_client()
             .database(TEST_DB)
-            .collection::<Document>(TEST_COLLECTION);
+            .collection::<Document>(&engine_collection(cfg));
         // `_id` is immutable, so re-key by copy-then-delete.
         let originals: Vec<Document> = coll
             .find(doc! {})
@@ -2182,7 +2222,7 @@ fn test_binary_mongodb_mixed_updates_that_miss_the_corpus_are_fatal() {
         coll.delete_many(doc! {}).run().unwrap();
         coll.insert_many(shifted).run().unwrap();
         assert_eq!(
-            count_test_docs(),
+            count_docs(&engine_collection(cfg)),
             common::N_DOCS as u64,
             "the shifted corpus must keep its document count, so the reuse check \
              passes and this test exercises the #293 gate rather than #238's"
@@ -2274,6 +2314,272 @@ fn test_binary_mongodb_mixed_updates_that_miss_the_corpus_are_fatal() {
         update_count, 0,
         "not one update matched, so the count must be 0"
     );
+
+    drop_test_collection();
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+// ---------------------------------------------------------------------------
+// Issue #306 — every config addresses its OWN collection and search index
+// ---------------------------------------------------------------------------
+
+/// The headline failure of #306, end to end.
+///
+/// Before the fix every config in a sweep wrote to the one literal
+/// `bench.vectors` with the one literal `vector_index`. `--skip-upload` skips
+/// `configure()`, which is the only caller of `create_vector_index`, so config B
+/// searched config A's HNSW graph, `countDocuments` returned A's row count, the
+/// reuse check printed "holds N of N", and the run published B's `M` /
+/// `EF_CONSTRUCTION` label over A's measurement and exited 0.
+///
+/// Phase 1 uploads under config A. Phase 2 runs config B with `--skip-upload`
+/// and must be REJECTED: B's collection does not exist, so the reuse
+/// precondition sees 0 of N.
+///
+/// RED ON REVERT: with the shared collection, phase 2's `countDocuments` finds
+/// A's N documents, the precondition passes, and `run_binary_extra` returns
+/// true — the first assertion fires. The follow-up assertions pin that the
+/// rejection is the reuse gate (not an incidental connection error) and that
+/// A's corpus was left untouched.
+#[test]
+fn test_binary_mongodb_skip_upload_against_another_configs_corpus_is_fatal() {
+    wait_for_mongodb();
+    drop_test_collection();
+
+    let port: u16 = std::env::var("MONGODB_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(MONGODB_PORT);
+    let port_s = port.to_string();
+
+    let cfg_a = "cfg306a";
+    let cfg_b = "cfg306b";
+    let ds = "cfg306-test";
+    let configs = serde_json::json!([
+        {
+            "name": cfg_a, "engine": "mongodb",
+            "search_params": [{"parallel": 1, "num_candidates": 20}],
+            "upload_params": {"parallel": 1}
+        },
+        {
+            "name": cfg_b, "engine": "mongodb",
+            "search_params": [{"parallel": 1, "num_candidates": 20}],
+            "upload_params": {"parallel": 1}
+        },
+    ]);
+    let proj = common::write_match_any_project(ds, &serde_json::to_string(&configs).unwrap(), 8);
+    let envs: [(&str, &str); 4] = [
+        ("MONGODB_PORT", port_s.as_str()),
+        ("MONGODB_DB", TEST_DB),
+        ("MONGODB_COLLECTION", TEST_COLLECTION),
+        ("MONGODB_INDEX_NAME", TEST_INDEX),
+    ];
+
+    // Phase 1: config A populates ITS collection.
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            cfg_a,
+            ds,
+            MONGODB_HOST,
+            &envs,
+            &["--keep-data", "--skip-search"],
+        ),
+        "phase 1 (config A upload) failed"
+    );
+    assert_eq!(
+        count_docs(&engine_collection(cfg_a)),
+        common::N_DOCS as u64,
+        "config A must populate '{}' — if this is 0 the engine wrote somewhere else",
+        engine_collection(cfg_a)
+    );
+
+    // Phase 2: config B reuses "the corpus". There is no corpus of B's.
+    let out = Command::new(binary_path())
+        .args([
+            "--engines",
+            cfg_b,
+            "--datasets",
+            ds,
+            "--host",
+            MONGODB_HOST,
+            "--skip-if-exists",
+            "false",
+            "--skip-upload",
+            "--keep-data",
+        ])
+        .envs(envs.iter().map(|(k, v)| (*k, *v)))
+        .current_dir(&proj.root)
+        .output()
+        .expect("run vector-db-benchmark");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "config B has no corpus of its own; --skip-upload must abort rather than \
+         measure config A's index and label it B (#306):\n{combined}"
+    );
+    assert!(
+        combined.contains(&format!("holds 0 of the {} rows", common::N_DOCS)),
+        "the rejection must be the reuse precondition seeing an empty corpus, not \
+         an incidental failure:\n{combined}"
+    );
+    assert!(
+        combined.contains("is empty or missing"),
+        "config B's collection must read as absent, not merely short:\n{combined}"
+    );
+
+    // And B must not have destroyed A on its way out.
+    assert_eq!(
+        count_docs(&engine_collection(cfg_a)),
+        common::N_DOCS as u64,
+        "config B's aborted run touched config A's collection"
+    );
+
+    drop_test_collection();
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+/// #306 × #151-4 — MongoDB must PARTICIPATE in the startup collision guard.
+///
+/// The derivation alone leaves one way back into the shared-collection world:
+/// `MONGODB_COLLECTION_EXACT=1` drops the per-config suffix, so N configs
+/// resolve to one verbatim collection again and `configure()`'s
+/// `collection.drop()` is back to wiping the sibling. The Redis-family engines
+/// have that case rejected at startup; the guard did not know the string
+/// `"mongodb"` at all.
+///
+/// Asserted on the ERROR TEXT, not merely a non-zero exit: without a reachable
+/// server the run would fail anyway, so a bare exit-code assertion would pass
+/// against a removed guard. This test needs no server — the guard runs before
+/// any engine is constructed.
+#[test]
+fn test_binary_mongodb_exact_pin_with_two_configs_is_rejected_at_startup() {
+    let configs = serde_json::json!([
+        {
+            "name": "mongo-guard-a", "engine": "mongodb",
+            "search_params": [{"parallel": 1, "num_candidates": 20}],
+        },
+        {
+            "name": "mongo-guard-b", "engine": "mongodb",
+            "search_params": [{"parallel": 1, "num_candidates": 20}],
+        },
+    ]);
+    let proj = common::write_match_any_project(
+        "mongo-guard",
+        &serde_json::to_string(&configs).unwrap(),
+        8,
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "--engines",
+            "mongo-guard-*",
+            "--datasets",
+            "mongo-guard",
+            "--host",
+            MONGODB_HOST,
+            "--skip-if-exists",
+            "false",
+        ])
+        .current_dir(&proj.root)
+        .env("MONGODB_DB", TEST_DB)
+        .env("MONGODB_COLLECTION", "shared-coll")
+        .env("MONGODB_COLLECTION_EXACT", "1")
+        .output()
+        .expect("run vector-db-benchmark");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "exact-pinned sweep of 2 mongodb configs must be rejected, not run: {combined}"
+    );
+    assert!(
+        combined.contains("derive the same index namespace"),
+        "the failure must be the #151-4 collision guard, not an incidental error: {combined}"
+    );
+    assert!(
+        combined.contains("MONGODB_COLLECTION_EXACT is set"),
+        "the guard must name the exact-pin as the cause so the fix is obvious: {combined}"
+    );
+    assert!(
+        combined.contains("the mongodb collection"),
+        "the guard must name the object that would be overwritten: {combined}"
+    );
+    fs::remove_dir_all(&proj.root).ok();
+}
+
+/// `--keep-data` across a multi-config sweep is documented (experiment.rs) as
+/// keeping EVERY config's data resident simultaneously. That was false for
+/// MongoDB — config B's `configure()` dropped config A's collection — and #306
+/// makes it true. This pins the documented behaviour.
+///
+/// RED ON REVERT: with one shared collection, config B's `configure()` drops it,
+/// so after the sweep only ONE collection exists and A's count is 0.
+#[test]
+fn test_binary_mongodb_keep_data_keeps_every_configs_corpus() {
+    wait_for_mongodb();
+    drop_test_collection();
+
+    let port: u16 = std::env::var("MONGODB_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(MONGODB_PORT);
+    let port_s = port.to_string();
+
+    let ds = "cfg306keep-test";
+    let cfg_a = "cfg306keepa";
+    let cfg_b = "cfg306keepb";
+    let configs = serde_json::json!([
+        {
+            "name": cfg_a, "engine": "mongodb",
+            "search_params": [{"parallel": 1, "num_candidates": 20}],
+            "upload_params": {"parallel": 1}
+        },
+        {
+            "name": cfg_b, "engine": "mongodb",
+            "search_params": [{"parallel": 1, "num_candidates": 20}],
+            "upload_params": {"parallel": 1}
+        },
+    ]);
+    let proj = common::write_match_any_project(ds, &serde_json::to_string(&configs).unwrap(), 8);
+    let envs: [(&str, &str); 4] = [
+        ("MONGODB_PORT", port_s.as_str()),
+        ("MONGODB_DB", TEST_DB),
+        ("MONGODB_COLLECTION", TEST_COLLECTION),
+        ("MONGODB_INDEX_NAME", TEST_INDEX),
+    ];
+
+    // One invocation, both configs (`cfg306keep*`), --keep-data.
+    assert!(
+        common::run_binary_extra(
+            &proj.root,
+            "cfg306keep*",
+            ds,
+            MONGODB_HOST,
+            &envs,
+            &["--keep-data", "--skip-search"],
+        ),
+        "two-config --keep-data sweep failed"
+    );
+
+    for cfg in [cfg_a, cfg_b] {
+        assert_eq!(
+            count_docs(&engine_collection(cfg)),
+            common::N_DOCS as u64,
+            "--keep-data must leave '{}' resident; config '{}' lost its corpus to \
+             a sibling's configure() (#306)",
+            engine_collection(cfg),
+            cfg
+        );
+    }
 
     drop_test_collection();
     fs::remove_dir_all(&proj.root).ok();


### PR DESCRIPTION
Closes #306.

## The bug

MongoDB addressed one fixed `bench.vectors` / `vector_index` for every config, and never adopted the per-config namespacing from #151-4 (used today by redis, valkey, dragonfly, kividb, vectorsets).

Under `--skip-upload`, the shipped 12-config HNSW sweep (M ∈ {16,32,64} × EF_CONSTRUCTION ∈ {100,200,400,800}) therefore produced **12 result files with 12 distinct HNSW labels, all measured against whichever index the first config built** — `--skip-upload` skips `configure()`, and `configure()` is the only caller of `create_vector_index`.

The reuse precondition could not catch it: `corpus_row_count` is `countDocuments({})`, which interrogates the *write* store, while queries are served by the Atlas search index — a separate system that can be missing, stale, or built with different parameters while the count is perfect.

## The fix

`collection_name` and `index_name` now derive from `engine::index_naming::derive_index_name`, following the Redis-family convention exactly. `MONGODB_COLLECTION` / `MONGODB_INDEX_NAME` remain overrides but are now **bases** with the sanitized config name appended, with the usual `<BASE>_EXACT=1` escape hatch — the same precedent #151-4 set for `REDIS_INDEX_NAME`.

MongoDB-specific wrinkle: the server refuses a `<db>.<collection>` namespace over 255 bytes (verified live against `mongodb-atlas-local:8.0.17` — 200 bytes accepted, 250 rejected). Over-budget names become `<head>~<16 hex FNV-1a-64 of the whole name>`, **hashed rather than truncated**, so two configs sharing a long prefix cannot collapse back onto one collection. FNV rather than `DefaultHasher` because SipHash is not guaranteed stable across Rust releases and the name must resolve identically from a later build for `--skip-upload` to find the corpus. The search index name is left unbounded (a 5000-byte one was accepted).

MongoDB also joins the #151-4 startup collision guard. Its destructible namespace is the **collection**, not the index — `configure()` drops the collection and the search index lives inside it — so that is what the guard compares, and it calls the engine's own naming function rather than re-deriving, so the guard checks the name production actually uses.

`index_naming` itself is untouched: a 255-byte namespace ceiling is MongoDB-specific knowledge with no Redis analogue, so the bound lives in the engine. Zero conflict surface with other in-flight branches there.

## Tests

Every test was verified **RED by mutation** — reverting derivation to `env_or`, replacing the hash with plain truncation, dropping `db_name` from the budget, and removing `"mongodb"` from the guard.

| Test | Breaks when |
|---|---|
| `sweep_configs_derive_distinct_collections_and_indexes` | derivation reverted |
| `shipped_hnsw_sweep_gives_every_config_its_own_collection` | reads the real 12-config file; a colliding 13th config fails here |
| `long_config_names_are_bounded_without_colliding` | plain truncation — this is the #294 sanitize-collision path, now tested |
| `the_namespace_budget_accounts_for_the_database_name` | budget stops subtracting `db_name.len()+1` |
| `bounding_is_deterministic` | hash swapped (pins literal FNV vectors) |
| `bounding_survives_a_budget_smaller_than_the_digest` | slice panic at tiny budgets |
| `bounding_cuts_on_a_char_boundary` | mid-UTF-8 slice panic (env base is unsanitized) |
| `collection_env_override_is_a_base_not_a_pin` | derivation reverted |
| `test_binary_mongodb_skip_upload_against_another_configs_corpus_is_fatal` | **the headline regression** — config B reusing config A's corpus must abort, and A's corpus must survive |
| `test_binary_mongodb_exact_pin_with_two_configs_is_rejected_at_startup` | `"mongodb"` removed from the guard; asserts the error *text* |
| `test_binary_mongodb_keep_data_keeps_every_configs_corpus` | pins the `experiment.rs:298-305` claim, which is now true for MongoDB |

## Verification

`make check` clean · `cargo test --bin vector-db-benchmark` 883 pass · `cargo test --lib` 129 pass · `MONGODB_PORT=27018 cargo test --test integration_mongodb` 25 pass · `overhead_invariants` 9 pass · `integration_vectorsets exact_pin` passes (its asserted substring is preserved).

## Reviewer notes — deliberate calls worth challenging

1. **`MONGODB_COLLECTION` / `MONGODB_INDEX_NAME` semantics change** from "exact name" to "base name". Anyone scripting against a fixed collection now gets `vectors:<config>`; `_EXACT=1` restores the old behaviour. This follows the #151-4 precedent, but it is a user-visible break and no doc outside the engine mentions these vars.
2. **The index name is namespaced too, not just the collection.** Per-config collections alone fully isolate (an Atlas search index is scoped to its collection), and the guard now rejects the pinned shared-collection case anyway — so this half arguably buys nothing today. It matches the issue text and costs nothing; dropping it is a clean one-line revert if you prefer a smaller blast radius on `MONGODB_INDEX_NAME`.
3. **No identity marker added to `corpus_row_count`.** Per-config naming makes a cross-config `--skip-upload` count 0 and fail, so a marker would answer the same question one layer later. The *dataset* dimension of #279 (one config reused across two same-sized datasets) is deliberately left open — that is identical on all 15 engines and wants one cross-engine mechanism.

## Merge order

This conflicts with #305's branch in `mongodb_engine.rs` and `tests/integration_mongodb.rs` (both edit the same file in different regions). #305 fixes a higher-severity bug — recall published against a ~1%-indexed index — so **land #305 first and I will rebase this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
