### PR TITLE
mongodb: wait for the WHOLE corpus to be searchable, not the first 10,000 (#305)

### DIFF
--- a/src/bin/vector_db_benchmark/engine/chroma.rs
+++ b/src/bin/vector_db_benchmark/engine/chroma.rs
@@ -662,6 +662,7 @@ impl Engine for ChromaEngine {
             parallel: self.parallel,
             batch_size: self.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/dragonfly.rs
+++ b/src/bin/vector_db_benchmark/engine/dragonfly.rs
@@ -1018,6 +1018,7 @@ impl Engine for DragonflyEngine {
             parallel: self.config.parallel,
             batch_size: self.config.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/elasticsearch.rs
+++ b/src/bin/vector_db_benchmark/engine/elasticsearch.rs
@@ -1017,6 +1017,7 @@ impl Engine for ElasticsearchEngine {
             parallel: self.config.parallel,
             batch_size: self.config.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/kividb.rs
+++ b/src/bin/vector_db_benchmark/engine/kividb.rs
@@ -2139,6 +2139,7 @@ impl Engine for KividbEngine {
             parallel: self.config.parallel,
             batch_size: self.config.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/milvus.rs
+++ b/src/bin/vector_db_benchmark/engine/milvus.rs
@@ -1533,6 +1533,7 @@ impl Engine for MilvusEngine {
             parallel: self.parallel,
             batch_size: self.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/mod.rs
+++ b/src/bin/vector_db_benchmark/engine/mod.rs
@@ -49,6 +49,36 @@ pub use vectorsets::VectorSetsEngine;
 pub use vertex::VertexEngine;
 pub use weaviate::WeaviateEngine;
 
+/// How much of the uploaded corpus the engine CONFIRMED to be searchable
+/// before the search phase was allowed to start (#305).
+///
+/// `None` on [`UploadStats::index_coverage`] means the engine performs no such
+/// verification — which is a materially different claim from "verified, and it
+/// was complete", so the two must not be conflated in the artifact. An engine
+/// that does verify writes the achieved and expected counts here, and the
+/// upload JSON carries them, so a reader of the result file can tell what the
+/// recall in the sibling search file was measured against instead of having to
+/// find a scrolled-past line on stderr.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct IndexCoverage {
+    /// Documents the engine observed to be searchable through the index.
+    pub searchable: usize,
+    /// Documents the upload phase sent.
+    pub expected: usize,
+}
+
+impl IndexCoverage {
+    /// `searchable / expected`. An empty corpus is trivially complete (`1.0`)
+    /// rather than `NaN`, so the emitted JSON is always a number.
+    pub fn fraction(&self) -> f64 {
+        if self.expected == 0 {
+            1.0
+        } else {
+            self.searchable as f64 / self.expected as f64
+        }
+    }
+}
+
 /// Upload statistics
 #[derive(Debug, Clone, Default)]
 pub struct UploadStats {
@@ -58,6 +88,8 @@ pub struct UploadStats {
     pub parallel: usize,
     pub batch_size: usize,
     pub memory_usage: Option<serde_json::Value>,
+    /// See [`IndexCoverage`]. `None` = this engine does not verify.
+    pub index_coverage: Option<IndexCoverage>,
 }
 
 /// Update-to-search ratio for mixed workload benchmarks.

--- a/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
+++ b/src/bin/vector_db_benchmark/engine/mongodb_engine.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use indicatif::{HumanCount, ProgressBar, ProgressState, ProgressStyle};
 use mongodb::bson::{doc, Document};
@@ -17,7 +17,9 @@ use rand::{seq::SliceRandom, SeedableRng};
 use super::geo;
 use crate::config::{EngineConfig, SearchParams};
 use crate::dataset::Dataset;
-use crate::engine::{CorpusCount, Engine, SearchResults, UpdateSearchRatio, UploadStats};
+use crate::engine::{
+    CorpusCount, Engine, IndexCoverage, SearchResults, UpdateSearchRatio, UploadStats,
+};
 use vector_db_benchmark::query_filter::QueryFilter;
 use vector_db_benchmark::readers::metadata::MetadataItem;
 use vector_db_benchmark::start_gate::WorkerPool;
@@ -555,132 +557,117 @@ impl MongoDBEngine {
         }
     }
 
-    /// Wait for the vector search index to finish indexing all uploaded documents.
+    /// Wait until EVERY uploaded document is searchable through the index, and
+    /// report how many were confirmed.
     ///
-    /// Polls `listSearchIndexes` until the index reports `queryable=true` and
-    /// `status` is READY or ACTIVE, then verifies with a probe search using
-    /// the first uploaded vector.
+    /// Atlas Vector Search is EVENTUALLY CONSISTENT, and the index STATUS
+    /// cannot detect that: `configure()` creates the index on a one-document
+    /// collection *before* the upload, so `listSearchIndexes` reports
+    /// `status: READY, queryable: true` from that moment and keeps reporting it
+    /// the whole time mongot is ingesting the real corpus off a change stream.
+    /// The searchable-document count is therefore the entire guarantee, and
+    /// searching before it is complete measures recall against a fraction of the
+    /// corpus (the observed `recall 0.27` flake).
     ///
-    /// Atlas Vector Search is EVENTUALLY CONSISTENT: the index flips to
-    /// `queryable=true` (and `$vectorSearch` starts returning PARTIAL results)
-    /// while it is still ingesting the just-uploaded documents. A probe that
-    /// stops at the first non-empty result therefore lets the benchmark search
-    /// run against a half-built index, which understates recall (the observed
-    /// `recall 0.27` flake). To close that race we run the probe as a
-    /// full-precision search (`numCandidates >= expected`) and wait until it
-    /// surfaces EVERY uploaded document — i.e. the index has fully caught up —
-    /// before returning. The required count is bounded by `PROBE_CAP` so a huge
-    /// production dataset doesn't wait on an impractically large single query.
+    /// The count comes from an EXHAUSTIVE (`exact: true`, ENN) probe reduced to
+    /// a single number server-side by `$count`. An approximate probe cannot
+    /// answer the question at all: Atlas rejects `numCandidates` above 10_000
+    /// and requires `limit <= numCandidates`, so an ANN probe can never see past
+    /// the first 10_000 documents — which is why the previous capped gate
+    /// released at 0.85% indexed on glove-100 and let the run publish recall
+    /// against a near-empty index (#305). ENN takes no `numCandidates` and so
+    /// carries no such ceiling; verified against mongodb-atlas-local 8.0.17 for
+    /// both dialects, returning 12_000 of 12_000 at `limit` 12_000 and 20_000.
+    ///
+    /// There is no success path that returns while under-indexed: either the
+    /// probe confirms the whole corpus, or this returns `Err` and the run stops
+    /// before it can publish an unbacked recall.
     fn wait_for_index_catchup(
         &self,
         expected_count: usize,
         probe_vector: &[f32],
         dialect: SearchDialect,
-    ) -> Result<(), String> {
-        // Upper bound on how many docs we require the probe to surface. Atlas
-        // caps both `limit` and `numCandidates` at 10_000, and for large corpora
-        // "index reports ready AND has surfaced this many docs" is a sufficient
-        // catch-up signal.
-        const PROBE_CAP: usize = 10_000;
-        let want = expected_count.min(PROBE_CAP);
-        // Request all wanted docs, scanning a candidate pool that covers the
-        // whole (bounded) corpus so the search is effectively exact — an indexed
-        // doc is guaranteed to be surfaced, so `results.len() < want` means the
-        // index has not finished ingesting yet.
-        let probe_top = want.max(1);
-        let probe_candidates = expected_count.saturating_mul(2).clamp(probe_top, PROBE_CAP) as i64;
+    ) -> Result<IndexCoverage, String> {
+        let plan = catchup_plan(expected_count);
+        let pipeline =
+            build_catchup_count_pipeline(&self.index_name, probe_vector, plan.limit, dialect);
 
         println!(
-            "Waiting for vector search index to index all {} documents...",
-            expected_count
+            "Waiting for vector search index to index all {} documents (exhaustive count probe, budget {}s)...",
+            expected_count,
+            plan.deadline.as_secs()
         );
         let db = self.client.database(&self.db_name);
         let coll = db.collection::<Document>(&self.collection_name);
         let start = Instant::now();
-        let deadline = start + std::time::Duration::from_secs(600);
+        let deadline = start + plan.deadline;
         let mut last_print = Instant::now();
-        let mut index_ready = false;
+        let mut last_seen = 0usize;
+        // The probe legitimately errors while mongot is still starting up ("is
+        // not queryable"), so a single error is not fatal — but the LAST one is
+        // kept so a gate that never succeeds can name why instead of reporting a
+        // bare timeout. Every arm below that reaches the deadline check assigns
+        // it, so it deliberately carries no initial value.
+        let mut last_error: Option<String>;
 
         loop {
-            if !index_ready {
-                let cmd = doc! { "listSearchIndexes": &self.collection_name };
-                if let Ok(result) = db.run_command(cmd).run() {
-                    if let Ok(cursor) = result.get_document("cursor") {
-                        if let Ok(batch) = cursor.get_array("firstBatch") {
-                            for index in batch {
-                                if let Some(index_doc) = index.as_document() {
-                                    let name = index_doc.get_str("name").unwrap_or("");
-                                    if name != self.index_name {
-                                        continue;
-                                    }
-                                    let status = index_doc.get_str("status").unwrap_or("");
-                                    let queryable =
-                                        index_doc.get_bool("queryable").unwrap_or(false);
+            let probe_start = Instant::now();
+            let outcome = run_catchup_count(&coll, &pipeline);
+            let probe_elapsed = probe_start.elapsed();
 
-                                    if (status == "READY" || status == "ACTIVE") && queryable {
-                                        index_ready = true;
-                                    } else if last_print.elapsed().as_secs() >= 10 {
-                                        println!(
-                                            "  index building... status={}, queryable={}",
-                                            status, queryable
-                                        );
-                                        last_print = Instant::now();
-                                    }
-                                }
-                            }
-                        }
+            match outcome {
+                Ok(searchable) if searchable >= plan.want => {
+                    println!(
+                        "Index caught up ({} / {} docs searchable) after {:.1}s.",
+                        searchable,
+                        expected_count,
+                        start.elapsed().as_secs_f64()
+                    );
+                    return Ok(IndexCoverage {
+                        searchable,
+                        expected: expected_count,
+                    });
+                }
+                Ok(searchable) => {
+                    last_seen = searchable;
+                    last_error = None;
+                    if last_print.elapsed().as_secs() >= 10 {
+                        println!(
+                            "  still ingesting: {} / {} docs searchable, waiting...",
+                            searchable, plan.want
+                        );
+                        last_print = Instant::now();
                     }
                 }
-            }
-
-            // Once the index reports ready, probe with a full-precision search and
-            // wait until it has surfaced EVERY uploaded document — only then has the
-            // eventually-consistent index finished ingesting (partial ingestion
-            // returns fewer than `want` and understates recall).
-            if index_ready {
-                match vector_search(
-                    &coll,
-                    &self.index_name,
-                    probe_vector,
-                    probe_top,
-                    probe_candidates,
-                    None,
-                    dialect,
-                ) {
-                    Ok(results) if results.len() >= want => {
-                        println!(
-                            "Index caught up ({} / {} docs searchable) after {:.1}s.",
-                            results.len(),
-                            expected_count,
-                            start.elapsed().as_secs_f64()
-                        );
-                        return Ok(());
+                Err(e) => {
+                    if last_print.elapsed().as_secs() >= 10 {
+                        println!("  catch-up probe not answering yet: {}", e);
+                        last_print = Instant::now();
                     }
-                    Ok(results) => {
-                        if last_print.elapsed().as_secs() >= 10 {
-                            println!(
-                                "  index ready but still ingesting: {} / {} docs searchable, waiting...",
-                                results.len(),
-                                want
-                            );
-                            last_print = Instant::now();
-                        }
-                    }
-                    Err(_) => {
-                        if last_print.elapsed().as_secs() >= 10 {
-                            println!("  index ready but probe search errored, waiting...");
-                            last_print = Instant::now();
-                        }
-                    }
+                    last_error = Some(e);
                 }
             }
 
             if Instant::now() > deadline {
-                return Err(
-                    "Vector search index did not finish indexing within 600 seconds".to_string(),
-                );
+                return Err(format!(
+                    "MongoDB index catch-up FAILED: only {} of {} documents ({:.2}%) were \
+                     searchable after {:.0}s. Refusing to run the search phase against a \
+                     partially built index — any recall it produced would be measured against \
+                     that fraction of the corpus, not the corpus the ground truth describes. \
+                     Last probe error: {}",
+                    last_seen,
+                    expected_count,
+                    IndexCoverage {
+                        searchable: last_seen,
+                        expected: expected_count
+                    }
+                    .fraction()
+                        * 100.0,
+                    start.elapsed().as_secs_f64(),
+                    last_error.as_deref().unwrap_or("none"),
+                ));
             }
-            std::thread::sleep(std::time::Duration::from_secs(2));
+            std::thread::sleep(catchup_poll_interval(probe_elapsed));
         }
     }
 
@@ -1116,32 +1103,142 @@ fn extract_search_hits(docs: &[Document]) -> Vec<(i64, f64)> {
         .collect()
 }
 
-/// Execute a vector search end-to-end (build + send + extract).
+// ---------------------------------------------------------------------------
+// Index catch-up gate (#305)
+// ---------------------------------------------------------------------------
+
+/// Everything about the index catch-up gate that is a pure function of the
+/// corpus size.
 ///
-/// Convenience wrapper used by the untimed index-catchup probe
-/// (`wait_for_index_catchup`), where the split boundary is irrelevant. The timed
-/// search()/search_mixed() paths deliberately do NOT use this: they precompute
-/// pipelines out of the window and call `send_search`/`extract_search_hits`
-/// directly so only the RPC + decode is timed.
-fn vector_search(
-    coll: &mongodb::sync::Collection<Document>,
+/// Extracted out of `wait_for_index_catchup` — a `&self` method that needs a
+/// live `Client` — precisely because the #305 defect lived in this arithmetic
+/// and nothing could reach it: every mongodb integration corpus in this repo is
+/// 20-500 vectors, so a cap that only bites above 10_000 documents was
+/// unreachable from the whole suite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CatchupPlan {
+    /// Searchable documents the gate requires before it releases. This is
+    /// `expected_count` itself and MUST NOT be capped: capping it is exactly
+    /// how the gate came to release at 10_000 of glove-100's 1_183_514.
+    want: usize,
+    /// `limit` for the probe stage. `expected_count` again, floored at 1
+    /// because the stage rejects `limit: 0`.
+    limit: usize,
+    /// Wall-clock budget for the whole gate.
+    deadline: Duration,
+}
+
+/// Build the catch-up plan for a corpus of `expected_count` documents.
+fn catchup_plan(expected_count: usize) -> CatchupPlan {
+    // Ten minutes of slack for index creation and mongot startup, plus a
+    // millisecond per document — an assumed floor of 1_000 docs/sec of mongot
+    // ingest. The previous flat 600s was sized for a gate that gave up after
+    // 10_000 documents; a gate that genuinely waits for a million-document
+    // corpus would trip it on arrival.
+    const BASE_SECS: u64 = 600;
+    const ASSUMED_MIN_INGEST_DOCS_PER_SEC: u64 = 1_000;
+
+    CatchupPlan {
+        want: expected_count,
+        limit: expected_count.max(1),
+        deadline: Duration::from_secs(
+            BASE_SECS + expected_count as u64 / ASSUMED_MIN_INGEST_DOCS_PER_SEC,
+        ),
+    }
+}
+
+/// How long to sleep before the next catch-up probe.
+///
+/// The exhaustive probe costs O(corpus), so a fixed short interval would spend
+/// most of a large gate inside probes. Sleeping at least as long as the last
+/// probe took bounds probe cost at about half the gate's wall clock; the floor
+/// keeps small corpora responsive and the ceiling stops the gate overshooting
+/// catch-up by minutes on a huge one.
+fn catchup_poll_interval(last_probe: Duration) -> Duration {
+    last_probe.clamp(Duration::from_secs(2), Duration::from_secs(30))
+}
+
+/// Build the pipeline for one catch-up probe: an exhaustive nearest-neighbour
+/// query over the whole index, reduced to a single number server-side.
+///
+/// `exact: true` is what makes the count both trustworthy and UNBOUNDED. The
+/// approximate form takes `numCandidates`, which Atlas rejects above 10_000
+/// (`"numCandidates" must be within bounds [1..10000]`) while also requiring
+/// `limit <= numCandidates` — so no ANN probe can count past 10_000 documents,
+/// no matter how it is parameterised. The exhaustive form takes no
+/// `numCandidates` at all (passing one alongside `exact` is an error), scans
+/// every indexed document, and so returns the true indexed count.
+///
+/// `$count` keeps the answer cheap on the wire: mongot still scores the corpus,
+/// but a single `{n: ...}` comes back instead of a million documents.
+fn build_catchup_count_pipeline(
     index_name: &str,
     query_vector: &[f32],
-    top: usize,
-    num_candidates: i64,
-    filter: Option<&Document>,
+    limit: usize,
     dialect: SearchDialect,
-) -> Result<Vec<(i64, f64)>, String> {
-    let pipeline = build_search_pipeline(
-        index_name,
-        query_vector,
-        top,
-        num_candidates,
-        filter,
-        dialect,
-    );
-    let docs = send_search(coll, &pipeline)?;
-    Ok(extract_search_hits(&docs))
+) -> Vec<Document> {
+    let bson_vec: Vec<mongodb::bson::Bson> = query_vector
+        .iter()
+        .map(|&f| mongodb::bson::Bson::Double(f as f64))
+        .collect();
+
+    let vs_stage = doc! {
+        "path": "vector",
+        "queryVector": bson_vec,
+        "limit": limit as i64,
+        "exact": true,
+    };
+
+    let search_stage = match dialect {
+        SearchDialect::VectorSearchStage => {
+            let mut stage = doc! { "index": index_name };
+            stage.extend(vs_stage);
+            doc! { "$vectorSearch": stage }
+        }
+        SearchDialect::SearchStage => {
+            doc! { "$search": { "index": index_name, "vectorSearch": vs_stage } }
+        }
+    };
+
+    vec![search_stage, doc! { "$count": "n" }]
+}
+
+/// Read the count out of one `$count` output document.
+///
+/// `$count` emits an int32 on the servers seen so far, but nothing in the
+/// aggregation contract pins the width, and reading it as the wrong one would
+/// turn a complete index into an unreadable probe and hang the gate to its
+/// deadline. A missing `n` is an error rather than a zero: silently reporting
+/// "0 searchable" for a malformed reply would look identical to a cold index
+/// and burn the whole budget.
+fn catchup_count_from_doc(doc: &Document) -> Result<usize, String> {
+    let n = doc
+        .get_i32("n")
+        .map(i64::from)
+        .or_else(|_| doc.get_i64("n"))
+        .map_err(|_| format!("catch-up count returned no `n` field: {:?}", doc))?;
+    Ok(n.max(0) as usize)
+}
+
+/// Run a catch-up count pipeline and return the searchable-document count.
+///
+/// `$count` emits NO document when its input is empty, which is how "nothing
+/// indexed yet" arrives — zero, not an error.
+fn run_catchup_count(
+    coll: &mongodb::sync::Collection<Document>,
+    pipeline: &[Document],
+) -> Result<usize, String> {
+    let cursor = coll
+        .aggregate(pipeline.to_vec())
+        .run()
+        .map_err(|e| format!("catch-up count failed: {}", e))?;
+
+    let mut searchable = 0usize;
+    for result in cursor {
+        let doc = result.map_err(|e| format!("catch-up count read failed: {}", e))?;
+        searchable = catchup_count_from_doc(&doc)?;
+    }
+    Ok(searchable)
 }
 
 /// Parse filter conditions into MongoDB query document.
@@ -1653,6 +1750,9 @@ impl Engine for MongoDBEngine {
         );
 
         let total_time;
+        // `None` means "not verified" — the only honest value when no vector
+        // index was built. It is NOT the same claim as a verified 1.0 (#305).
+        let mut index_coverage = None;
         if self.config.skip_vector_index {
             total_time = read_time + upload_time;
             println!(
@@ -1664,11 +1764,11 @@ impl Engine for MongoDBEngine {
             // Use the first vector as a probe query to verify actual search readiness
             let probe_vector = vectors.first().ok_or("No vectors uploaded")?;
             let index_start = Instant::now();
-            self.wait_for_index_catchup(
+            index_coverage = Some(self.wait_for_index_catchup(
                 vectors.len(),
                 probe_vector,
                 SearchDialect::for_dataset(dataset),
-            )?;
+            )?);
             let index_time = index_start.elapsed().as_secs_f64();
 
             total_time = read_time + upload_time + index_time;
@@ -1685,6 +1785,7 @@ impl Engine for MongoDBEngine {
             parallel: self.config.parallel,
             batch_size: self.config.batch_size,
             memory_usage: None,
+            index_coverage,
         })
     }
 
@@ -2788,5 +2889,174 @@ mod tests {
             Some(v) => std::env::set_var("MONGODB_PASSWORD", v),
             None => std::env::remove_var("MONGODB_PASSWORD"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Index catch-up gate (#305)
+    //
+    // Every mongodb integration corpus in this repo is 20-500 vectors, so the
+    // >10_000 branch these tests pin is reachable from NOTHING else in the
+    // suite. That is why #305 survived: the gate's cap only bites above 10_000
+    // documents, and no test ever handed it that many.
+    // -----------------------------------------------------------------------
+
+    /// The #305 defect itself: `want` was `expected_count.min(10_000)`, so the
+    /// gate released once 10_000 documents of a 1_183_514-document corpus were
+    /// searchable — 0.85% — and the search phase published recall against it.
+    ///
+    /// `want` must equal the corpus, at every size, with no ceiling.
+    #[test]
+    fn catchup_plan_requires_the_whole_corpus_at_every_size() {
+        // Straddles the old cap: 9_999 passed before AND after, 10_001 is the
+        // smallest corpus the old code got wrong.
+        for expected in [1usize, 9_999, 10_000, 10_001, 1_000_000, 1_183_514] {
+            let plan = catchup_plan(expected);
+            assert_eq!(
+                plan.want, expected,
+                "catch-up must wait for all {expected} documents, not a capped \
+                 fraction of them (#305)"
+            );
+            assert_eq!(
+                plan.limit, expected,
+                "the probe must ASK for all {expected} documents; a smaller limit \
+                 makes a complete count unobservable no matter what `want` says"
+            );
+        }
+    }
+
+    /// `limit: 0` is rejected by the stage, so an empty corpus still asks for
+    /// one document — while `want` stays 0, so the gate releases immediately
+    /// rather than waiting for a document that will never exist.
+    #[test]
+    fn catchup_plan_floors_the_probe_limit_at_one() {
+        let plan = catchup_plan(0);
+        assert_eq!(plan.want, 0);
+        assert_eq!(plan.limit, 1);
+    }
+
+    /// A gate that genuinely waits for the whole corpus needs a budget that
+    /// scales with it. The flat 600s was sized for a gate that gave up after
+    /// 10_000 documents; kept flat, a corpus this tool actually ships would hit
+    /// the deadline as a matter of course and the fix would trade a silent wrong
+    /// answer for a guaranteed hard failure.
+    #[test]
+    fn catchup_plan_deadline_scales_with_the_corpus() {
+        assert_eq!(catchup_plan(0).deadline, Duration::from_secs(600));
+        assert_eq!(catchup_plan(9_999).deadline, Duration::from_secs(609));
+        assert_eq!(catchup_plan(1_000_000).deadline, Duration::from_secs(1_600));
+        assert!(
+            catchup_plan(1_183_514).deadline > Duration::from_secs(600),
+            "glove-100 must get more than the old flat budget"
+        );
+    }
+
+    /// Probe cost is O(corpus), so the interval must not be a fixed short sleep
+    /// on a large corpus, nor a long one on a small corpus.
+    #[test]
+    fn catchup_poll_interval_is_bounded_by_the_last_probe() {
+        assert_eq!(
+            catchup_poll_interval(Duration::from_millis(5)),
+            Duration::from_secs(2),
+            "floor keeps small corpora responsive"
+        );
+        assert_eq!(
+            catchup_poll_interval(Duration::from_secs(7)),
+            Duration::from_secs(7),
+            "in between, sleep as long as the probe took"
+        );
+        assert_eq!(
+            catchup_poll_interval(Duration::from_secs(600)),
+            Duration::from_secs(30),
+            "ceiling stops the gate overshooting catch-up by minutes"
+        );
+    }
+
+    /// The probe must be EXHAUSTIVE, because the approximate one physically
+    /// cannot count past 10_000: Atlas rejects `numCandidates` above 10_000 and
+    /// requires `limit <= numCandidates`. A probe carrying `numCandidates` is
+    /// therefore a probe that has silently reacquired the #305 ceiling — and it
+    /// is also the shape that produced the secondary hazard the issue names
+    /// (`limit == numCandidates == 10_000`).
+    #[test]
+    fn catchup_probe_is_exhaustive_and_carries_no_ann_knob() {
+        let query = vec![0.1f32, -0.2, 0.3];
+        let pipeline = build_catchup_count_pipeline(
+            "vidx",
+            &query,
+            1_183_514,
+            SearchDialect::VectorSearchStage,
+        );
+
+        assert_eq!(pipeline.len(), 2, "probe is <search stage> + $count");
+        let vs = pipeline[0].get_document("$vectorSearch").unwrap();
+        assert!(
+            vs.get_bool("exact").unwrap(),
+            "the probe must be exhaustive (ENN)"
+        );
+        assert!(
+            !vs.contains_key("numCandidates"),
+            "numCandidates caps the probe at 10_000 documents and is invalid \
+             alongside `exact`: {vs:?}"
+        );
+        assert_eq!(
+            vs.get_i64("limit").unwrap(),
+            1_183_514,
+            "the probe must ask for the whole corpus, above the ANN ceiling"
+        );
+        assert_eq!(vs.get_str("index").unwrap(), "vidx");
+
+        // Counted server-side: mongot still scans, but one `{n: ...}` comes back
+        // instead of a million documents.
+        assert_eq!(pipeline[1], doc! { "$count": "n" });
+    }
+
+    /// The geo datasets run the `$search` dialect (#223), and they are subject
+    /// to exactly the same ceiling — so the same exhaustive shape has to reach
+    /// the other stage too, nested under the `vectorSearch` operator.
+    #[test]
+    fn catchup_probe_is_exhaustive_on_the_search_dialect_too() {
+        let query = vec![0.1f32, -0.2, 0.3];
+        let pipeline =
+            build_catchup_count_pipeline("vidx", &query, 25_000, SearchDialect::SearchStage);
+
+        let vs = pipeline[0]
+            .get_document("$search")
+            .unwrap()
+            .get_document("vectorSearch")
+            .unwrap();
+        assert!(
+            vs.get_bool("exact").unwrap(),
+            "the probe must be exhaustive (ENN)"
+        );
+        assert!(!vs.contains_key("numCandidates"), "{vs:?}");
+        assert_eq!(vs.get_i64("limit").unwrap(), 25_000);
+        assert_eq!(
+            pipeline[0]
+                .get_document("$search")
+                .unwrap()
+                .get_str("index")
+                .unwrap(),
+            "vidx"
+        );
+        assert_eq!(pipeline[1], doc! { "$count": "n" });
+    }
+
+    /// The count reader must not depend on the integer width `$count` happens
+    /// to emit, and must not turn a malformed reply into a plausible-looking
+    /// "0 searchable" — which is indistinguishable from a cold index and would
+    /// burn the entire budget before failing.
+    #[test]
+    fn catchup_count_reads_either_integer_width_and_rejects_a_missing_count() {
+        assert_eq!(
+            catchup_count_from_doc(&doc! { "n": 10_001i32 }).unwrap(),
+            10_001
+        );
+        assert_eq!(
+            catchup_count_from_doc(&doc! { "n": 1_183_514i64 }).unwrap(),
+            1_183_514
+        );
+        let err = catchup_count_from_doc(&doc! { "total": 5i32 })
+            .expect_err("a reply without `n` is not a zero count");
+        assert!(err.contains("no `n`"), "{err}");
     }
 }

--- a/src/bin/vector_db_benchmark/engine/opensearch.rs
+++ b/src/bin/vector_db_benchmark/engine/opensearch.rs
@@ -1927,6 +1927,7 @@ impl Engine for OpenSearchEngine {
             parallel: self.config.parallel,
             batch_size: self.config.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/pgvector.rs
+++ b/src/bin/vector_db_benchmark/engine/pgvector.rs
@@ -507,6 +507,7 @@ impl Engine for PgVectorEngine {
             parallel: self.parallel,
             batch_size: self.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/qdrant.rs
+++ b/src/bin/vector_db_benchmark/engine/qdrant.rs
@@ -667,6 +667,7 @@ impl QdrantEngine {
             parallel: 1,
             batch_size: self.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 
@@ -726,6 +727,7 @@ impl QdrantEngine {
             parallel: 1,
             batch_size: self.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 
@@ -1837,6 +1839,7 @@ impl Engine for QdrantEngine {
             parallel: self.parallel,
             batch_size: self.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/redis.rs
+++ b/src/bin/vector_db_benchmark/engine/redis.rs
@@ -2057,6 +2057,7 @@ impl Engine for RedisEngine {
                         parallel: self.config.parallel,
                         batch_size: self.config.batch_size,
                         memory_usage: None,
+                        index_coverage: None,
                     });
                 }
             }
@@ -2130,6 +2131,7 @@ impl Engine for RedisEngine {
             parallel: self.config.parallel,
             batch_size: self.config.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/turbopuffer.rs
+++ b/src/bin/vector_db_benchmark/engine/turbopuffer.rs
@@ -499,6 +499,7 @@ impl Engine for TurbopufferEngine {
             parallel: self.parallel,
             batch_size: self.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/valkey.rs
+++ b/src/bin/vector_db_benchmark/engine/valkey.rs
@@ -1829,6 +1829,7 @@ impl Engine for ValkeyEngine {
             parallel: self.config.parallel,
             batch_size: self.config.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/vectorsets.rs
+++ b/src/bin/vector_db_benchmark/engine/vectorsets.rs
@@ -672,6 +672,7 @@ impl Engine for VectorSetsEngine {
             parallel: self.config.parallel,
             batch_size: self.config.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/vertex.rs
+++ b/src/bin/vector_db_benchmark/engine/vertex.rs
@@ -1525,6 +1525,7 @@ impl Engine for VertexEngine {
                 parallel: 1,
                 batch_size: vectors.len(),
                 memory_usage: None,
+                index_coverage: None,
             });
         }
 
@@ -1716,6 +1717,7 @@ impl Engine for VertexEngine {
             parallel: workers,
             batch_size: self.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/engine/weaviate.rs
+++ b/src/bin/vector_db_benchmark/engine/weaviate.rs
@@ -1312,6 +1312,7 @@ impl Engine for WeaviateEngine {
             parallel: self.parallel,
             batch_size: self.batch_size,
             memory_usage: None,
+            index_coverage: None,
         })
     }
 

--- a/src/bin/vector_db_benchmark/experiment.rs
+++ b/src/bin/vector_db_benchmark/experiment.rs
@@ -2498,6 +2498,16 @@ fn build_upload_result_json(
         result["params"]["number_of_shards"] = shards.clone();
     }
 
+    // What the engine CONFIRMED searchable before the search phase started
+    // (#305). Absent for engines that do not verify — absence therefore reads as
+    // "unverified", NOT as "complete" — and a fraction below 1.0 says the recall
+    // in the sibling search file was measured against a partially built index.
+    if let Some(coverage) = &stats.index_coverage {
+        result["results"]["index_searchable_count"] = json!(coverage.searchable);
+        result["results"]["index_expected_count"] = json!(coverage.expected);
+        result["results"]["index_coverage_fraction"] = json!(coverage.fraction());
+    }
+
     // Same provenance block as the search files (#212), tagged `phase: "upload"`.
     // It is scoped to what had been resolved when this file was written, so a
     // knob the engine only resolves during search is absent here. The phase tag
@@ -3166,6 +3176,95 @@ mod tests {
             );
             assert_ne!(d, other);
             assert_eq!(d["results"], other["results"]);
+        }
+
+        /// #305: how much of the corpus the engine confirmed searchable has to
+        /// reach the ARTIFACT. It used to exist only as a `println!` — the
+        /// mongodb gate literally printed `10000 / 1183514 docs searchable` and
+        /// then succeeded, so the one number that invalidated the run scrolled
+        /// past while the result file said nothing.
+        ///
+        /// And absence must stay readable as "this engine does not verify",
+        /// never as "verified complete": the two are different claims and the
+        /// file is the only place a later reader can tell them apart.
+        #[test]
+        fn upload_result_carries_the_index_coverage_the_engine_confirmed() {
+            use super::super::build_upload_result_json;
+            use crate::engine::{IndexCoverage, UploadStats};
+
+            let ep = serde_json::json!({"schema_version": 1, "phase": "upload"});
+
+            // The glove-100 failure from the issue, as it would have been
+            // published: 10_000 of 1_183_514.
+            let under = build_upload_result_json(
+                "mongodb-x",
+                "glove-100-angular",
+                &UploadStats {
+                    index_coverage: Some(IndexCoverage {
+                        searchable: 10_000,
+                        expected: 1_183_514,
+                    }),
+                    ..Default::default()
+                },
+                None,
+                &ep,
+            );
+            assert_eq!(under["results"]["index_searchable_count"], 10_000);
+            assert_eq!(under["results"]["index_expected_count"], 1_183_514);
+            let fraction = under["results"]["index_coverage_fraction"]
+                .as_f64()
+                .expect("coverage fraction must be a number in the artifact");
+            assert!(
+                fraction < 0.01,
+                "0.85% coverage must be visible as such, got {fraction}"
+            );
+
+            // A complete gate is a DIFFERENT artifact from an unverified one.
+            let complete = build_upload_result_json(
+                "mongodb-x",
+                "glove-100-angular",
+                &UploadStats {
+                    index_coverage: Some(IndexCoverage {
+                        searchable: 1_183_514,
+                        expected: 1_183_514,
+                    }),
+                    ..Default::default()
+                },
+                None,
+                &ep,
+            );
+            assert_eq!(complete["results"]["index_coverage_fraction"], 1.0);
+            assert_ne!(under["results"], complete["results"]);
+
+            // Engines that do not verify emit none of the three keys, so a
+            // reader can never mistake silence for a confirmed 1.0.
+            let unverified =
+                build_upload_result_json("redis-x", "glove", &UploadStats::default(), None, &ep);
+            for key in [
+                "index_searchable_count",
+                "index_expected_count",
+                "index_coverage_fraction",
+            ] {
+                assert!(
+                    unverified["results"].get(key).is_none(),
+                    "`{key}` must be absent when the engine does not verify"
+                );
+            }
+            assert_ne!(unverified["results"], complete["results"]);
+        }
+
+        /// An empty corpus is trivially complete, and the artifact must carry a
+        /// number rather than the `null` a NaN serializes to.
+        #[test]
+        fn index_coverage_fraction_of_an_empty_corpus_is_a_number() {
+            use crate::engine::IndexCoverage;
+            let f = IndexCoverage {
+                searchable: 0,
+                expected: 0,
+            }
+            .fraction();
+            assert!(f.is_finite(), "NaN would serialize as JSON null");
+            assert_eq!(f, 1.0);
         }
 
         /// Every connection-string shape, asserted against the BYTES ON DISK.

--- a/tests/integration_mongodb.rs
+++ b/tests/integration_mongodb.rs
@@ -2449,8 +2449,7 @@ fn test_exhaustive_probe_counts_past_the_ann_10000_document_ceiling() {
         .run()
         .and_then(|c| c.collect::<Result<Vec<_>, _>>());
     let err = rejected
-        .err()
-        .expect("numCandidates above 10_000 must be rejected, not silently clamped")
+        .expect_err("numCandidates above 10_000 must be rejected, not silently clamped")
         .to_string();
     assert!(
         err.contains("numCandidates"),

--- a/tests/integration_mongodb.rs
+++ b/tests/integration_mongodb.rs
@@ -2278,3 +2278,187 @@ fn test_binary_mongodb_mixed_updates_that_miss_the_corpus_are_fatal() {
     drop_test_collection();
     fs::remove_dir_all(&proj.root).ok();
 }
+
+// ---------------------------------------------------------------------------
+// #305: the ANN ceiling that made the capped catch-up gate unfixable in place
+// ---------------------------------------------------------------------------
+
+/// The three server facts the #305 fix stands on, at a corpus size no other
+/// test in this suite reaches.
+///
+/// Every other mongodb integration corpus here is 20-500 vectors, so the branch
+/// that broke — a catch-up gate that stopped waiting at 10_000 documents — was
+/// unreachable from the whole suite; a regression re-capping it would leave the
+/// file green. This uses 10_001 documents, the smallest corpus the old gate got
+/// wrong, and pins:
+///
+/// 1. the APPROXIMATE probe cannot see the 10_001st document even at its
+///    maximum settings (so the old gate released at 10_000/10_001 — the
+///    positive control that the bug is real, and that the exhaustive assertion
+///    below is not passing for free);
+/// 2. the ceiling is the SERVER's, not a choice: `numCandidates: 10_001` is
+///    rejected outright, so no ANN parameterisation can count the corpus;
+/// 3. the EXHAUSTIVE probe the fix uses has no such ceiling and returns all
+///    10_001 — the claim `wait_for_index_catchup` now depends on.
+///
+/// This does not exercise the benchmark's own code path (the probe builder is
+/// private to the binary and unit-tested there); it pins the server behaviour
+/// that path assumes, in the manner of the #293 `matched_count` test above.
+#[test]
+fn test_exhaustive_probe_counts_past_the_ann_10000_document_ceiling() {
+    // One document past the old cap: below this the bug is invisible.
+    const N: i64 = 10_001;
+    const DIM: usize = 4;
+    const COLL: &str = "probe_305_ann_ceiling";
+    const INDEX: &str = "probe_305_index";
+
+    wait_for_mongodb();
+    let client = mongodb_client();
+    let db = client.database(TEST_DB);
+    let coll = db.collection::<Document>(COLL);
+
+    // Own collection and own index name, so this never races the shared corpus.
+    let _ = db
+        .run_command(doc! { "dropSearchIndex": COLL, "name": INDEX })
+        .run();
+    let _ = coll.drop().run();
+
+    let mut docs = Vec::with_capacity(N as usize);
+    for i in 0..N {
+        let f = i as f64;
+        docs.push(doc! {
+            "_id": i,
+            "vector": [ (f * 0.001).sin(), (f * 0.001).cos(), (i % 97) as f64 / 97.0, 0.5 ],
+        });
+    }
+    coll.insert_many(&docs)
+        .run()
+        .expect("failed to insert the 10_001-document probe corpus");
+    assert_eq!(
+        coll.count_documents(doc! {}).run().unwrap(),
+        N as u64,
+        "the corpus must be one document past the old 10_000 cap"
+    );
+
+    db.run_command(doc! {
+        "createSearchIndexes": COLL,
+        "indexes": [ {
+            "name": INDEX,
+            "type": "vectorSearch",
+            "definition": { "fields": [ {
+                "type": "vector",
+                "path": "vector",
+                "numDimensions": DIM as i32,
+                "similarity": "cosine",
+            } ] },
+        } ],
+    })
+    .run()
+    .expect("failed to create the probe vector search index");
+
+    let query: Vec<f64> = vec![0.1, 0.2, 0.3, 0.4];
+    let enn = vec![
+        doc! { "$vectorSearch": {
+            "index": INDEX,
+            "path": "vector",
+            "queryVector": query.clone(),
+            "limit": N,
+            "exact": true,
+        } },
+        doc! { "$count": "n" },
+    ];
+
+    // FACT 3, and the wait: the exhaustive probe must eventually report the
+    // WHOLE corpus. If it plateaus below N this fails with the number it
+    // plateaued at — which is precisely the shape of the bug.
+    let deadline = Instant::now() + Duration::from_secs(300);
+    let mut last = 0i64;
+    let mut last_err = String::from("none");
+    loop {
+        match coll.aggregate(enn.clone()).run() {
+            Ok(cursor) => {
+                last = cursor
+                    .filter_map(|r| r.ok())
+                    .filter_map(|d| d.get_i32("n").map(i64::from).ok())
+                    .last()
+                    .unwrap_or(0);
+                if last >= N {
+                    break;
+                }
+            }
+            Err(e) => last_err = e.to_string(),
+        }
+        assert!(
+            Instant::now() < deadline,
+            "exhaustive probe never reported the whole corpus: {last} / {N} after \
+             300s (last error: {last_err}). If `limit` above 10_000 is now \
+             rejected, the catch-up gate in mongodb_engine.rs has lost its only \
+             corpus-complete signal and must not be allowed to pass silently.",
+        );
+        thread::sleep(Duration::from_secs(2));
+    }
+    assert_eq!(
+        last, N,
+        "exhaustive probe must count every indexed document"
+    );
+
+    // FACT 1 (positive control): the approximate probe at its MAXIMUM settings
+    // sees exactly 10_000 — one short — so the old `results.len() >= want` gate
+    // with `want = min(expected, 10_000)` released here, on a corpus that is
+    // fully indexed only by luck of timing at this size and 0.85% indexed on
+    // glove-100. Without this control the exhaustive assertion above could pass
+    // on a server with no ceiling at all and prove nothing.
+    let ann = coll
+        .aggregate(vec![
+            doc! { "$vectorSearch": {
+                "index": INDEX,
+                "path": "vector",
+                "queryVector": query.clone(),
+                "limit": 10_000i64,
+                "numCandidates": 10_000i64,
+            } },
+            doc! { "$count": "n" },
+        ])
+        .run()
+        .expect("the maximal approximate probe must still be a legal query");
+    let ann_n = ann
+        .filter_map(|r| r.ok())
+        .filter_map(|d| d.get_i32("n").map(i64::from).ok())
+        .last()
+        .unwrap_or(0);
+    assert_eq!(
+        ann_n, 10_000,
+        "the maximal approximate probe must top out at 10_000 — if it did not, \
+         this test is not exercising the ceiling #305 is about"
+    );
+    assert!(
+        ann_n < N,
+        "the approximate probe cannot see the whole corpus, which is why the \
+         capped gate could never be made correct"
+    );
+
+    // FACT 2: the ceiling is the server's. No ANN parameterisation reaches N.
+    let rejected = coll
+        .aggregate(vec![doc! { "$vectorSearch": {
+            "index": INDEX,
+            "path": "vector",
+            "queryVector": query,
+            "limit": N,
+            "numCandidates": N,
+        } }])
+        .run()
+        .and_then(|c| c.collect::<Result<Vec<_>, _>>());
+    let err = rejected
+        .err()
+        .expect("numCandidates above 10_000 must be rejected, not silently clamped")
+        .to_string();
+    assert!(
+        err.contains("numCandidates"),
+        "expected the server to name numCandidates as out of bounds, got: {err}"
+    );
+
+    let _ = db
+        .run_command(doc! { "dropSearchIndex": COLL, "name": INDEX })
+        .run();
+    let _ = coll.drop().run();
+}


### PR DESCRIPTION
Closes #305.

## The bug

`wait_for_index_catchup` capped the wait at `PROBE_CAP = 10_000` documents (`want = expected_count.min(PROBE_CAP)`) and gated on `results.len() >= want`. On **50 of 57 shipped datasets** the gate was satisfied while the Atlas index was a fraction ingested, and the search phase then published recall against it.

On glove-100 (1,183,514 vectors) it returned `Ok` at **0.85% indexed**, printing its own discrepancy on the way out:

```
Index caught up (10000 / 1183514 docs searchable) after N.Ns.
```

The status half of the gate could not compensate: `configure()` creates the index on a 1-document collection *before* upload, so Atlas reports `READY`/`queryable` from the first second and keeps reporting it while mongot ingests behind a change stream. The capped count was the entire guarantee.

No test caught it because every MongoDB integration corpus is 20-500 vectors, so `want == expected_count` and the capped branch never executed.

## What the investigation found

Measured live against `mongodb-atlas-local:8.0.17`:

- `numCandidates: 12000` → rejected, `"numCandidates" must be within bounds [1..10000]`; `limit > numCandidates` is also rejected. **No approximate-search parameterisation can count past 10,000.**
- `exact: true, limit: 12000` → returns 12,000 of 12,000. Same at `limit: 20000`. True on **both** dialects (`$vectorSearch` and the geo path's `$search` + `vectorSearch` operator).
- `$listSearchIndexes` carries no document count, and `$searchMeta` is unavailable on a vectorSearch index.

So exhaustive (ENN) + `$count` is the only corpus-complete signal — and it exists, so the gate verifies rather than refusing to measure. *(Independently reproduced by the reviewer against the same container before this PR was opened.)*

## The fix

The probe is now `exact: true` + `$count`: exhaustive, so the count is the true indexed count, and reduced server-side to a single `{n: …}`. `want = expected_count`, uncapped. **There is no success path that returns while under-indexed** — the gate either confirms the whole corpus or returns `Err` naming the fraction reached.

Dropping `numCandidates` *deletes* the secondary hazard in the issue (`limit == numCandidates == 10_000`, which could make the gate unsatisfiable) rather than patching it — that shape no longer exists.

Two consequential adjustments the honest gate requires:
- **The deadline scales**: `600s + 1ms/doc` instead of flat 600s. A gate that genuinely waits for glove-100 would otherwise trade a silent wrong answer for a guaranteed hard failure.
- **Polling backs off** to the last probe's duration (2s..30s), because an exhaustive probe costs O(corpus) — measured 2.8s per 100k docs locally, extrapolating to ~33s at glove-100 scale.

Pure functions extracted so the arithmetic is testable without a live client: `catchup_plan()`, `catchup_poll_interval()`, `build_catchup_count_pipeline()`, `catchup_count_from_doc()`. The drifted doc comment (which claimed it waited for every document) is rewritten.

**The artifact now carries the claim**: `UploadStats::index_coverage` emits `index_searchable_count` / `index_expected_count` / `index_coverage_fraction`. Absence of all three means "this engine does not verify" — deliberately *not* the same claim as a verified 1.0. The other 14 engines get a mechanical `index_coverage: None`.

## Tests

Each was verified by **actually mutating the production code** and watching it fail:

| Test | Mutation that breaks it |
|---|---|
| `catchup_plan_requires_the_whole_corpus_at_every_size` | reinstating `min(10_000)` → FAILED ✓ |
| `catchup_probe_is_exhaustive_and_carries_no_ann_knob` | swapping in `numCandidates` → FAILED ✓ |
| `catchup_probe_is_exhaustive_on_the_search_dialect_too` | same, geo path → FAILED ✓ |
| `catchup_plan_deadline_scales_with_the_corpus` | flat 600s → FAILED ✓ |
| `upload_result_carries_the_index_coverage_the_engine_confirmed` | deleting the emit block → FAILED ✓ |
| plus: probe-limit floor, poll bounds, integer-width/malformed `n`, empty-corpus NaN |

`test_exhaustive_probe_counts_past_the_ann_10000_document_ceiling` uses **10,001 documents** — the smallest corpus the old gate got wrong, and a size no other test in this repo reaches. It pins three server facts with a positive control so it cannot pass for free: the maximal ANN probe tops out at exactly 10,000 (one short — the bug), `numCandidates: 10001` is rejected so the ceiling is the server's, and the exhaustive probe returns all 10,001.

## Verification

`make check` clean · `cargo test --bin vector-db-benchmark` 884 pass · `cargo test --lib` 129 pass · new integration test passes (5.07s).

**End-to-end through the real binary at 10,001 vectors:** `Index caught up (10001 / 10001 docs searchable) after 3.4s`, with the artifact carrying `"index_coverage_fraction": 1.0`. Under the old code that run released at 10,000.

**Honest gap:** the *full* `integration_mongodb` suite did not complete locally. Three sibling agents were running it against the same shared container and the same hardcoded `bench_test.vectors`, wiping each other's corpus (E11000 dup-key). `and_filter` was re-run alone and passed; `geo`, `hnsw_config_reaches_server` and `match_any` are unverified post-change and are left to CI, which runs its own container.

## Reviewer notes — deliberate calls worth challenging

1. **ENN `limit` above 10,000 is verified on `mongodb-atlas-local:8.0.17`, not on Atlas cloud.** Atlas documents no absolute cap on ENN `limit` (only `limit <= numCandidates` when numCandidates is given), but this could not be tested against cloud. If cloud rejects it, the gate hard-errors with the server's message rather than passing silently — the safe direction — but it would be a hard failure on every large run.
2. **Probe cost is now inside `index_time`, hence `total_time`.** At glove-100 scale the final successful probe (~33s) is billed to the engine. MongoDB's ingest time becomes slightly *conservative* where it was previously flattered by stopping at 0.85%. Honest over flattering, but it is a measurement change.
3. **`600s + 1ms/doc` assumes a 1,000 docs/s mongot floor** — ~30 min for glove-100, ~3 h for deep-image-96. No env override; a reviewer may want one.
4. **The `listSearchIndexes` status poll was removed from this function** (it was the no-op the issue names). The separate `wait_for_index_ready` still polls status and is untouched.

## Merge order

Conflicts with #308 (issue #306) in `mongodb_engine.rs` and `tests/integration_mongodb.rs` — different regions of the same file. This PR is the higher severity of the two, so **land this first**; #308 will rebase onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
